### PR TITLE
feat: enhance bug report screen to create proper markdown file

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/serranoie/app/minus/navigation/AppNavGraph.kt
@@ -593,7 +593,7 @@ fun AppNavGraph(
             val context = LocalContext.current
             val shareTitle = stringResource(com.serranoie.app.minus.R.string.bug_report_share_title)
             val recipientEmail = stringResource(R.string.bug_report_recipient_email)
-            val emailSubject = stringResource(R.string.bug_report_email_subject)
+            val emailSubjectTemplate = stringResource(R.string.bug_report_email_subject)
             val emailBody = stringResource(R.string.bug_report_email_body)
             val viewModel: BugReportViewModel = hiltViewModel()
             val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
@@ -610,7 +610,7 @@ fun AppNavGraph(
                                 type = "application/zip"
                                 defaultEmailPackage?.let(::setPackage)
                                 putExtra(Intent.EXTRA_EMAIL, arrayOf(recipientEmail))
-                                putExtra(Intent.EXTRA_SUBJECT, emailSubject)
+                                putExtra(Intent.EXTRA_SUBJECT, emailSubjectTemplate.format(effect.title))
                                 putExtra(Intent.EXTRA_TEXT, emailBody)
                                 putExtra(Intent.EXTRA_STREAM, effect.uri)
                                 putExtra(Intent.EXTRA_TITLE, effect.fileName)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
@@ -3,6 +3,9 @@
 package com.serranoie.app.minus.presentation.ui.settings
 
 import android.app.TimePickerDialog
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -44,6 +47,7 @@ import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -56,6 +60,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,6 +79,7 @@ import com.serranoie.app.minus.BuildConfig
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.PeriodMappingMode
 import com.serranoie.app.minus.presentation.ui.history.RecurrentPaymentsViewMode
+import com.serranoie.app.minus.presentation.ui.settings.bugreport.buildAppEnvironmentMetadata
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.CustomPaddedExpandableItem
 import com.serranoie.app.minus.presentation.ui.theme.component.CustomPaddedListItem
@@ -86,6 +92,7 @@ import com.serranoie.app.minus.presentation.util.Utils.weakHapticFeedback
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -128,7 +135,9 @@ fun Settings(
 	val context = LocalContext.current
 	val view = LocalView.current
 	val snackbarHostState = remember { SnackbarHostState() }
+	val coroutineScope = rememberCoroutineScope()
 	val appVersionName = "v${BuildConfig.VERSION_NAME}"
+	val metadataCopiedMessage = stringResource(R.string.settings_version_metadata_copied)
 
 	Scaffold(
 		modifier = modifier
@@ -557,7 +566,18 @@ fun Settings(
 					CustomPaddedListItem(
 						onClick = {
 							view.weakHapticFeedback()
-						}, position = PaddedListItemPosition.Last
+						},
+						position = PaddedListItemPosition.Last,
+						onLongClick = {
+							context.copyAppEnvironmentMetadataToClipboard()
+							view.toggleFeedback()
+							coroutineScope.launch {
+								snackbarHostState.showSnackbar(
+									message = metadataCopiedMessage,
+									duration = SnackbarDuration.Short,
+								)
+							}
+						},
 					) {
 						Icon(
 							imageVector = Icons.Default.Info,
@@ -928,8 +948,18 @@ private fun RecurrentPaymentsViewMode.label(): String {
 	}
 }
 
+private fun Context.copyAppEnvironmentMetadataToClipboard() {
+	val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+	clipboard.setPrimaryClip(
+		ClipData.newPlainText(
+			"Minus app environment metadata",
+			buildAppEnvironmentMetadata(),
+		)
+	)
+}
+
 private fun formatNotificationTime(
-	context: android.content.Context, hour: Int, minute: Int
+	context: Context, hour: Int, minute: Int
 ): String {
 	val pattern = if (android.text.format.DateFormat.is24HourFormat(context)) "HH:mm" else "h:mm a"
 	return LocalTime.of(hour, minute)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportForm.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportForm.kt
@@ -39,10 +39,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Help
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.UploadFile
-import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Feedback
+import androidx.compose.material.icons.outlined.Help
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
@@ -55,6 +57,7 @@ import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonDefaults
@@ -118,7 +121,6 @@ fun BugReportForm(
 	val scrollBehavior =
 		TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
 	val context = LocalContext.current
-	val showCurrentBehaviorError = uiState.hasReproductionSteps && !uiState.hasCurrentBehavior
 	val attachmentPickerLauncher = rememberLauncherForActivityResult(
 		contract = ActivityResultContracts.OpenMultipleDocuments(),
 		onResult = { uris ->
@@ -168,7 +170,7 @@ fun BugReportForm(
 				accentColor = MaterialTheme.colorScheme.primary
 			)
 
-			Spacer(modifier = Modifier.height(16.dp))
+			Spacer(modifier = Modifier.height(24.dp))
 
 			SectionLabel(text = stringResource(R.string.bug_report_type_label))
 
@@ -183,44 +185,114 @@ fun BugReportForm(
 			Spacer(modifier = Modifier.height(28.dp))
 
 			FormField(
-				label = if (uiState.selectedIssueType == BugReportIssueType.FeatureRequest) {
-					stringResource(R.string.bug_report_change_label)
-				} else {
-					stringResource(R.string.bug_report_current_behavior_label)
-				},
-				placeholder = stringResource(R.string.bug_report_current_behavior_placeholder),
-				value = uiState.currentBehavior,
-				onValueChange = { onIntent(BugReportUiIntent.ChangeCurrentBehavior(it)) },
-				minHeight = 118.dp,
-				isError = showCurrentBehaviorError,
-				errorText = stringResource(R.string.bug_report_current_behavior_required)
+				label = stringResource(R.string.bug_report_title_label),
+				placeholder = stringResource(R.string.bug_report_title_placeholder),
+				value = uiState.title,
+				onValueChange = { onIntent(BugReportUiIntent.ChangeTitle(it)) },
+				minHeight = 56.dp,
+				isError = uiState.description.isNotBlank() && !uiState.hasTitle,
+				errorText = stringResource(R.string.bug_report_title_required),
+				singleLine = true
 			)
 
 			Spacer(modifier = Modifier.height(24.dp))
 
-			StepsToReproduceField(
-				stepCount = uiState.reproductionSteps.size,
-				stepIdAt = { index -> uiState.reproductionSteps[index].id },
-				stepValueAt = { index -> uiState.reproductionSteps[index].value },
-				stepVisibleAt = { index -> uiState.reproductionSteps[index].visible },
-				onStepChange = { index, value ->
-					onIntent(BugReportUiIntent.ChangeStep(index, value))
+			FormField(
+				label = if (uiState.selectedIssueType == BugReportIssueType.FeatureRequest) {
+					stringResource(R.string.bug_report_problem_label)
+				} else {
+					stringResource(R.string.bug_report_description_label)
 				},
-				onAddStep = {
-					onIntent(BugReportUiIntent.AddStep)
+				placeholder = if (uiState.selectedIssueType == BugReportIssueType.FeatureRequest) {
+					stringResource(R.string.bug_report_problem_placeholder)
+				} else {
+					stringResource(R.string.bug_report_description_placeholder)
 				},
-				onRemoveStep = { index ->
-					onIntent(BugReportUiIntent.RemoveStep(index))
-				},
-				onStepExitFinish = { stepId ->
-					onIntent(BugReportUiIntent.FinishStepExit(stepId))
-				})
+				value = uiState.description,
+				onValueChange = { onIntent(BugReportUiIntent.ChangeDescription(it)) },
+				minHeight = 118.dp,
+				isError = uiState.hasTitle && !uiState.hasDescription,
+				errorText = if (uiState.selectedIssueType == BugReportIssueType.FeatureRequest) {
+					stringResource(R.string.bug_report_problem_required)
+				} else {
+					stringResource(R.string.bug_report_description_required)
+				}
+			)
 
 			Spacer(modifier = Modifier.height(24.dp))
 
+			if (uiState.selectedIssueType == BugReportIssueType.BugReport) {
+				Row(
+					modifier = Modifier.fillMaxWidth(),
+					verticalAlignment = Alignment.CenterVertically,
+					horizontalArrangement = Arrangement.SpaceBetween
+				) {
+					SectionLabel(text = stringResource(R.string.bug_report_include_steps_label))
+					Switch(
+						checked = uiState.showReproductionSteps,
+						onCheckedChange = { onIntent(BugReportUiIntent.ToggleReproductionSteps(it)) }
+					)
+				}
+
+				AnimatedVisibility(
+					visible = uiState.showReproductionSteps,
+					enter = expandVertically() + fadeIn(),
+					exit = shrinkVertically() + fadeOut()
+				) {
+					Column {
+						Spacer(modifier = Modifier.height(16.dp))
+						StepsToReproduceField(
+							stepCount = uiState.reproductionSteps.size,
+							stepIdAt = { index -> uiState.reproductionSteps[index].id },
+							stepValueAt = { index -> uiState.reproductionSteps[index].value },
+							stepVisibleAt = { index -> uiState.reproductionSteps[index].visible },
+							onStepChange = { index, value ->
+								onIntent(BugReportUiIntent.ChangeStep(index, value))
+							},
+							onAddStep = {
+								onIntent(BugReportUiIntent.AddStep)
+							},
+							onRemoveStep = { index ->
+								onIntent(BugReportUiIntent.RemoveStep(index))
+							},
+							onStepExitFinish = { stepId ->
+								onIntent(BugReportUiIntent.FinishStepExit(stepId))
+							}
+						)
+					}
+				}
+				Spacer(modifier = Modifier.height(24.dp))
+			} else {
+				FormField(
+					label = stringResource(R.string.bug_report_proposed_solution_label),
+					placeholder = stringResource(R.string.bug_report_proposed_solution_placeholder),
+					value = uiState.proposedSolution,
+					onValueChange = { onIntent(BugReportUiIntent.ChangeProposedSolution(it)) },
+					minHeight = 118.dp,
+					isError = uiState.hasTitle && !uiState.hasProposedSolution,
+					errorText = stringResource(R.string.bug_report_proposed_solution_required)
+				)
+
+				Spacer(modifier = Modifier.height(24.dp))
+
+				FormField(
+					label = stringResource(R.string.bug_report_alternatives_considered_label),
+					placeholder = stringResource(R.string.bug_report_alternatives_considered_placeholder),
+					value = uiState.alternativesConsidered,
+					onValueChange = { onIntent(BugReportUiIntent.ChangeAlternativesConsidered(it)) },
+					minHeight = 94.dp
+				)
+
+				Spacer(modifier = Modifier.height(24.dp))
+			}
+
 			FormField(
-				label = stringResource(R.string.bug_report_other_information_label),
-				placeholder = stringResource(R.string.bug_report_other_information_placeholder),
+				label = stringResource(R.string.bug_report_additional_context_label),
+				placeholder = if (uiState.selectedIssueType == BugReportIssueType.BugReport) {
+					stringResource(R.string.bug_report_additional_context_placeholder_bug)
+				} else {
+					stringResource(R.string.bug_report_additional_context_placeholder_feature)
+				},
 				value = uiState.additionalInfo,
 				onValueChange = { onIntent(BugReportUiIntent.ChangeAdditionalInfo(it)) },
 				minHeight = 94.dp
@@ -228,7 +300,13 @@ fun BugReportForm(
 
 			Spacer(modifier = Modifier.height(24.dp))
 
-			SectionLabel(text = stringResource(R.string.bug_report_attachments_label))
+			SectionLabel(
+				text = if (uiState.selectedIssueType == BugReportIssueType.BugReport) {
+					stringResource(R.string.bug_report_attachments_label_bug)
+				} else {
+					stringResource(R.string.bug_report_attachments_label)
+				}
+			)
 			Spacer(modifier = Modifier.height(8.dp))
 			AttachmentDropZone(
 				attachmentCount = uiState.attachmentCount,
@@ -329,7 +407,7 @@ private fun HelpBanner(
 	) {
 		Row(verticalAlignment = Alignment.CenterVertically) {
 			Icon(
-				imageVector = Icons.Outlined.Info,
+				imageVector = Icons.AutoMirrored.Outlined.Help,
 				contentDescription = null,
 				tint = MaterialTheme.colorScheme.outline,
 				modifier = Modifier.size(20.dp)
@@ -380,6 +458,7 @@ private fun FormField(
 	rounded: Boolean = false,
 	isError: Boolean = false,
 	errorText: String? = null,
+	singleLine: Boolean = false
 ) {
 	Column(modifier = modifier.fillMaxWidth()) {
 		AnimatedContent(
@@ -413,7 +492,8 @@ private fun FormField(
 			modifier = Modifier
 				.fillMaxWidth()
 				.heightIn(min = minHeight),
-			minLines = 4,
+			minLines = if (singleLine) 1 else 4,
+			singleLine = singleLine
 		)
 
 		AnimatedVisibility(visible = isError && !errorText.isNullOrBlank()) {
@@ -445,12 +525,6 @@ private fun StepsToReproduceField(
 			.animateContentSize(animationSpec = tween(240)),
 		verticalArrangement = Arrangement.spacedBy(10.dp)
 	) {
-		Text(
-			text = stringResource(R.string.bug_report_steps_to_reproduce_label),
-			style = MaterialTheme.typography.labelLargeEmphasized,
-			color = MaterialTheme.colorScheme.onBackground
-		)
-
 		repeat(stepCount) { index ->
 			val stepId = stepIdAt(index)
 			key(stepId) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportViewModel.kt
@@ -2,6 +2,7 @@ package com.serranoie.app.minus.presentation.ui.settings.bugreport
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.serranoie.app.minus.presentation.ui.settings.bugreport.mvi.BugReportIssueType
 import com.serranoie.app.minus.presentation.ui.settings.bugreport.mvi.BugReportStep
 import com.serranoie.app.minus.presentation.ui.settings.bugreport.mvi.BugReportUiEffect
 import com.serranoie.app.minus.presentation.ui.settings.bugreport.mvi.BugReportUiIntent
@@ -35,10 +36,25 @@ class BugReportViewModel @Inject constructor(
 	fun onIntent(intent: BugReportUiIntent) {
 		when (intent) {
 			is BugReportUiIntent.SelectIssueType -> _uiState.update {
-				it.copy(selectedIssueType = intent.issueType)
+				it.copy(
+					selectedIssueType = intent.issueType,
+					showReproductionSteps = intent.issueType == BugReportIssueType.BugReport
+				)
 			}
-			is BugReportUiIntent.ChangeCurrentBehavior -> _uiState.update {
-				it.copy(currentBehavior = intent.value)
+			is BugReportUiIntent.ChangeTitle -> _uiState.update {
+				it.copy(title = intent.value)
+			}
+			is BugReportUiIntent.ChangeDescription -> _uiState.update {
+				it.copy(description = intent.value)
+			}
+			is BugReportUiIntent.ChangeProposedSolution -> _uiState.update {
+				it.copy(proposedSolution = intent.value)
+			}
+			is BugReportUiIntent.ChangeAlternativesConsidered -> _uiState.update {
+				it.copy(alternativesConsidered = intent.value)
+			}
+			is BugReportUiIntent.ToggleReproductionSteps -> _uiState.update {
+				it.copy(showReproductionSteps = intent.visible)
 			}
 			is BugReportUiIntent.ChangeStep -> updateStep(intent.index, intent.value)
 			BugReportUiIntent.AddStep -> addStep()
@@ -96,7 +112,18 @@ class BugReportViewModel @Inject constructor(
 			_uiState.update { it.copy(isGeneratingReport = true) }
 			runCatching { zipGenerator.generate(currentState) }
 				.onSuccess { report ->
-					_effects.emit(BugReportUiEffect.OpenEmailComposer(report.uri, report.fileName))
+					val titlePrefix = if (currentState.selectedIssueType == BugReportIssueType.BugReport) {
+						"[Bug]: "
+					} else {
+						"[Feature]: "
+					}
+					_effects.emit(
+						BugReportUiEffect.OpenEmailComposer(
+							uri = report.uri,
+							fileName = report.fileName,
+							title = "$titlePrefix${currentState.title}"
+						)
+					)
 				}
 				.onFailure { throwable ->
 					logcat { "Failed to generate bug report: ${throwable.asLog()}" }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportZipGenerator.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/BugReportZipGenerator.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.Normalizer
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.zip.ZipEntry
@@ -65,68 +64,90 @@ class BugReportZipGenerator @Inject constructor(
 	}
 
 	private fun buildMarkdown(state: BugReportUiState): String {
-		val issueType = when (state.selectedIssueType) {
-			BugReportIssueType.BugReport -> "Bug Report"
-			BugReportIssueType.FeatureRequest -> "Feature Request"
-		}
-		val behaviorTitle = when (state.selectedIssueType) {
-			BugReportIssueType.BugReport -> "What is happening?"
-			BugReportIssueType.FeatureRequest -> "What should change?"
-		}
-		val steps = state.reproductionSteps
-			.filter { it.visible && it.value.isNotBlank() }
-			.mapIndexed { index, step -> "${index + 1}. ${step.value.trim()}" }
-			.ifEmpty { listOf("No steps provided.") }
-			.joinToString(separator = "\n")
-		val attachments = state.selectedAttachmentUris
-			.mapIndexed { index, uri -> "- attachments/${buildAttachmentEntryName(index, uri)}" }
-			.ifEmpty { listOf("No attachments selected.") }
-			.joinToString(separator = "\n")
-		val deviceMetadata = buildDeviceMetadata()
-
-		return buildString {
-			appendLine("# Minus Feedback Report")
-			appendLine()
-			appendLine("## Metadata")
-			appendLine("- Issue type: $issueType")
-			appendLine("- App version: v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
-			appendLine("- Package name: ${context.packageName}")
-			appendLine("- Generated on: ${LocalDate.now()}")
-			deviceMetadata.forEach { (label, value) ->
-				appendLine("- $label: $value")
-			}
-			appendLine()
-			appendLine("## $behaviorTitle")
-			appendLine(state.currentBehavior.takeIf { it.isNotBlank() }?.trim() ?: "No description provided.")
-			appendLine()
-			appendLine("## Steps to reproduce")
-			appendLine(steps)
-			appendLine()
-			appendLine("## Other information")
-			appendLine(state.additionalInfo.takeIf { it.isNotBlank() }?.trim() ?: "No additional information provided.")
-			appendLine()
-			appendLine("## Attachments")
-			appendLine(attachments)
+		return when (state.selectedIssueType) {
+			BugReportIssueType.BugReport -> buildBugReportMarkdown(state)
+			BugReportIssueType.FeatureRequest -> buildFeatureRequestMarkdown(state)
 		}
 	}
 
-	private fun buildDeviceMetadata(): List<Pair<String, String>> {
-		return listOf(
-			"Device" to listOf(Build.MANUFACTURER, Build.MODEL)
-				.filter { it.isNotBlank() }
-				.distinctBy { it.lowercase(Locale.US) }
-				.joinToString(separator = " ")
-				.ifBlank { "Unknown" },
-			"Android version" to "${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})",
-			"Android codename" to Build.VERSION.CODENAME,
-			"Brand" to Build.BRAND,
-			"Product" to Build.PRODUCT,
-			"Device name" to Build.DEVICE,
-			"Hardware" to Build.HARDWARE,
-			"Supported ABIs" to Build.SUPPORTED_ABIS.joinToString(separator = ", "),
-			"Locale" to Locale.getDefault().toLanguageTag(),
-			"Timezone" to ZoneId.systemDefault().id,
-		)
+	private fun buildBugReportMarkdown(state: BugReportUiState): String {
+		val steps = if (state.showReproductionSteps) {
+			state.reproductionSteps
+				.filter { it.visible && it.value.isNotBlank() }
+				.mapIndexed { index, step -> "${index + 1}. ${step.value.trim()}" }
+				.ifEmpty { listOf("1. ", "2. ", "3. ") }
+				.joinToString(separator = "\n")
+		} else {
+			"1. \n2. \n3. "
+		}
+
+		val attachments = state.selectedAttachmentUris
+			.mapIndexed { index, uri -> "- attachments/${buildAttachmentEntryName(index, uri)}" }
+			.ifEmpty { emptyList() }
+			.joinToString(separator = "\n")
+
+		return buildString {
+			appendLine("# [Bug]: ${state.title}")
+			appendLine()
+			appendLine("## Description")
+			appendLine("<!-- What happened? What did you expect to happen? -->")
+			appendLine(state.description.takeIf { it.isNotBlank() }?.trim() ?: "")
+			appendLine()
+			appendLine("## Steps to reproduce")
+			appendLine()
+			appendLine(steps)
+			appendLine()
+			appendLine("## Screenshots or recordings")
+			appendLine("<!-- Add screenshots or videos if this is a UI issue. -->")
+			if (attachments.isNotBlank()) {
+				appendLine(attachments)
+			}
+			appendLine()
+			appendLine("## Environment")
+			appendLine("<!-- You can get this holding tap on the version section of the app, if not this sections is populated when creating the bug report from the Bug Report from the app. -->")
+			appendLine()
+			appendLine(buildAppEnvironmentMetadata())
+			appendLine()
+			appendLine("## Additional context")
+			appendLine("<!-- Logs, exported data details, recurrence/budget period setup, or anything else useful. -->")
+			appendLine(state.additionalInfo.takeIf { it.isNotBlank() }?.trim() ?: "")
+		}
+	}
+
+	private fun buildFeatureRequestMarkdown(state: BugReportUiState): String {
+		val attachments = state.selectedAttachmentUris
+			.mapIndexed { index, uri -> "- attachments/${buildAttachmentEntryName(index, uri)}" }
+			.ifEmpty { emptyList() }
+			.joinToString(separator = "\n")
+
+		return buildString {
+			appendLine("# [Feature]: ${state.title}")
+			appendLine()
+			appendLine("## Problem")
+			appendLine("<!-- What problem or workflow would this improve? -->")
+			appendLine(state.description.takeIf { it.isNotBlank() }?.trim() ?: "")
+			appendLine()
+			appendLine("## Proposed solution")
+			appendLine("<!-- Describe the change you would like to see. -->")
+			appendLine(state.proposedSolution.takeIf { it.isNotBlank() }?.trim() ?: "")
+			appendLine()
+			appendLine("## Alternatives considered")
+			appendLine("<!-- Optional: other ways this could work. -->")
+			appendLine(state.alternativesConsidered.takeIf { it.isNotBlank() }?.trim() ?: "")
+			appendLine()
+			appendLine("## Additional context")
+			appendLine("<!-- Mockups, screenshots, examples, or related issues. -->")
+			appendLine(state.additionalInfo.takeIf { it.isNotBlank() }?.trim() ?: "")
+			if (attachments.isNotBlank()) {
+				appendLine()
+				appendLine("### Screenshots or recordings")
+				appendLine(attachments)
+			}
+			appendLine()
+			appendLine("### Metadata")
+			appendLine("- App version: v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+			appendLine("- Generated on: ${LocalDate.now()}")
+		}
 	}
 
 	private fun buildAttachmentEntryName(index: Int, uri: Uri): String {
@@ -163,3 +184,30 @@ data class GeneratedBugReport(
 	val uri: Uri,
 	val fileName: String,
 )
+
+fun buildAppEnvironmentMetadata(): String {
+	return buildString {
+		appendLine("- App version: v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+		buildDeviceMetadata().forEach { (label, value) ->
+			appendLine("- $label: $value")
+		}
+	}.trimEnd()
+}
+
+private fun buildDeviceMetadata(): List<Pair<String, String>> {
+	return listOf(
+		"Device" to listOf(Build.MANUFACTURER, Build.MODEL)
+			.filter { it.isNotBlank() }
+			.distinctBy { it.lowercase(Locale.US) }
+			.joinToString(separator = " ")
+			.ifBlank { "Unknown" },
+		"Android version" to "${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})",
+		"Android codename" to Build.VERSION.CODENAME,
+		"Brand" to Build.BRAND,
+		"Product" to Build.PRODUCT,
+		"Device name" to Build.DEVICE,
+		"Hardware" to Build.HARDWARE,
+		"Supported ABIs" to Build.SUPPORTED_ABIS.joinToString(separator = ", "),
+		"Locale" to Locale.getDefault().toLanguageTag(),
+	)
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/mvi/BugReportMviContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/bugreport/mvi/BugReportMviContract.kt
@@ -15,7 +15,11 @@ data class BugReportStep(
 
 data class BugReportUiState(
 	val selectedIssueType: BugReportIssueType = BugReportIssueType.BugReport,
-	val currentBehavior: String = "",
+	val title: String = "",
+	val description: String = "",
+	val proposedSolution: String = "",
+	val alternativesConsidered: String = "",
+	val showReproductionSteps: Boolean = true,
 	val reproductionSteps: List<BugReportStep> = listOf(
 		BugReportStep(id = 0L),
 		BugReportStep(id = 1L),
@@ -26,14 +30,24 @@ data class BugReportUiState(
 	val isGeneratingReport: Boolean = false,
 ) {
 	val attachmentCount: Int = selectedAttachmentUris.size
-	val hasCurrentBehavior: Boolean = currentBehavior.isNotBlank()
+	val hasTitle: Boolean = title.isNotBlank()
+	val hasDescription: Boolean = description.isNotBlank()
+	val hasProposedSolution: Boolean = proposedSolution.isNotBlank()
 	val hasReproductionSteps: Boolean = reproductionSteps.any { it.visible && it.value.isNotBlank() }
-	val canSubmit: Boolean = hasCurrentBehavior && hasReproductionSteps && !isGeneratingReport
+	
+	val canSubmit: Boolean = hasTitle && hasDescription && 
+			(selectedIssueType != BugReportIssueType.FeatureRequest || hasProposedSolution) &&
+			(selectedIssueType != BugReportIssueType.BugReport || !showReproductionSteps || hasReproductionSteps) && 
+			!isGeneratingReport
 }
 
 sealed interface BugReportUiIntent {
 	data class SelectIssueType(val issueType: BugReportIssueType) : BugReportUiIntent
-	data class ChangeCurrentBehavior(val value: String) : BugReportUiIntent
+	data class ChangeTitle(val value: String) : BugReportUiIntent
+	data class ChangeDescription(val value: String) : BugReportUiIntent
+	data class ChangeProposedSolution(val value: String) : BugReportUiIntent
+	data class ChangeAlternativesConsidered(val value: String) : BugReportUiIntent
+	data class ToggleReproductionSteps(val visible: Boolean) : BugReportUiIntent
 	data class ChangeStep(val index: Int, val value: String) : BugReportUiIntent
 	data object AddStep : BugReportUiIntent
 	data class RemoveStep(val index: Int) : BugReportUiIntent
@@ -44,6 +58,6 @@ sealed interface BugReportUiIntent {
 }
 
 sealed interface BugReportUiEffect {
-	data class OpenEmailComposer(val uri: Uri, val fileName: String) : BugReportUiEffect
+	data class OpenEmailComposer(val uri: Uri, val fileName: String, val title: String) : BugReportUiEffect
 	data class ShowError(val message: String) : BugReportUiEffect
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
@@ -5,7 +5,9 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -265,6 +267,7 @@ fun PaddedListItem(
  * @param contentColor The content color for the item
  * @param content The custom content layout
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CustomPaddedListItem(
 	onClick: () -> Unit,
@@ -272,6 +275,7 @@ fun CustomPaddedListItem(
 	modifier: Modifier = Modifier,
 	background: Color = MaterialTheme.colorScheme.surfaceContainer,
 	contentColor: Color = MaterialTheme.colorScheme.onSurface,
+	onLongClick: (() -> Unit)? = null,
 	content: @Composable RowScope.() -> Unit
 ) {
 	val shape = when (position) {
@@ -297,7 +301,10 @@ fun CustomPaddedListItem(
 	) {
 		Row(
 			modifier = Modifier
-				.clickable { onClick() }
+				.combinedClickable(
+					onClick = onClick,
+					onLongClick = onLongClick,
+				)
 				.padding(horizontal = 16.dp, vertical = 12.dp),
 			verticalAlignment = Alignment.CenterVertically,
 			content = content)

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Menos</string>
 
@@ -136,6 +136,8 @@
     <string name="days_left">días</string>
     <string name="budget_overview">Resumen del presupuesto</string>
 
+    <string name="spent_per_day">Gastado por día</string>
+
     <string name="budget_period_daily">A diario</string>
     <string name="budget_period_weekly">Semanalmente</string>
     <string name="budget_period_biweekly">Quincenal</string>
@@ -164,8 +166,8 @@
 
     <string name="settings_title">Ajustes</string>
     <string name="settings_section_appearance">Apariencia</string>
-    <string name="settings_section_notifications">Notificaciones</string>
-    <string name="settings_section_features">Funciones</string>
+    <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_features">Features</string>
     <string name="settings_section_app_info">Información de la aplicación</string>
     <string name="settings_section_data_backup">Copia de seguridad de datos</string>
     <string name="settings_section_tutorial">Tutorial</string>
@@ -193,28 +195,42 @@
     <string name="settings_bug_report_title">¿Encontraste un error?</string>
     <string name="settings_bug_report_subtitle">Crea un informe de error y lo solucionaremos pronto.</string>
     <string name="settings_version_title">Versión</string>
+    <string name="settings_version_metadata_copied">Metadatos de la app y del dispositivo copiados al portapapeles</string>
 
     <!-- Bug Report -->
     <string name="bug_report_title">Comentarios y soporte</string>
     <string name="bug_report_type_label">Tipo de reporte</string>
     <string name="bug_report_type_bug_report">Reporte de error</string>
     <string name="bug_report_type_feature_request">Solicitud de función</string>
-    <string name="bug_report_change_label">¿Qué debería cambiar?</string>
-    <string name="bug_report_current_behavior_label">¿Qué está pasando?</string>
-    <string name="bug_report_current_behavior_placeholder">Describe el comportamiento actual en detalle…</string>
-    <string name="bug_report_current_behavior_required">Describe qué está pasando antes de enviar.</string>
-    <string name="bug_report_other_information_label">Otra información</string>
-    <string name="bug_report_other_information_placeholder">Cualquier contexto adicional o sugerencia…</string>
+    <string name="bug_report_title_label">Título</string>
+    <string name="bug_report_title_placeholder">Resumen del problema o solicitud…</string>
+    <string name="bug_report_title_required">Se requiere un título para enviar.</string>
+    <string name="bug_report_description_label">Descripción</string>
+    <string name="bug_report_description_placeholder">¿Qué pasó? ¿Qué esperabas que pasara?</string>
+    <string name="bug_report_description_required">Se requiere una descripción para enviar.</string>
+    <string name="bug_report_problem_label">Problema</string>
+    <string name="bug_report_problem_placeholder">¿Qué problema o flujo de trabajo mejoraría esto?</string>
+    <string name="bug_report_problem_required">Se requiere una descripción del problema.</string>
+    <string name="bug_report_proposed_solution_label">Solución propuesta</string>
+    <string name="bug_report_proposed_solution_placeholder">Describe el cambio que te gustaría ver…</string>
+    <string name="bug_report_proposed_solution_required">Se requiere una solución propuesta para solicitudes de funciones.</string>
+    <string name="bug_report_alternatives_considered_label">Alternativas consideradas</string>
+    <string name="bug_report_alternatives_considered_placeholder">Opcional: otras formas en que esto podría funcionar…</string>
+    <string name="bug_report_additional_context_label">Contexto adicional</string>
+    <string name="bug_report_additional_context_placeholder_bug">Registros, detalles de datos exportados, configuración de recurrencia/período o cualquier otra cosa útil.</string>
+    <string name="bug_report_additional_context_placeholder_feature">Cualquier información extra si es necesario</string>
     <string name="bug_report_attachments_label">Archivos adjuntos</string>
+    <string name="bug_report_attachments_label_bug">Capturas de pantalla o grabaciones</string>
     <string name="bug_report_submit">Enviar reporte</string>
     <string name="bug_report_share_title">Enviar reporte</string>
-    <string name="bug_report_email_subject">Reporte de Minus</string>
+    <string name="bug_report_email_subject">%1$s</string>
     <string name="bug_report_email_body">Hola, adjunto mi reporte generado de Minus.</string>
     <string name="bug_report_help_title">Ayúdanos a mejorar</string>
-    <string name="bug_report_help_message_prefix">Completar este formulario generará un archivo .zip con el contenido del reporte y los archivos adjuntos para que puedas enviarlo por correo electrónico.\nSi tienes una cuenta de GitHub, también puedes abrir </string>
+    <string name="bug_report_help_message_prefix">"¿Encontraste un error o tienes una gran idea?\n\nEsta pantalla nos ayuda a crear todos los detalles necesarios en un reporte. Incluiremos automáticamente diagnósticos técnicos sobre tu dispositivo y la versión de la aplicación para ayudarnos a solucionar problemas más rápido.\n\nUna vez finalizado, puedes enviar el reporte por correo electrónico o publicarlo en "</string>
     <string name="bug_report_help_github_issues">" GitHub Issues "</string>
-    <string name="bug_report_help_message_suffix"> para este repositorio.</string>
+    <string name="bug_report_help_message_suffix"> directamente en nuestro repositorio.</string>
     <string name="bug_report_steps_to_reproduce_label">Pasos para reproducir</string>
+    <string name="bug_report_include_steps_label">Incluir pasos de reproducción</string>
     <string name="bug_report_add_step">Agregar paso</string>
     <string name="bug_report_step_placeholder_wallet">Abre la pantalla de billetera</string>
     <string name="bug_report_step_placeholder_transfer">Toca \'Transferir\'</string>
@@ -254,7 +270,7 @@
 
     <string name="budget_pill_over_budget">Presupuesto agotado</string>
     <string name="budget_pill_no_budget">Sin presupuesto</string>
-    <string name="budget_pill_exhausted_daily_label"></string>
+    <string name="budget_pill_exhausted_daily_label">diario</string>
     <string name="budget_pill_exhausted_weekly_label">semanalmente</string>
     <string name="budget_pill_exhausted_biweekly_label">quincenal</string>
     <string name="budget_pill_exhausted_single">%1$s presupuesto agotado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Minus</string>
 
@@ -198,28 +199,41 @@
     <string name="settings_bug_report_title">Un bug ?</string>
     <string name="settings_bug_report_subtitle">Créez un rapport de bug et nous le corrigerons bientôt</string>
     <string name="settings_version_title">Version</string>
+    <string name="settings_version_metadata_copied">Métadonnées de l’app et de l’appareil copiées dans le presse-papiers</string>
 
     <!-- Bug Report -->
     <string name="bug_report_title">Commentaires et assistance</string>
     <string name="bug_report_type_label">Type de rapport</string>
     <string name="bug_report_type_bug_report">Rapport de bug</string>
     <string name="bug_report_type_feature_request">Demande de fonctionnalité</string>
-    <string name="bug_report_change_label">Que faudrait-il changer ?</string>
-    <string name="bug_report_current_behavior_label">Que se passe-t-il ?</string>
-    <string name="bug_report_current_behavior_placeholder">Décrivez le comportement actuel en détail…</string>
-    <string name="bug_report_current_behavior_required">Décrivez ce qui se passe avant d’envoyer.</string>
-    <string name="bug_report_other_information_label">Autres informations</string>
-    <string name="bug_report_other_information_placeholder">Tout contexte supplémentaire ou suggestion…</string>
+    <string name="bug_report_title_label">Titre</string>
+    <string name="bug_report_title_placeholder">Résumer le problème ou la demande…</string>
+    <string name="bug_report_title_required">Un titre est requis pour envoyer.</string>
+    <string name="bug_report_description_label">Description</string>
+    <string name="bug_report_description_placeholder">Que s\'est-il passé ? À quoi vous attendiez-vous ?</string>
+    <string name="bug_report_description_required">Une description est requise pour envoyer.</string>
+    <string name="bug_report_problem_label">Problème</string>
+    <string name="bug_report_problem_placeholder">Quel problème ou flux de travail cela améliorerait-il ?</string>
+    <string name="bug_report_problem_required">Une description du problème est requise.</string>
+    <string name="bug_report_proposed_solution_label">Solution proposée</string>
+    <string name="bug_report_proposed_solution_placeholder">Décrivez le changement que vous aimeriez voir…</string>
+    <string name="bug_report_proposed_solution_required">Une solution proposée est requise pour les demandes de fonctionnalités.</string>
+    <string name="bug_report_alternatives_considered_label">Alternatives envisagées</string>
+    <string name="bug_report_alternatives_considered_placeholder">Facultatif : d\'autres façons dont cela pourrait fonctionner…</string>
+    <string name="bug_report_additional_context_label">Contexte supplémentaire</string>
+    <string name="bug_report_additional_context_placeholder_bug">Logs, détails des données exportées, configuration de la récurrence/période budgétaire ou tout autre élément utile.</string>
+    <string name="bug_report_additional_context_placeholder_feature">Toute information supplémentaire si nécessaire</string>
     <string name="bug_report_attachments_label">Pièces jointes</string>
     <string name="bug_report_submit">Envoyer le rapport</string>
     <string name="bug_report_share_title">Envoyer le rapport</string>
-    <string name="bug_report_email_subject">Rapport Minus</string>
+    <string name="bug_report_email_subject">%1$s</string>
     <string name="bug_report_email_body">Bonjour, vous trouverez ci-joint mon rapport Minus généré.</string>
     <string name="bug_report_help_title">Aidez-nous à nous améliorer</string>
     <string name="bug_report_help_message_prefix">Remplir ce formulaire générera un fichier .zip avec le contenu du rapport et les pièces jointes afin que vous puissiez l’envoyer par e-mail.\nSi vous avez un compte GitHub, vous pouvez aussi ouvrir </string>
     <string name="bug_report_help_github_issues">" GitHub Issues "</string>
     <string name="bug_report_help_message_suffix"> pour ce dépôt.</string>
     <string name="bug_report_steps_to_reproduce_label">Étapes pour reproduire</string>
+    <string name="bug_report_include_steps_label">Inclure les étapes de reproduction</string>
     <string name="bug_report_add_step">Ajouter une étape</string>
     <string name="bug_report_step_placeholder_wallet">Ouvrez l’écran du portefeuille</string>
     <string name="bug_report_step_placeholder_transfer">Appuyez sur \'Transférer\'</string>
@@ -274,7 +288,7 @@
     <!-- Categories Chart -->
     <string name="categories_chart_uncategorized">Non catégorisé</string>
     <string name="categories_chart_rest">Restant</string>
-    <string name="categories_chart_empty_title">Nous ne pouvons pas répartir vos dépenses par catégories</string>
+    <string name="categories_chart_empty_title">Nous ne pouvons pas répartir vos dpenses par catégories</string>
     <string name="categories_chart_empty_subtitle">Utilisez des étiquettes pour voir le graphique par catégories</string>
 
     <!-- Calendar Heatmap -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,8 @@
     <string name="days_left">days left</string>
     <string name="budget_overview">Budget Overview</string>
 
+    <string name="spent_per_day">Spent per day</string>
+
     <string name="budget_period_daily">Daily</string>
     <string name="budget_period_weekly">Weekly</string>
     <string name="budget_period_biweekly">Biweekly</string>
@@ -208,30 +210,44 @@
     <string name="settings_bug_report_title">Found a bug?</string>
     <string name="settings_bug_report_subtitle">Create a bug report and we will fix it soon</string>
     <string name="settings_version_title">Version</string>
+    <string name="settings_version_metadata_copied">App and device metadata copied to clipboard</string>
 
     <!-- Bug Report -->
     <string name="bug_report_title">Feedback &amp; Support</string>
     <string name="bug_report_type_label">Report type</string>
     <string name="bug_report_type_bug_report">Bug Report</string>
     <string name="bug_report_type_feature_request">Feature Request</string>
-    <string name="bug_report_change_label">What you should change?</string>
-    <string name="bug_report_current_behavior_label">What is happening?</string>
-    <string name="bug_report_current_behavior_placeholder">Describe the current behavior in detail…</string>
-    <string name="bug_report_current_behavior_required">Describe what is happening before submitting.</string>
-    <string name="bug_report_other_information_label">Other information</string>
-    <string name="bug_report_other_information_placeholder">Any additional context or suggestions…</string>
+    <string name="bug_report_title_label">Title</string>
+    <string name="bug_report_title_placeholder">Summarize the issue or request…</string>
+    <string name="bug_report_title_required">A title is required to submit.</string>
+    <string name="bug_report_description_label">Description</string>
+    <string name="bug_report_description_placeholder">What happened? What did you expect to happen?</string>
+    <string name="bug_report_description_required">A description is required to submit.</string>
+    <string name="bug_report_problem_label">Problem</string>
+    <string name="bug_report_problem_placeholder">What problem or workflow would this improve?</string>
+    <string name="bug_report_problem_required">A problem description is required.</string>
+    <string name="bug_report_proposed_solution_label">Proposed solution</string>
+    <string name="bug_report_proposed_solution_placeholder">Describe the change you would like to see…</string>
+    <string name="bug_report_proposed_solution_required">A proposed solution is required for feature requests.</string>
+    <string name="bug_report_alternatives_considered_label">Alternatives considered</string>
+    <string name="bug_report_alternatives_considered_placeholder">Optional: other ways this could work…</string>
+    <string name="bug_report_additional_context_label">Additional context</string>
+    <string name="bug_report_additional_context_placeholder_bug">Logs, exported data details, recurrence/budget period setup, or anything else useful.</string>
+    <string name="bug_report_additional_context_placeholder_feature">Any extra info if necessary</string>
     <string name="bug_report_attachments_label">Attachments</string>
+    <string name="bug_report_attachments_label_bug">Screenshots or recordings</string>
     <string name="bug_report_submit">Submit Report</string>
-    <string name="bug_report_share_title">Send bug report</string>
+    <string name="bug_report_share_title">Send report</string>
     <string name="bug_report_recipient_email" translatable="false">serranoie99@gmail.com</string>
-    <string name="bug_report_email_subject">Minus bug report</string>
+    <string name="bug_report_email_subject">%1$s</string>
     <string name="bug_report_email_body">Hi, attached is my generated Minus report.</string>
-    <string name="bug_report_help_title">Help us improve</string>
-    <string name="bug_report_help_message_prefix">Filling out this form will generate a .zip file with the report content and any attachments, so you can send it via email.\nIf you have a GitHub account, you can also open </string>
+    <string name="bug_report_help_title">Help us make Minus better</string>
+    <string name="bug_report_help_message_prefix">"Reporting issues or suggesting improvements helps us make Minus better for everyone.\n\nThis guided form helps you package all the necessary details into a report, automatically attaching device metadata and app diagnostics to speed up our investigation.\n\nOnce prepared, you can send the report via email or contribute via "</string>
     <string name="bug_report_help_github_issues">" GitHub Issues "</string>
-    <string name="bug_report_help_message_suffix"> for this repository.</string>
+    <string name="bug_report_help_message_suffix"> directly on our repository.</string>
     <string name="bug_report_github_issues_url" translatable="false">https://github.com/isaacsa51/Minus/issues</string>
     <string name="bug_report_steps_to_reproduce_label">Steps to reproduce</string>
+    <string name="bug_report_include_steps_label">Include reproduction steps</string>
     <string name="bug_report_add_step">Add Step</string>
     <string name="bug_report_step_placeholder_wallet">Open the wallet screen</string>
     <string name="bug_report_step_placeholder_transfer">Click on \'Transfer\'</string>


### PR DESCRIPTION
## Description
Enhanced Bug Report screen process and information. This PR closes #16 Request when merged.

## Change strategy
Modified the UI layout depending of the type of report following Github Issues templates.

## Implemented
- Holding app version to get App/Device metadata
- Redefined Feature Request UI layout form to get more data
- Be able to mark to dismiss steps to reproduce on a bug form in case of not applicable.

## Working demo
[Screen_recording_20260614_165450.webm](https://github.com/user-attachments/assets/caaceb9a-e5a8-4a84-ac15-d95c6672cd53)

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
N/A