### PR TITLE
fix: show active recurrent payments on history

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/history/History.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/history/History.kt
@@ -223,21 +223,18 @@ fun History(
 	}
 
 	val groupedCurrentTransactions = remember(
-		currentPeriodTransactions, budgetStartDate, budgetEndDate
+		currentPeriodTransactions, displayTransactions, budgetStartDate, budgetEndDate
 	) {
 		val today = LocalDate.now()
-
-		val withVirtualRecurrent = currentPeriodTransactions.flatMap { transaction ->
-			if (transaction.isRecurrent && !transaction.isDeleted) {
-				val charges =
-					getRecurringChargesInPeriod(transaction, budgetStartDate, budgetEndDate, today)
-				if (charges.isEmpty()) listOf(transaction) else charges
-			} else {
-				listOf(transaction)
+		val regularTransactions = currentPeriodTransactions.filterNot { it.isRecurrent }
+		val recurrentCharges = displayTransactions
+			.filter { it.isRecurrent && !it.isDeleted }
+			.flatMap { transaction ->
+				getRecurringChargesInPeriod(transaction, budgetStartDate, budgetEndDate, today)
 			}
-		}
 
-		withVirtualRecurrent.groupBy { it.date?.toLocalDate() }
+		(regularTransactions + recurrentCharges)
+			.groupBy { it.date?.toLocalDate() }
 			.toSortedMap(compareByDescending { it })
 	}
 
@@ -1284,7 +1281,9 @@ private fun getRecurringChargesInPeriod(
 	transaction: Transaction, periodStart: LocalDate, periodEnd: LocalDate, today: LocalDate
 ): List<Transaction> {
 	val frequency = transaction.recurrentFrequency ?: return emptyList()
-	val startDate = transaction.date?.toLocalDate() ?: return emptyList()
+	val originalDateTime = transaction.date ?: return emptyList()
+	val startDate = originalDateTime.toLocalDate()
+	val originalTime = originalDateTime.toLocalTime()
 	val subscriptionEnd = transaction.recurrentEndDate?.toLocalDate() ?: periodEnd.plusMonths(1)
 
 	val virtualTransactions = mutableListOf<Transaction>()
@@ -1297,7 +1296,7 @@ private fun getRecurringChargesInPeriod(
 		) {
 			virtualTransactions.add(
 				transaction.copy(
-					date = chargeDate.atStartOfDay(),
+					date = chargeDate.atTime(originalTime),
 					id = transaction.id * 1000000 + chargeDate.toEpochDay()
 				)
 			)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
@@ -229,7 +229,7 @@ fun PaddedListItem(
 
 	Surface(
 		shape = shape,
-		tonalElevation = 4.dp,
+		tonalElevation = 2.dp,
 		color = MaterialTheme.colorScheme.surfaceVariant,
 		modifier = Modifier
 			.fillMaxWidth()
@@ -270,7 +270,7 @@ fun CustomPaddedListItem(
 	onClick: () -> Unit,
 	position: PaddedListItemPosition = PaddedListItemPosition.Middle,
 	modifier: Modifier = Modifier,
-	background: Color = MaterialTheme.colorScheme.surfaceVariant,
+	background: Color = MaterialTheme.colorScheme.surfaceContainer,
 	contentColor: Color = MaterialTheme.colorScheme.onSurface,
 	content: @Composable RowScope.() -> Unit
 ) {
@@ -338,7 +338,7 @@ fun CustomPaddedExpandableItem(
 	Surface(
 		shape = shape,
 		tonalElevation = 4.dp,
-		color = MaterialTheme.colorScheme.surfaceVariant,
+		color = MaterialTheme.colorScheme.surfaceContainer,
 		modifier = modifier
 			.fillMaxWidth()
 			.clip(shape)
@@ -383,7 +383,6 @@ fun FlexibleSettingsGroupPreview() {
 	MinusTheme {
 		LazyColumn {
 			item {
-				// Example 1: Using standard SettingsGroupItem
 				FlexibleListGroup(
 					title = "Standard Items"
 				) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
@@ -1,19 +1,21 @@
 package com.serranoie.app.minus.presentation.ui.theme.component.expense
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.CustomPaddedListItem
 import com.serranoie.app.minus.presentation.ui.theme.component.PaddedListItemPosition
-import com.serranoie.app.minus.presentation.util.prettyDate
-import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.titleMediumCondensed
+import com.serranoie.app.minus.presentation.util.prettyDate
 import java.text.NumberFormat
 import java.time.LocalDateTime
 import java.util.Locale
@@ -34,7 +36,7 @@ fun ExpenseItem(
 	) {
 		Column(modifier = Modifier.weight(1f)) {
 			Text(
-				text = transaction.comment.ifEmpty { "Gasto sin nombre" },
+				text = transaction.comment.ifEmpty { stringResource(R.string.expense_item_unnamed_expense) },
 				style = MaterialTheme.typography.titleMediumCondensed,
 				color = MaterialTheme.colorScheme.onSurface,
 				fontWeight = FontWeight.Medium
@@ -42,7 +44,11 @@ fun ExpenseItem(
 			val timeText = prettyDate(
 				date = transaction.date, showTime = true, forceHideDate = true
 			)
-			val subtitle = if (transaction.isRecurrent) "Gasto recurrente - $timeText" else timeText
+			val subtitle = if (transaction.isRecurrent) {
+				stringResource(R.string.expense_item_recurrent_subtitle_format, timeText)
+			} else {
+				timeText
+			}
 			Text(
 				text = subtitle,
 				style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/util/DateFormatting.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/util/DateFormatting.kt
@@ -134,7 +134,7 @@ fun prettyDate(
 	val timeFormatter = if (DateFormat.is24HourFormat(LocalContext.current)) {
 		DateTimeFormatter.ofPattern("HH:mm", locale)
 	} else {
-		DateTimeFormatter.ofPattern("KK:mm", locale)
+		DateTimeFormatter.ofPattern("hh:mm a", locale)
 	}
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,6 +86,8 @@
 
     <string name="expense_deleted_format">%1$s eliminado</string>
     <string name="generic_expense">Gastos</string>
+    <string name="expense_item_unnamed_expense">Gasto sin nombre</string>
+    <string name="expense_item_recurrent_subtitle_format">Gasto recurrente — %1$s</string>
     <string name="hide_subscriptions_outside_period">Ocultar suscripciones fuera del período</string>
     <string name="show_subscriptions_outside_period">Mostrar suscripciones fuera del periodo</string>
     <string name="hide_past_period_expenses">Ocultar gastos del período pasado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -88,6 +88,8 @@
     <!-- History -->
     <string name="expense_deleted_format">%1$s deleted</string>
     <string name="generic_expense">Expense</string>
+    <string name="expense_item_unnamed_expense">Dépense sans nom</string>
+    <string name="expense_item_recurrent_subtitle_format">Dépense récurrente — %1$s</string>
     <string name="hide_subscriptions_outside_period">Hide subscriptions outside of the period</string>
     <string name="show_subscriptions_outside_period">Show subscriptions outside of the period</string>
     <string name="hide_past_period_expenses">Hide past period expenses</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <!-- History -->
     <string name="expense_deleted_format">%1$s deleted</string>
     <string name="generic_expense">Expense</string>
+    <string name="expense_item_unnamed_expense">Unnamed expense</string>
+    <string name="expense_item_recurrent_subtitle_format">Recurrent expense — %1$s</string>
     <string name="hide_subscriptions_outside_period">Hide subscriptions outside of the period</string>
     <string name="show_subscriptions_outside_period">Show subscriptions outside of the period</string>
     <string name="hide_past_period_expenses">Hide past period expenses</string>


### PR DESCRIPTION
### Description
Fixes recurrent expenses visibility and display details in History, ensuring current-period recurring payments appear correctly with proper time formatting and localized labels.


### Change strategy
Generate current-period recurring rows from all active recurrent transactions, preserve original transaction time, and move user-facing hardcoded labels into string resources.

### Implemented
- Current-period recurrent expenses now appear in History.
- Virtual recurrent rows keep original hour/minute.
- 12-hour time format now includes AM/PM.
- ExpenseItem labels are localized in EN/ES/FR.
- Minor settings list surface styling adjustments.



### Working demo
<img width="566" height="1228" alt="image" src="https://github.com/user-attachments/assets/48e99f0b-a087-47e2-a4c2-545c281b24be" />
