### PR TITLE
feat: update modal bottom sheet state to skip partially expanded

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/BudgetPeriodSheet.kt
@@ -16,9 +16,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -108,10 +108,10 @@ import java.time.temporal.ChronoUnit
 import java.util.Date
 import java.util.Locale
 
-private const val PERIOD_SWITCHER_TAG = "PeriodSwitcherSheet - ISAAC"
+private const val BUDGET_PERIOD_SHEET_TAG = "BudgetPeriodSheet - ISAAC"
 
 @Composable
-fun PeriodSwitcherSheet(
+fun BudgetPeriodSheet(
 	budgetSettings: BudgetSettings?,
 	budgetState: BudgetState?,
 	selectedPeriod: BudgetPeriod = budgetSettings?.period ?: BudgetPeriod.DAILY,
@@ -163,71 +163,67 @@ fun PeriodSwitcherSheet(
 		}
 	}
 
-	Box(
-		modifier = Modifier.fillMaxSize()
-	) {
-		AnimatedContent(
-			targetState = isEditMode, transitionSpec = {
-				if (targetState) {
-					// Forward: entering edit mode
-					(slideInHorizontally(
-						initialOffsetX = { it / 3 }, animationSpec = tween(300)
-					) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
-						slideOutHorizontally(
-							targetOffsetX = { -it / 3 }, animationSpec = tween(300)
-						) + fadeOut(tween(200))
-					)
-				} else {
-					// Backward: exiting edit mode
-					(slideInHorizontally(
-						initialOffsetX = { -it / 3 }, animationSpec = tween(300)
-					) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
-						slideOutHorizontally(
-							targetOffsetX = { it / 3 }, animationSpec = tween(300)
-						) + fadeOut(tween(200))
-					)
-				}
-			}, label = "sheetContent"
-		) { editMode ->
-			if (editMode) {
-				EditBudgetContent(
-					budgetSettings = budgetSettings,
-					onBack = { isEditMode = false },
-					onApply = { newSettings ->
-						onSaveBudget?.invoke(newSettings)
-						isEditMode = false
-					},
-					pendingExpensesCount = pendingExpensesCount,
+	AnimatedContent(
+		targetState = isEditMode, transitionSpec = {
+			if (targetState) {
+				// Forward: entering edit mode
+				(slideInHorizontally(
+					initialOffsetX = { it / 3 }, animationSpec = tween(300)
+				) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
+					slideOutHorizontally(
+						targetOffsetX = { -it / 3 }, animationSpec = tween(300)
+					) + fadeOut(tween(200))
 				)
 			} else {
-				ViewBudgetContent(
-					budgetSettings = budgetSettings,
-					budgetState = budgetState,
-					periodCache = periodCache,
-					currencyFormat = currencyFormat,
-					currencyCode = currencyCode,
-					totalBudget = totalBudget,
-					totalSpent = totalSpent,
-					totalDays = totalDays,
-					startDateAsDate = startDateAsDate,
-					endDateAsDate = endDateAsDate,
-					available = available,
-					onPeriodSelected = { p ->
-						logcat { "User selected period chip: $p (previous=$periodCache)" }
-						periodCache = p
-						onPeriodSelected(p)
-					},
-					onEditClick = {
-						if (onSaveBudget != null) {
-							isEditMode = true
-						} else {
-							onEditBudget?.invoke()
-						}
-					},
-					onFinishEarlyClick = { showFinishConfirm = true },
-					showFinishEarly = onFinishEarly != null && budgetSettings != null,
+				// Backward: exiting edit mode
+				(slideInHorizontally(
+					initialOffsetX = { -it / 3 }, animationSpec = tween(300)
+				) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
+					slideOutHorizontally(
+						targetOffsetX = { it / 3 }, animationSpec = tween(300)
+					) + fadeOut(tween(200))
 				)
 			}
+		}, label = "sheetContent"
+	) { editMode ->
+		if (editMode) {
+			EditBudgetContent(
+				budgetSettings = budgetSettings,
+				onBack = { isEditMode = false },
+				onApply = { newSettings ->
+					onSaveBudget?.invoke(newSettings)
+					isEditMode = false
+				},
+				pendingExpensesCount = pendingExpensesCount,
+			)
+		} else {
+			ViewBudgetContent(
+				budgetSettings = budgetSettings,
+				budgetState = budgetState,
+				periodCache = periodCache,
+				currencyFormat = currencyFormat,
+				currencyCode = currencyCode,
+				totalBudget = totalBudget,
+				totalSpent = totalSpent,
+				totalDays = totalDays,
+				startDateAsDate = startDateAsDate,
+				endDateAsDate = endDateAsDate,
+				available = available,
+				onPeriodSelected = { p ->
+					logcat { "User selected period chip: $p (previous=$periodCache)" }
+					periodCache = p
+					onPeriodSelected(p)
+				},
+				onEditClick = {
+					if (onSaveBudget != null) {
+						isEditMode = true
+					} else {
+						onEditBudget?.invoke()
+					}
+				},
+				onFinishEarlyClick = { showFinishConfirm = true },
+				showFinishEarly = onFinishEarly != null && budgetSettings != null,
+			)
 		}
 	}
 
@@ -292,8 +288,7 @@ private fun ViewBudgetContent(
 			.fillMaxWidth()
 			.padding(horizontal = 16.dp)
 			.padding(top = 4.dp, bottom = 32.dp)
-			.navigationBarsPadding()
-			.verticalScroll(rememberScrollState()),
+			.navigationBarsPadding(),
 	) {
 		Row(
 			modifier = Modifier
@@ -320,20 +315,23 @@ private fun ViewBudgetContent(
 
 		Spacer(modifier = Modifier.height(8.dp))
 
-		logcat(PERIOD_SWITCHER_TAG) {
+		logcat(BUDGET_PERIOD_SHEET_TAG) {
 			"BudgetDisplay input totalBudget=$totalBudget budgetStateTotal=${budgetState?.totalBudget} budgetSettingsTotal=${budgetSettings?.totalBudget} rollOverLimit=${budgetSettings?.rollOverLimit} rollOverCarry=${budgetSettings?.rollOverCarryForward}"
 		}
 
 		SpendBudgetCard(
 			modifier = Modifier
 				.fillMaxWidth()
+				.height(IntrinsicSize.Min)
 				.padding(bottom = 8.dp),
 			budget = totalBudget,
 			spend = totalSpent,
 		)
 
 		Row(
-			modifier = Modifier.fillMaxWidth(),
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(120.dp),
 			horizontalArrangement = Arrangement.spacedBy(8.dp),
 			verticalAlignment = Alignment.CenterVertically,
 		) {
@@ -343,22 +341,30 @@ private fun ViewBudgetContent(
 				budgetSettings = budgetSettings,
 				currencyCode = currencyCode,
 				bigVariant = false,
-				modifier = Modifier.weight(1.5f),
+				modifier = Modifier
+					.weight(1.5f)
+					.height(120.dp),
 				startDate = startDateAsDate,
 				finishDate = endDateAsDate
 			)
 
 			if (endDateAsDate != null) {
-				DaysLeftCard(
-					startDate = startDateAsDate,
-					finishDate = endDateAsDate,
-					modifier = Modifier.weight(1f)
-				)
+				Box(
+					modifier = Modifier
+						.weight(1f)
+						.height(120.dp),
+					contentAlignment = Alignment.Center,
+				) {
+					DaysLeftCard(
+						startDate = startDateAsDate,
+						finishDate = endDateAsDate,
+					)
+				}
 			} else {
 				Card(
 					modifier = Modifier
 						.weight(1f)
-						.heightIn(min = 100.dp),
+						.height(120.dp),
 					colors = CardDefaults.cardColors(
 						containerColor = MaterialTheme.colorScheme.surfaceVariant
 					),
@@ -509,8 +515,7 @@ fun EditBudgetContent(
 		modifier = Modifier
 			.fillMaxWidth()
 			.padding(horizontal = 16.dp)
-			.navigationBarsPadding()
-			.verticalScroll(rememberScrollState()),
+			.navigationBarsPadding(),
 	) {
 		Text(
 			text = title,
@@ -1133,10 +1138,10 @@ private fun CompactPeriodCard(
 	uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
 )
 @Composable
-private fun PeriodSwitcherSheetPreview() {
+private fun BudgetPeriodSheetPreview() {
 	MinusTheme {
 		Surface {
-			PeriodSwitcherSheet(
+			BudgetPeriodSheet(
 				budgetSettings = BudgetSettings(
 					totalBudget = BigDecimal("17725"),
 					period = BudgetPeriod.DAILY,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -129,7 +128,7 @@ fun Editor(
 ) {
 	val view = LocalView.current
 	val scope = rememberCoroutineScope()
-	val sheetState = rememberModalBottomSheetState()
+	val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 	var showBottomSheet by remember { mutableStateOf(false) }
 	var hasAutoOpenedWalletSheet by remember { mutableStateOf(false) }
 
@@ -328,45 +327,40 @@ fun Editor(
 			onDismissRequest = { showBottomSheet = false },
 			sheetState = sheetState,
 		) {
-			Box(
-				modifier = Modifier
-					.fillMaxWidth()
-					.heightIn(max = 600.dp)
-			) {
-				val shouldForceSetupMode = forceWalletSetup
-				logcat {
-					"Opening PeriodSwitcherSheet: forceWalletSetup=$forceWalletSetup, hasBudgetSettings=${uiState.budgetSettings != null}, currentPeriodId=${uiState.currentPeriodId}, startInEditMode=$shouldForceSetupMode"
-				}
-				PeriodSwitcherSheet(
-					budgetSettings = uiState.budgetSettings,
-					budgetState = uiState.budgetState,
-					selectedPeriod = selectedViewPeriod,
-					pendingExpensesCount = uiState.pendingExpensesForNextPeriod.size,
-					currencyCode = uiState.budgetSettings?.currencyCode ?: "USD",
-					startInEditMode = shouldForceSetupMode,
-					onPeriodSelected = { newPeriod ->
-						logcat { "PeriodSwitcher onPeriodSelected -> newPeriod=$newPeriod, previousSelectedViewPeriod=$selectedViewPeriod" }
-						selectedViewPeriod = newPeriod
-						onChangePeriod(newPeriod)
-					},
-					onSaveBudget = { newSettings ->
-						logcat { "PeriodSwitcher onSaveBudget -> $newSettings" }
-						onSaveBudget(newSettings)
-						scope.launch { sheetState.hide() }
-						showBottomSheet = false
-					},
-					onEditBudget = {
-						onOpenWallet()
-						scope.launch { sheetState.hide() }
-						showBottomSheet = false
-					},
-					onFinishEarly = {
-						onFinishBudgetEarly()
-						onOpenAnalytics()
-						scope.launch { sheetState.hide() }
-						showBottomSheet = false
-					})
+			val shouldForceSetupMode = forceWalletSetup
+			logcat {
+				"Opening BudgetPeriodSheet: forceWalletSetup=$forceWalletSetup, hasBudgetSettings=${uiState.budgetSettings != null}, currentPeriodId=${uiState.currentPeriodId}, startInEditMode=$shouldForceSetupMode"
 			}
+			BudgetPeriodSheet(
+				budgetSettings = uiState.budgetSettings,
+				budgetState = uiState.budgetState,
+				selectedPeriod = selectedViewPeriod,
+				pendingExpensesCount = uiState.pendingExpensesForNextPeriod.size,
+				currencyCode = uiState.budgetSettings?.currencyCode ?: "USD",
+				startInEditMode = shouldForceSetupMode,
+				onPeriodSelected = { newPeriod ->
+					logcat { "BudgetPeriodSheet onPeriodSelected -> newPeriod=$newPeriod, previousSelectedViewPeriod=$selectedViewPeriod" }
+					selectedViewPeriod = newPeriod
+					onChangePeriod(newPeriod)
+				},
+				onSaveBudget = { newSettings ->
+					logcat { "BudgetPeriodSheet onSaveBudget -> $newSettings" }
+					onSaveBudget(newSettings)
+					scope.launch { sheetState.hide() }
+					showBottomSheet = false
+				},
+				onEditBudget = {
+					onOpenWallet()
+					scope.launch { sheetState.hide() }
+					showBottomSheet = false
+				},
+				onFinishEarly = {
+					onFinishBudgetEarly()
+					onOpenAnalytics()
+					scope.launch { sheetState.hide() }
+					showBottomSheet = false
+				},
+			)
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fix `BudgetPeriodSheet` bottom sheet sizing so active budget content opens expanded and no longer requires scrolling/pulling to reveal content. This PR closes #19 feature request.

## Change strategy
Remove sheet-level forced sizing/scrolling, then constrain only the child cards that expand under loose bottom-sheet measurement.

## Implemented
- Renamed `PeriodSwitcherSheet` to `BudgetPeriodSheet`.
- Removed main sheet vertical scroll and fillMaxSize.
- Removed parent `heightIn(max = 600.dp)`.
- Disabled partial modal sheet expansion with `skipPartiallyExpanded = true`.
- Added local height constraints for budget cards/summary row.

## Working demo
[Screen_recording_20260614_220940.webm](https://github.com/user-attachments/assets/948a0455-0ad2-4059-be7b-750900989503)

## Testing
- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes
