### PR TITLE
hotfix: numpad layout to use weights and dynamic screen height

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/History.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/History.kt
@@ -4,9 +4,9 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,11 +20,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.RECURRENT_PAYMENTS_VIEW_MODE_KEY
 import com.serranoie.app.minus.presentation.settingsDataStore
@@ -59,6 +61,7 @@ fun History(
 	onShowInfoSnackbar: (message: String) -> Unit = {},
 ) {
 	val context = LocalContext.current
+	val resources = LocalResources.current
 	val view = LocalView.current
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val preferences by context.settingsDataStore.data.collectAsStateWithLifecycle(initialValue = emptyPreferences())
@@ -67,9 +70,10 @@ fun History(
 	}
 	val scrollState = rememberLazyListState()
 
-	val isAtEndOfList = remember(scrollState.canScrollForward, scrollState.layoutInfo.visibleItemsInfo) {
-		!scrollState.canScrollForward && scrollState.layoutInfo.visibleItemsInfo.lastOrNull() != null
-	}
+	val isAtEndOfList =
+		remember(scrollState.canScrollForward, scrollState.layoutInfo.visibleItemsInfo) {
+			!scrollState.canScrollForward && scrollState.layoutInfo.visibleItemsInfo.lastOrNull() != null
+		}
 
 	LaunchedEffect(isAtEndOfList) {
 		viewModel.processIntent(BudgetSystemIntent.SetLockSwipeable(!isAtEndOfList))
@@ -176,10 +180,16 @@ fun History(
 
 	fun queueDeleteWithUndo(transaction: Transaction) {
 		pendingRemovedTransactions = pendingRemovedTransactions + (transaction.id to transaction)
-		onQueueDeleteWithUndo(transaction, "${transaction.comment.ifEmpty { "Gasto" }} eliminado", {
+		onQueueDeleteWithUndo(
+			transaction,
+			resources.getString(
+				R.string.expense_deleted_format,
+				transaction.comment.ifEmpty { resources.getString(R.string.generic_expense) },
+			),
+		) {
 			pendingRemovedTransactions = pendingRemovedTransactions - transaction.id
 			onCancelPendingDelete()
-		})
+		}
 	}
 
 	fun toggleExpandedDate(date: LocalDate) {
@@ -194,7 +204,12 @@ fun History(
 		viewModel.processIntent(
 			BudgetTransactionIntent.EditTransactionTapped(updatedTransaction)
 		)
-		onShowInfoSnackbar("${updatedTransaction.comment.ifEmpty { "Gasto" }} ha sido modificado")
+		onShowInfoSnackbar(
+			resources.getString(
+				R.string.expense_modified_format,
+				updatedTransaction.comment.ifEmpty { resources.getString(R.string.generic_expense) },
+			),
+		)
 		onSaved()
 	}
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/TransactionEditScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/TransactionEditScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
@@ -140,6 +141,10 @@ fun TransactionEditScreen(
 
 	var isCalculation by remember { mutableStateOf(false) }
 
+	// Calculate dynamic target height for numpad to take 48% of screen height
+	val configuration = LocalConfiguration.current
+	val screenHeight = configuration.screenHeightDp.dp
+	val targetNumpadHeight = screenHeight * 0.48f
 
 	val baseTextStyle = MaterialTheme.typography.displayLargeCondensed.copy(
 		fontWeight = FontWeight.W500
@@ -330,7 +335,7 @@ fun TransactionEditScreen(
 		Numpad(
 			modifier = Modifier
 				.fillMaxWidth()
-				.weight(2f),
+				.height(targetNumpadHeight),
 			editorState = editorState,
 			onNumberInput = { digit ->
 				editedAmount = if (editedAmount == "0") {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/Numpad.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/Numpad.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -94,7 +94,7 @@ fun Numpad(
 	onApplyPressedForTutorial: (() -> Unit)? = null,
 	onDragProgressChanged: (Float) -> Unit = {},
 	dragProgress: Float = 0f,
-	rowHeight: Dp = 55.dp,
+	rowHeight: Dp = 55.dp, // Still kept for backward compatibility but internal logic now uses weights
 ) {
 	val view = LocalView.current
 	val haptic = LocalHapticFeedback.current
@@ -186,14 +186,14 @@ fun Numpad(
 			Box(
 				Modifier
 					.fillMaxWidth()
-					.height(rowHeight * effectiveDragProgress)
+					.weight(effectiveDragProgress.coerceAtLeast(0.01f)) // Ensure weight > 0 to prevent crash
 					.clipToBounds(),
 				contentAlignment = androidx.compose.ui.Alignment.BottomCenter
 			) {
 				Row(
 					Modifier
 						.fillMaxWidth()
-						.height(rowHeight)
+						.fillMaxHeight()
 						.graphicsLayer(alpha = effectiveDragProgress)
 				) {
 					val operators = listOf('÷', '×', '+', '-')
@@ -216,7 +216,7 @@ fun Numpad(
 		Row(
 			Modifier
 				.fillMaxWidth()
-				.height(rowHeight * 4)
+				.weight(4f) // Use weight instead of fixed height
 		) {
 			Column(
 				modifier = Modifier
@@ -279,7 +279,6 @@ fun Numpad(
 							text = i.toString(),
 							onClick = {
 								onNumberInput(i)
-								onNumberPressedForTutorial?.invoke()
 								debugProgress = 0
 								haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
 							})

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -85,7 +85,8 @@
     <string name="new_budget_period">Nuevo período de ahorro</string>
 
     <string name="expense_deleted_format">%1$s eliminado</string>
-    <string name="generic_expense">Gastos</string>
+    <string name="expense_modified_format">%1$s ha sido modificado</string>
+    <string name="generic_expense">Gasto</string>
     <string name="expense_item_unnamed_expense">Gasto sin nombre</string>
     <string name="expense_item_recurrent_subtitle_format">Gasto recurrente — %1$s</string>
     <string name="hide_subscriptions_outside_period">Ocultar suscripciones fuera del período</string>
@@ -108,8 +109,8 @@
     </plurals>
 
     <plurals name="analytics_days_left">
-        <item quantity="one">%d día</item>
-        <item quantity="other">%d días</item>
+        <item quantity="one">%d día left</item>
+        <item quantity="other">%d días left</item>
     </plurals>
 
     <string name="total_budget">Presupuesto total</string>
@@ -325,7 +326,7 @@
 
     <!-- Remaining Budget Strategy -->
     <string name="strategy_dialog_title">Sobrante del presupuesto</string>
-    <string name="strategy_dialog_description">Puedes elegir como distribuir el balance del presupuesto al final de cada día.\n\nPor ejemplo, tienes un presupuesto de 500 al día, y ayer gastaste 400: puedes repartir 100 en los días que queda, o gastar 600 (presupuesto por día + sobrante del periodo anterior) hoy.</string>
+    <string name="strategy_dialog_description">Puedes elegir como distribuir el balance del presupuesto al final de cada día.\n\nFor ejemplo, tienes un presupuesto de 500 al día, y ayer gastaste 400: puedes repartir 100 en los días que queda, o gastar 600 (presupuesto por día + sobrante del periodo anterior) hoy.</string>
     <string name="strategy_ask_always">Preguntarme siempre</string>
     <string name="strategy_ask_always_desc">Al final del período te preguntaremos qué hacer con el sobrante</string>
     <string name="strategy_split_equally">Repartir entre todos los días</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,200 +1,201 @@
 <resources>
     <string name="app_name">Minus</string>
 
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="tomorrow">Tomorrow</string>
-    <string name="apply">Apply</string>
-    <string name="accept">Accept</string>
-    <string name="cancel">Cancel</string>
+    <string name="today">Aujourd\'hui</string>
+    <string name="yesterday">Hier</string>
+    <string name="tomorrow">Demain</string>
+    <string name="apply">Appliquer</string>
+    <string name="accept">Accepter</string>
+    <string name="cancel">Annuler</string>
     <string name="ok">OK</string>
-    <string name="save">Save</string>
-    <string name="delete">Delete</string>
-    <string name="edit">Edit</string>
-    <string name="close">Close</string>
-    <string name="done">Done</string>
-    <string name="add">Add</string>
-    <string name="remove">Remove</string>
-    <string name="back">Back</string>
-    <string name="next">Next</string>
-    <string name="period">Period</string>
-    <string name="previous_values">Previous values</string>
+    <string name="save">Enregistrer</string>
+    <string name="delete">Supprimer</string>
+    <string name="edit">Modifier</string>
+    <string name="close">Fermer</string>
+    <string name="done">Terminé</string>
+    <string name="add">Ajouter</string>
+    <string name="remove">Retirer</string>
+    <string name="back">Retour</string>
+    <string name="next">Suivant</string>
+    <string name="period">Période</string>
+    <string name="previous_values">Valeurs précédentes</string>
     <string name="budget">Budget</string>
-    <string name="recurrent_expense">Recurrent Expense</string>
-    <string name="recurrent_expense_details">Let\'s define the recurrent expense</string>
-    <string name="recurrent_expense_frequency_subtitle">How often do you want to pay this expense?</string>
-    <string name="recurrent_frequency_weekly">Weekly</string>
-    <string name="recurrent_frequency_biweekly">Biweekly</string>
-    <string name="recurrent_frequency_monthly">Monthly</string>
-    <string name="previous_day">Previous day</string>
-    <string name="next_day">Next day</string>
-    <string name="monthly_on_day_format">Day %1$d of each month</string>
-    <string name="limit_date">Limit date</string>
+    <string name="recurrent_expense">Dépense récurrente</string>
+    <string name="recurrent_expense_details">Définissons la dépense récurrente</string>
+    <string name="recurrent_expense_frequency_subtitle">À quelle fréquence souhaitez-vous payer cette dépense ?</string>
+    <string name="recurrent_frequency_weekly">Hebdomadaire</string>
+    <string name="recurrent_frequency_biweekly">Toutes les deux semaines</string>
+    <string name="recurrent_frequency_monthly">Mensuel</string>
+    <string name="previous_day">Jour précédent</string>
+    <string name="next_day">Jour suivant</string>
+    <string name="monthly_on_day_format">Le %1$d de chaque mois</string>
+    <string name="limit_date">Date limite</string>
     <string name="date_placeholder">Date</string>
-    <string name="change_date">Change date</string>
-    <string name="summary_weekly_format">It will be charged every week until %1$s.</string>
-    <string name="summary_biweekly_format">It will be charged every two weeks until %1$s.</string>
-    <string name="summary_monthly_format">It will be charged every month on day %1$d until %2$s.</string>
-    <string name="credit_cutoff_dialog_title">Credit card cutoff date</string>
-    <string name="credit_cutoff_dialog_message">To track credit expenses, set the billing cutoff day (1-31).</string>
-    <string name="credit_cutoff_dialog_label">Cutoff day</string>
+    <string name="change_date">Modifier la date</string>
+    <string name="summary_weekly_format">Il sera prélevé chaque semaine jusqu\'au %1$s.</string>
+    <string name="summary_biweekly_format">Il sera prélevé toutes les deux semaines jusqu\'au %1$s.</string>
+    <string name="summary_monthly_format">Il sera prélevé chaque mois le %1$d jusqu\'au %2$s.</string>
+    <string name="credit_cutoff_dialog_title">Date de clôture de la carte de crédit</string>
+    <string name="credit_cutoff_dialog_message">Pour suivre les dépenses à crédit, définissez le jour de clôture de facturation (1-31).</string>
+    <string name="credit_cutoff_dialog_label">Jour de clôture</string>
 
     <!-- Rollover Dialog -->
-    <string name="period_finished">Period finished</string>
-    <string name="remaining_budget">Remaining budget</string>
-    <string name="rollover_question">What do you want to do with the remaining money?</string>
-    <string name="split_equally">Split equally</string>
-    <string name="split_equally_desc">Add %1$s to the budget for the next few days</string>
-    <string name="carry_to_next_day">Carry to tomorrow</string>
-    <string name="carry_to_next_day_desc">Add %1$s to tomorrow\'s budget</string>
-    <string name="view_analytics">View analytics</string>
-    <string name="view_analytics_desc">Review the summary of the finished period</string>
+    <string name="period_finished">Période terminée</string>
+    <string name="remaining_budget">Budget restant</string>
+    <string name="rollover_question">Que voulez-vous faire de l\'argent restant ?</string>
+    <string name="split_equally">Répartir équitablement</string>
+    <string name="split_equally_desc">Ajouter %1$s au budget pour les prochains jours</string>
+    <string name="carry_to_next_day">Reporter à demain</string>
+    <string name="carry_to_next_day_desc">Ajouter %1$s au budget de demain</string>
+    <string name="view_analytics">Voir les analyses</string>
+    <string name="view_analytics_desc">Consulter le résumé de la période terminée</string>
 
     <!-- Edit Transaction -->
-    <string name="edit_recurrent_expense_title">Edit recurrent expense</string>
-    <string name="edit_expense_title">Edit expense</string>
-    <string name="cancel_edit_content_desc">Cancel edit</string>
-    <string name="configure_recurrence">Configure recurrence</string>
-    <string name="make_recurrent">Make recurrent</string>
-    <string name="select_time">Select time</string>
-    <string name="billing_day">Billing day</string>
-    <string name="end_date">End date</string>
-    <string name="frequency_label">Frequency</string>
-    <string name="weekly_with_desc">Weekly (every 7 days)</string>
-    <string name="biweekly_with_desc">Biweekly (every 14 days)</string>
+    <string name="edit_recurrent_expense_title">Modifier la dépense récurrente</string>
+    <string name="edit_expense_title">Modifier la dépense</string>
+    <string name="cancel_edit_content_desc">Annuler la modification</string>
+    <string name="configure_recurrence">Configurer la récurrence</string>
+    <string name="make_recurrent">Rendre récurrent</string>
+    <string name="select_time">Choisir l\'heure</string>
+    <string name="billing_day">Jour de facturation</string>
+    <string name="end_date">Date de fin</string>
+    <string name="frequency_label">Fréquence</string>
+    <string name="weekly_with_desc">Hebdomadaire (tous les 7 jours)</string>
+    <string name="biweekly_with_desc">Bihebdomadaire (tous les 14 jours)</string>
 
-    <string name="edit_budget">Edit Budget</string>
-    <string name="new_budget">New budget period</string>
+    <string name="edit_budget">Modifier le budget</string>
+    <string name="new_budget">Nouvelle période budgétaire</string>
     <plurals name="pending_expense">
-        <item quantity="one">%d expense for the next period</item>
-        <item quantity="other">%d expenses for the next period</item>
+        <item quantity="one">%d dépense pour la période suivante</item>
+        <item quantity="other">%d dépenses pour la période suivante</item>
     </plurals>
-    <string name="new_period_title">New Budget Period</string>
-    <string name="widget_description">Quick view of your expenses and add new ones</string>
-    <string name="total_expenses">Total Expenses</string>
-    <string name="new_expense">New Expense</string>
-    <string name="daily_average">Daily average</string>
-    <string name="expenses_history">Expenses history</string>
-    <string name="single_expense">Single expense</string>
-    <string name="add_expense">+ Add Expense</string>
-    <string name="finalize_period_question">Finalize period?</string>
-    <string name="finalize_period">Finalize budget period early</string>
-    <string name="finalize_period_confirm">This will close the current period and start a new one. Are you sure?</string>
-    <string name="finalize_action">Finalize</string>
-    <string name="no_ending_date">No ending date</string>
-    <string name="budget_split_logic">How do you want to split the budget?</string>
-    <string name="new_budget_period">New Budget Period</string>
+    <string name="new_period_title">Nouvelle période budgétaire</string>
+    <string name="widget_description">Aperçu rapide de vos dépenses et ajout de nouvelles</string>
+    <string name="total_expenses">Total des dépenses</string>
+    <string name="new_expense">Nouvelle dépense</string>
+    <string name="daily_average">Moyenne quotidienne</string>
+    <string name="expenses_history">Historique des dépenses</string>
+    <string name="single_expense">Dépense unique</string>
+    <string name="add_expense">+ Ajouter une dépense</string>
+    <string name="finalize_period_question">Finaliser la période ?</string>
+    <string name="finalize_period">Finaliser la période budgétaire plus tôt</string>
+    <string name="finalize_period_confirm">Cela clôturera la période actuelle et en commencera une nouvelle. Êtes-vous sûr ?</string>
+    <string name="finalize_action">Finaliser</string>
+    <string name="no_ending_date">Pas de date de fin</string>
+    <string name="budget_split_logic">Comment voulez-vous répartir le budget ?</string>
+    <string name="new_budget_period">Nouvelle période budgétaire</string>
 
     <!-- History -->
-    <string name="expense_deleted_format">%1$s deleted</string>
-    <string name="generic_expense">Expense</string>
+    <string name="expense_deleted_format">%1$s supprimé</string>
+    <string name="expense_modified_format">%1$s a été modifié</string>
+    <string name="generic_expense">Dépense</string>
     <string name="expense_item_unnamed_expense">Dépense sans nom</string>
     <string name="expense_item_recurrent_subtitle_format">Dépense récurrente — %1$s</string>
-    <string name="hide_subscriptions_outside_period">Hide subscriptions outside of the period</string>
-    <string name="show_subscriptions_outside_period">Show subscriptions outside of the period</string>
-    <string name="hide_past_period_expenses">Hide past period expenses</string>
-    <string name="show_past_period_expenses">Show past period expenses</string>
+    <string name="hide_subscriptions_outside_period">Masquer les abonnements hors période</string>
+    <string name="show_subscriptions_outside_period">Afficher les abonnements hors période</string>
+    <string name="hide_past_period_expenses">Masquer les dépenses de la période passée</string>
+    <string name="show_past_period_expenses">Afficher les dépenses de la période passée</string>
 
-    <string name="add_new_category">Category</string>
+    <string name="add_new_category">Catégorie</string>
 
-    <string name="budget_validation_major_zero">Budget must be greater than 0</string>
-    <string name="budget_no_date_defined">No end date defined</string>
-    <string name="budget_no_days_defined">No days defined</string>
-    <string name="budget_less_than_one_day_validation">Budget must be for at least one day</string>
+    <string name="budget_validation_major_zero">Le budget doit être supérieur à 0</string>
+    <string name="budget_no_date_defined">Aucune date de fin définie</string>
+    <string name="budget_no_days_defined">Aucun jour défini</string>
+    <string name="budget_less_than_one_day_validation">Le budget doit être d\'au moins un jour</string>
     <!--  Analytics  -->
-    <string name="analytics_title">Analytics</string>
+    <string name="analytics_title">Analyses</string>
 
     <plurals name="days">
-        <item quantity="one">%d day</item>
-        <item quantity="other">%d days</item>
+        <item quantity="one">%d jour</item>
+        <item quantity="other">%d jours</item>
     </plurals>
 
     <plurals name="analytics_days_left">
-        <item quantity="one">%d day left</item>
-        <item quantity="other">%d days left</item>
+        <item quantity="one">%d jour restant</item>
+        <item quantity="other">%d jours restants</item>
     </plurals>
 
-    <string name="total_budget">Total budget</string>
-    <string name="minimum_spent">Minimum spent</string>
-    <string name="maximum_spent">Maximum spent</string>
-    <string name="average_spent">Average per day spent</string>
+    <string name="total_budget">Budget total</string>
+    <string name="minimum_spent">Dépense minimale</string>
+    <string name="maximum_spent">Dépense maximale</string>
+    <string name="average_spent">Moyenne dépensée par jour</string>
 
-    <string name="days_remaining_label">Days\nremaining</string>
+    <string name="days_remaining_label">Jours\nrestants</string>
 
     <!-- Widget Descriptions -->
-    <string name="widget_budget_overview_description">See spent and remaining budget at a glance</string>
-    <string name="widget_days_countdown_description">Countdown days remaining in budget period</string>
-    <string name="widget_budget_detail_description">Full budget overview with top category and days left</string>
-    <string name="widget_heatmap_description">Heatmap calendar to see spending distribution</string>
-    <string name="widget_month_heatmap_description">Current month heatmap calendar</string>
-    <string name="widget_add_expense_description">Quick shortcut to add a new expense</string>
-    <string name="widget_add_expense_label">Add new expense</string>
+    <string name="widget_budget_overview_description">Consultez le budget dépensé et restant en un coup d\'œil</string>
+    <string name="widget_days_countdown_description">Compte à rebours des jours restants dans la période budgétaire</string>
+    <string name="widget_budget_detail_description">Aperçu complet du budget avec la catégorie principale et les jours restants</string>
+    <string name="widget_heatmap_description">Calendrier thermique pour voir la répartition des dépenses</string>
+    <string name="widget_month_heatmap_description">Calendrier thermique du mois en cours</string>
+    <string name="widget_add_expense_description">Raccourci rapide pour ajouter une nouvelle dépense</string>
+    <string name="widget_add_expense_label">Ajouter une nouvelle dépense</string>
 
     <!-- Widget Labels -->
-    <string name="spent">Spent</string>
-    <string name="left">Left</string>
-    <string name="remaining">Remaining</string>
-    <string name="total_spent">Total Spent</string>
-    <string name="days_left">days left</string>
-    <string name="budget_overview">Budget Overview</string>
+    <string name="spent">Dépensé</string>
+    <string name="left">Restant</string>
+    <string name="remaining">Restant</string>
+    <string name="total_spent">Total dépensé</string>
+    <string name="days_left">jours restants</string>
+    <string name="budget_overview">Aperçu du budget</string>
 
-    <string name="budget_period_daily">Daily</string>
-    <string name="budget_period_weekly">Weekly</string>
-    <string name="budget_period_biweekly">Biweekly</string>
-    <string name="budget_period_monthly">Monthly</string>
+    <string name="budget_period_daily">Quotidien</string>
+    <string name="budget_period_weekly">Hebdomadaire</string>
+    <string name="budget_period_biweekly">Bihebdomadaire</string>
+    <string name="budget_period_monthly">Mensuel</string>
 
-    <string name="budget_period_label_today">Today\'s budget</string>
-    <string name="budget_period_label_this_week">This week</string>
-    <string name="budget_period_label_this_biweek">This fortnight</string>
-    <string name="budget_period_label_this_month">This month</string>
+    <string name="budget_period_label_today">Budget d\'aujourd\'hui</string>
+    <string name="budget_period_label_this_week">Cette semaine</string>
+    <string name="budget_period_label_this_biweek">Cette quinzaine</string>
+    <string name="budget_period_label_this_month">Ce mois-ci</string>
 
-    <string name="day_total_format">Total: %1$s</string>
+    <string name="day_total_format">Total : %1$s</string>
 
-    <string name="onboarding_welcome_title">Welcome to Minus!</string>
-    <string name="onboarding_welcome_subtitle">Hi and welcome, lets start saving together.</string>
-    <string name="onboarding_step_1_title">Set a budget</string>
-    <string name="onboarding_step_1_subtitle">Estimate how much money you need for a period and stay informed about how much you can save.</string>
-    <string name="onboarding_step_2_title">Track every expense</string>
-    <string name="onboarding_step_2_subtitle">This app helps you calculate how much you can spend per day, week, biweekly period, or month so you stay on track and know what is left.</string>
-    <string name="onboarding_step_3_title">Spend wisely</string>
-    <string name="onboarding_step_3_subtitle">Over time, you will learn how much you can save and how much you can spend.</string>
-    <string name="onboarding_set_budget_button">Set a budget</string>
+    <string name="onboarding_welcome_title">Bienvenue sur Minus !</string>
+    <string name="onboarding_welcome_subtitle">Bonjour et bienvenue, commençons à épargner ensemble.</string>
+    <string name="onboarding_step_1_title">Définir un budget</string>
+    <string name="onboarding_step_1_subtitle">Estimez l\'argent dont vous avez besoin pour une période et restez informé de ce que vous pouvez économiser.</string>
+    <string name="onboarding_step_2_title">Suivre chaque dépense</string>
+    <string name="onboarding_step_2_subtitle">Cette application vous aide à calculer ce que vous pouvez dépenser par jour, semaine, quinzaine ou mois pour garder le cap.</string>
+    <string name="onboarding_step_3_title">Dépenser intelligemment</string>
+    <string name="onboarding_step_3_subtitle">Au fil du temps, vous apprendrez combien vous pouvez économiser et combien vous pouvez dépenser.</string>
+    <string name="onboarding_set_budget_button">Définir un budget</string>
 
     <!-- Finish Date Selector -->
-    <string name="onboarding_finish_date_selector_title">Select the period</string>
-    <string name="onboarding_finish_date_selector_days_range">%1$d days · %2$s - %3$s</string>
-    <string name="onboarding_finish_date_selector_budget_view_question">How do you want to view your budget?</string>
+    <string name="onboarding_finish_date_selector_title">Sélectionnez la période</string>
+    <string name="onboarding_finish_date_selector_days_range">%1$d jours · %2$s - %3$s</string>
+    <string name="onboarding_finish_date_selector_budget_view_question">Comment souhaitez-vous visualiser votre budget ?</string>
 
     <!-- Settings -->
-    <string name="settings_title">Settings</string>
-    <string name="settings_section_appearance">Appearance</string>
+    <string name="settings_title">Paramètres</string>
+    <string name="settings_section_appearance">Apparence</string>
     <string name="settings_section_notifications">Notifications</string>
-    <string name="settings_section_features">Features</string>
-    <string name="settings_section_app_info">App information</string>
-    <string name="settings_section_data_backup">Data backup</string>
-    <string name="settings_section_tutorial">Tutorial</string>
+    <string name="settings_section_features">Fonctionnalités</string>
+    <string name="settings_section_app_info">Informations sur l\'application</string>
+    <string name="settings_section_data_backup">Sauvegarde des données</string>
+    <string name="settings_section_tutorial">Tutoriel</string>
 
-    <string name="settings_theme_title">Theme</string>
-    <string name="settings_theme_subtitle">Change the app theme style</string>
-    <string name="settings_typography_title">Typography</string>
-    <string name="settings_typography_subtitle">Change the app typography style</string>
+    <string name="settings_theme_title">Thème</string>
+    <string name="settings_theme_subtitle">Changer le style de thème de l\'application</string>
+    <string name="settings_typography_title">Typographie</string>
+    <string name="settings_typography_subtitle">Changer le style de typographie de l\'application</string>
     <string name="settings_material_you_title">Material You</string>
-    <string name="settings_material_you_subtitle">Use wallpaper colors to apply a dynamic app theme</string>
-    <string name="settings_feature_credit_toggle_title">Credit quick toggle in editor</string>
-    <string name="settings_feature_credit_toggle_subtitle">Tap to see details and controls</string>
-    <string name="settings_feature_credit_toggle_details">When enabled, the credit-card quick toggle appears next to the recurrent button while typing an amount in the editor. If disabled, that button is hidden to keep the quick-capture UI cleaner.</string>
-    <string name="settings_feature_credit_toggle_switch_label">Enable credit quick toggle</string>
+    <string name="settings_material_you_subtitle">Utiliser les couleurs du fond d\'écran pour appliquer un thème dynamique</string>
+    <string name="settings_feature_credit_toggle_title">Utiliser la carte de crédit comme paiement</string>
+    <string name="settings_feature_credit_toggle_subtitle">Appuyez pour voir plus de détails</string>
+    <string name="settings_feature_credit_toggle_details">Une fois activé, vous pouvez marquer les paiements effectués avec une carte de crédit. \nEn déclarant une date de facturation, vous saurez combien payer à votre banque avant de devoir payer des intérêts.</string>
+    <string name="settings_feature_credit_toggle_switch_label">Activer l\'usage CC</string>
 
-    <string name="settings_period_end_time_title">Period end time</string>
-    <string name="settings_period_end_time_subtitle">The notification will be shown the day after the period ends</string>
-    <string name="settings_exact_alarm_title">Exact alarms</string>
-    <string name="settings_exact_alarm_enabled_subtitle">Enabled to try showing notifications at the selected time</string>
-    <string name="settings_exact_alarm_disabled_subtitle">Disabled; Android may delay the notification</string>
+    <string name="settings_period_end_time_title">Heure de fin de période</string>
+    <string name="settings_period_end_time_subtitle">La notification sera affichée le lendemain de la fin de la période</string>
+    <string name="settings_exact_alarm_title">Alarmes exactes</string>
+    <string name="settings_exact_alarm_enabled_subtitle">Activé pour essayer d\'afficher les notifications à l\'heure sélectionnée</string>
+    <string name="settings_exact_alarm_disabled_subtitle">Désactivé ; Android peut retarder la notification</string>
 
-    <string name="settings_about_title">About</string>
-    <string name="settings_about_subtitle">Learn more about the app and its development</string>
-    <string name="settings_bug_report_title">Found a bug?</string>
-    <string name="settings_bug_report_subtitle">Create a bug report and we will fix it soon</string>
+    <string name="settings_about_title">À propos</string>
+    <string name="settings_about_subtitle">En savoir plus sur l\'application et son développement</string>
+    <string name="settings_bug_report_title">Un bug ?</string>
+    <string name="settings_bug_report_subtitle">Créez un rapport de bug et nous le corrigerons bientôt</string>
     <string name="settings_version_title">Version</string>
 
     <!-- Bug Report -->
@@ -228,108 +229,125 @@
     <string name="bug_report_upload_assets_subtitle">Captures d’écran ou vidéos (jusqu’à 10 Mo)</string>
     <string name="bug_report_upload_assets_selected_count">%1$d pièce(s) jointe(s) sélectionnée(s)</string>
 
-    <string name="settings_backup_title">Back up data</string>
-    <string name="settings_backup_subtitle">Back up data to minus_export.csv</string>
-    <string name="settings_import_csv_title">Import CSV</string>
-    <string name="settings_import_csv_subtitle">Import data from a CSV file</string>
+    <string name="settings_backup_title">Sauvegarder les données</string>
+    <string name="settings_backup_subtitle">Sauvegarder les données dans minus_export.csv</string>
+    <string name="settings_import_csv_title">Importer un CSV</string>
+    <string name="settings_import_csv_subtitle">Importer des données à partir d\'un fichier CSV</string>
 
-    <string name="settings_reset_tutorial_title">Reset tutorial</string>
-    <string name="settings_reset_tutorial_subtitle">You will see gesture hints, info, and actions across the app again.</string>
+    <string name="settings_reset_tutorial_title">Réinitialiser le tutoriel</string>
+    <string name="settings_reset_tutorial_subtitle">Vous verrez à nouveau les indices de gestes, les infos et les actions dans l\'application.</string>
 
-    <string name="settings_theme_dialog_title">App theme</string>
-    <string name="settings_theme_light_title">Light</string>
-    <string name="settings_theme_light_subtitle">Always use light theme</string>
-    <string name="settings_theme_dark_title">Dark</string>
-    <string name="settings_theme_dark_subtitle">Always use dark theme</string>
-    <string name="settings_theme_system_title">Follow system</string>
-    <string name="settings_theme_system_subtitle">Use the system theme setting</string>
+    <string name="settings_theme_dialog_title">Thème de l\'application</string>
+    <string name="settings_theme_light_title">Clair</string>
+    <string name="settings_theme_light_subtitle">Toujours utiliser le thème clair</string>
+    <string name="settings_theme_dark_title">Sombre</string>
+    <string name="settings_theme_dark_subtitle">Toujours utiliser le thème sombre</string>
+    <string name="settings_theme_system_title">Suivre le système</string>
+    <string name="settings_theme_system_subtitle">Utiliser le paramètre de thème du système</string>
 
-    <string name="settings_typography_dialog_title">App typography</string>
-    <string name="settings_typography_default_title">Default</string>
-    <string name="settings_typography_default_subtitle">Use the base typography</string>
-    <string name="settings_typography_condensed_title">Condensed</string>
-    <string name="settings_typography_condensed_subtitle">Use compact typography</string>
+    <string name="settings_typography_dialog_title">Typographie de l\'application</string>
+    <string name="settings_typography_default_title">Par défaut</string>
+    <string name="settings_typography_default_subtitle">Utiliser la typographie de base</string>
+    <string name="settings_typography_condensed_title">Condensée</string>
+    <string name="settings_typography_condensed_subtitle">Utiliser une typographie compacte</string>
     <string name="settings_typography_expressive_title">Expressive</string>
-    <string name="settings_typography_expressive_subtitle">Use expressive typography</string>
+    <string name="settings_typography_expressive_subtitle">Utiliser une typographie expressive</string>
 
-    <string name="expand">Expand</string>
-    <string name="collapse">Collapse</string>
+    <string name="expand">Développer</string>
+    <string name="collapse">Réduire</string>
 
     <!-- Budget Pill -->
-    <string name="budget_pill_over_budget">Budget exhausted</string>
-    <string name="budget_pill_no_budget">No budget</string>
-    <string name="budget_pill_exhausted_daily_label">daily</string>
-    <string name="budget_pill_exhausted_weekly_label">weekly</string>
-    <string name="budget_pill_exhausted_biweekly_label">biweekly</string>
-    <string name="budget_pill_exhausted_single">%1$s budget exhausted</string>
-    <string name="budget_pill_exhausted_double">%1$s and %2$s budget exhausted</string>
-    <string name="budget_pill_exhausted_triple">%1$s, %2$s and %3$s budget exhausted</string>
+    <string name="budget_pill_over_budget">Budget épuisé</string>
+    <string name="budget_pill_no_budget">Aucun budget</string>
+    <string name="budget_pill_exhausted_daily_label">quotidien</string>
+    <string name="budget_pill_exhausted_weekly_label">hebdomadaire</string>
+    <string name="budget_pill_exhausted_biweekly_label">bihebdomadaire</string>
+    <string name="budget_pill_exhausted_single">Budget %1$s épuisé</string>
+    <string name="budget_pill_exhausted_double">Budgets %1$s et %2$s épuisés</string>
+    <string name="budget_pill_exhausted_triple">Budgets %1$s, %2$s et %3$s épuisés</string>
 
     <!-- Spend Budget Card -->
-    <string name="spend_budget_card_spent_label">Spent</string>
-    <string name="spend_budget_card_available_percent_format">Available: %1$s%%</string>
+    <string name="spend_budget_card_spent_label">Dépensé</string>
+    <string name="spend_budget_card_available_percent_format">Disponible : %1$s%%</string>
 
     <!-- Categories Chart -->
-    <string name="categories_chart_uncategorized">Uncategorized</string>
-    <string name="categories_chart_rest">Remaining</string>
-    <string name="categories_chart_empty_title">We can\'t split your spending by categories</string>
-    <string name="categories_chart_empty_subtitle">Use tags to see the chart by categories</string>
+    <string name="categories_chart_uncategorized">Non catégorisé</string>
+    <string name="categories_chart_rest">Restant</string>
+    <string name="categories_chart_empty_title">Nous ne pouvons pas répartir vos dépenses par catégories</string>
+    <string name="categories_chart_empty_subtitle">Utilisez des étiquettes pour voir le graphique par catégories</string>
 
     <!-- Calendar Heatmap -->
-    <string name="calendar_heatmap_info_text">This chart shows money spent for each day in the period</string>
+    <string name="calendar_heatmap_info_text">Ce graphique montre l\'argent dépensé pour chaque jour de la période</string>
 
     <!-- No Transactions -->
-    <string name="no_transactions_title">No recorded expenses</string>
-    <string name="no_transactions_subtitle">Add an expense to get started</string>
+    <string name="no_transactions_title">Aucune dépense enregistrée</string>
+    <string name="no_transactions_subtitle">Ajoutez une dépense pour commencer</string>
 
     <!-- Recurrent Payments Divider -->
-    <string name="recurrent_payments_divider_title_upcoming">Upcoming recurrent payments</string>
-    <string name="recurrent_payments_divider_title_current_period">Recurrent Payments on this period</string>
+    <string name="recurrent_payments_divider_title_upcoming">Paiements récurrents à venir</string>
+    <string name="recurrent_payments_divider_title_current_period">Paiements récurrents sur cette période</string>
 
     <!-- Upcoming Recurrent Item -->
-    <string name="upcoming_recurrent_today">Today</string>
-    <string name="upcoming_recurrent_tomorrow">Tomorrow</string>
-    <string name="upcoming_recurrent_in_days">In %1$d days</string>
-    <string name="upcoming_recurrent_in_weeks">In %1$d weeks</string>
-    <string name="upcoming_recurrent_unnamed_expense">Unnamed recurrent expense</string>
-    <string name="delete_recurrent_expense_title">Delete recurrent expense</string>
-    <string name="delete_recurrent_expense_fallback_name">this recurrent expense</string>
-    <string name="delete_recurrent_expense_message">Are you sure you want to delete "%1$s"?</string>
-    <string name="delete_recurrent_expense_warning">This action will remove the whole recurrent expense configuration and you will not receive more notifications.</string>
+    <string name="upcoming_recurrent_today">Aujourd\'hui</string>
+    <string name="upcoming_recurrent_tomorrow">Demain</string>
+    <string name="upcoming_recurrent_in_days">Dans %1$d jours</string>
+    <string name="upcoming_recurrent_in_weeks">Dans %1$d semaines</string>
+    <string name="upcoming_recurrent_unnamed_expense">Dépense récurrente sans nom</string>
+    <string name="delete_recurrent_expense_title">Supprimer la dépense récurrente</string>
+    <string name="delete_recurrent_expense_fallback_name">cette dépense récurrente</string>
+    <string name="delete_recurrent_expense_message">Êtes-vous sûr de vouloir supprimer "%1$s" ?</string>
+    <string name="delete_recurrent_expense_warning">Cette action supprimera toute la configuration de la dépense récurrente et vous ne recevrez plus de notifications.</string>
 
     <!-- Recurrent Ticket -->
-    <string name="recurrent_ticket_unnamed_subscription">Unnamed subscription</string>
-    <string name="recurrent_ticket_frequency_weekly">Weekly</string>
-    <string name="recurrent_ticket_frequency_biweekly">Biweekly</string>
-    <string name="recurrent_ticket_frequency_monthly">Monthly</string>
+    <string name="recurrent_ticket_unnamed_subscription">Abonnement sans nom</string>
+    <string name="recurrent_ticket_frequency_weekly">Hebdomadaire</string>
+    <string name="recurrent_ticket_frequency_biweekly">Toutes les deux semaines</string>
+    <string name="recurrent_ticket_frequency_monthly">Mensuel</string>
 
     <!-- Rollover Dialog (component local) -->
-    <string name="rollover_dialog_period_finished_title">Period finished</string>
-    <string name="rollover_dialog_question">What do you want to do with the remaining money?</string>
-    <string name="rollover_dialog_split_equally_title">Split equally</string>
-    <string name="rollover_dialog_split_equally_desc">Add %1$s to the budget for the next days</string>
-    <string name="rollover_dialog_carry_to_tomorrow_title">Carry to tomorrow</string>
-    <string name="rollover_dialog_carry_to_tomorrow_desc">Add %1$s to tomorrow\'s budget</string>
-    <string name="rollover_dialog_view_analytics_title">View analytics</string>
-    <string name="rollover_dialog_view_analytics_desc">Review the summary of the finished period</string>
+    <string name="rollover_dialog_period_finished_title">Période terminée</string>
+    <string name="rollover_dialog_question">Que voulez-vous faire de l\'argent restant ?</string>
+    <string name="rollover_dialog_split_equally_title">Répartir équitablement</string>
+    <string name="rollover_dialog_split_equally_desc">Ajouter %1$s au budget pour les prochains jours</string>
+    <string name="rollover_dialog_carry_to_tomorrow_title">Reporter à demain</string>
+    <string name="rollover_dialog_carry_to_tomorrow_desc">Ajouter %1$s au budget de demain</string>
+    <string name="rollover_dialog_view_analytics_title">Voir les analyses</string>
+    <string name="rollover_dialog_view_analytics_desc">Consulter le résumé de la période terminée</string>
 
     <!-- Finished Period Header -->
-    <string name="finished_period_header_title">Period finished</string>
-    <string name="finished_period_header_no_spends">Huh? You didn\'t spend anything this period</string>
-    <string name="finished_period_header_over_budget">Watch out! You went over budget in this period</string>
-    <string name="finished_period_header_summary">Here are the stats for all your spending</string>
+    <string name="finished_period_header_title">Période terminée</string>
+    <string name="finished_period_header_no_spends">Euh ? Vous n\'avez rien dépensé cette période</string>
+    <string name="finished_period_header_over_budget">Attention ! Vous avez dépassé votre budget cette période</string>
+    <string name="finished_period_header_summary">Voici les statistiques de toutes vos dépenses</string>
 
     <!-- Savings Recommendation Card -->
-    <string name="savings_recommendation_title">Savings recommendation</string>
-    <string name="savings_recommendation_method_brief" formatted="false">The classic 50/30/20 method divides your budget into 50% needs, 30% wants, and 20% savings, helping you control spending and save consistently.</string>
-    <string name="savings_recommendation_current_savings_label">Current savings</string>
-    <string name="savings_recommendation_available_format">Available: %1$s</string>
-    <string name="savings_recommendation_ideal_savings_format">Ideal savings: %1$s</string>
-    <string name="savings_recommendation_current_savings_format">Current savings: %1$s</string>
-    <string name="savings_recommendation_recurrent_expenses_label">Recurring expenses</string>
-    <string name="savings_recommendation_one_time_expenses_label">One-time expenses</string>
-    <string name="savings_recommendation_six_month_example_intro" formatted="false">If you save the 20% each period for about 6 months, you could build:</string>
+    <string name="savings_recommendation_title">Recommandation d\'épargne</string>
+    <string name="savings_recommendation_method_brief" formatted="false">La méthode classique 50/30/20 divise votre budget en 50 % de besoins, 30 % d\'envies et 20 % d\'épargne, vous aidant ainsi à contrôler vos dépenses et à épargner régulièrement.</string>
+    <string name="savings_recommendation_current_savings_label">Épargne actuelle</string>
+    <string name="savings_recommendation_available_format">Disponible : %1$s</string>
+    <string name="savings_recommendation_ideal_savings_format">Épargne idéale : %1$s</string>
+    <string name="savings_recommendation_current_savings_format">Épargne actuelle : %1$s</string>
+    <string name="savings_recommendation_recurrent_expenses_label">Dépenses récurrentes</string>
+    <string name="savings_recommendation_one_time_expenses_label">Dépenses ponctuelles</string>
+    <string name="savings_recommendation_six_month_example_intro" formatted="false">Si vous épargnez les 20 % à chaque période pendant environ 6 mois, vous pourriez constituer :</string>
 
     <!-- Wavy Divider -->
-    <string name="wavy_divider_show_all_past_period_expenses">Show all expenses from the previous period…</string>
+    <string name="wavy_divider_show_all_past_period_expenses">Afficher toutes les dépenses de la période précédente…</string>
+
+    <!-- Edit Budget Settings -->
+    <string name="use_previous_period_days">Utiliser %d jours</string>
+    <string name="remaining_budget_label">Restant</string>
+    <string name="currency_label">Devise</string>
+    <string name="select_currency">Sélectionner la devise</string>
+    <string name="currency_selected">Sélectionné</string>
+
+    <!-- Remaining Budget Strategy -->
+    <string name="strategy_dialog_title">Surplus budgétaire</string>
+    <string name="strategy_dialog_description" formatted="false">Vous pouvez choisir comment répartir votre solde budgétaire à la fin de chaque journée.\n\nPar exemple, vous avez un budget de 500 par jour et vous avez dépensé 400 hier : vous pouvez répartir les 100 sur les jours restants, ou dépenser 600 aujourd\'hui (budget quotidien + surplus de la période précédente).</string>
+    <string name="strategy_ask_always">Toujours me demander</string>
+    <string name="strategy_ask_always_desc">À la fin de la période, nous vous demanderons quoi faire du surplus</string>
+    <string name="strategy_split_equally">Répartir sur tous les jours</string>
+    <string name="strategy_split_equally_desc">Le surplus est divisé équitablement entre tous les jours de la nouvelle période</string>
+    <string name="strategy_add_to_first_day">Ajouter au premier jour</string>
+    <string name="strategy_add_to_first_day_desc">Tout le surplus est ajouté au premier jour de la nouvelle période</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
 
     <!-- History -->
     <string name="expense_deleted_format">%1$s deleted</string>
+    <string name="expense_modified_format">%1$s has been modified</string>
     <string name="generic_expense">Expense</string>
     <string name="expense_item_unnamed_expense">Unnamed expense</string>
     <string name="expense_item_recurrent_subtitle_format">Recurrent expense — %1$s</string>


### PR DESCRIPTION
## Description
Changes made to fix the Numpad layout when editing an existing expense.

## Change strategy
Refactored the Numpad component to use a weight-based internal layout instead of fixed row heights, allowing it to scale dynamically to a parent-defined percentage of the screen.

## Implemented
- Refactored Numpad.kt to use Modifier.weight for rows.
- Updated TransactionEditScreen.kt to calculate and assign exactly 48% of screen height to the numpad.
- Added safety logic to ensure layout weights are always strictly positive to prevent `IllegalArgumentException` during transitions.

## Working demo
[Screen_recording_20260611_215709.webm](https://github.com/user-attachments/assets/2b74fe29-e5f0-46e0-8f74-efe24c7d3b59)

## Testing
- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
N/A