### PR TITLE
test: coverage for Onboard and Home screens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ local.properties
 # Detekt
 config/detekt/detekt-baseline.xml
 build/reports/detekt/
+.hotswan/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
 	testImplementation(libs.kotlinx.coroutines.test)
 	testImplementation(libs.turbine)
 	testImplementation(libs.google.truth)
+	testImplementation(libs.mockk)
 	androidTestImplementation(libs.androidx.junit)
 	androidTestImplementation(libs.androidx.espresso.core)
 	androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,10 @@ android {
     packaging {
         resources.excludes += "/META-INF/AL2.0"
         resources.excludes += "/META-INF/LGPL2.1"
+        // JUnit Jupiter (transitive of mockk) ships these META-INF
+        // resources in multiple jars — only keep the first.
+        resources.excludes += "/META-INF/LICENSE.md"
+        resources.excludes += "/META-INF/LICENSE-notice.md"
     }
     namespace = "com.serranoie.app.minus"
 
@@ -212,6 +216,7 @@ dependencies {
 	androidTestImplementation(platform(libs.androidx.compose.bom))
 	androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 	androidTestImplementation(libs.google.truth)
+	androidTestImplementation(libs.mockk.android)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,32 +1,32 @@
 plugins {
-	alias(libs.plugins.android.application)
-	alias(libs.plugins.kotlin.android)
-	alias(libs.plugins.kotlin.compose)
-	alias(libs.plugins.kotlin.serialization)
-	alias(libs.plugins.paparazzi)
-	alias(libs.plugins.detekt)
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.paparazzi)
+    alias(libs.plugins.detekt)
 
-	id("dagger.hilt.android.plugin")
-	id("com.google.devtools.ksp")
+    id("dagger.hilt.android.plugin")
+    id("com.google.devtools.ksp")
 }
 
 detekt {
-	buildUponDefaultConfig = true
-	config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
-	baseline = file("$rootDir/config/detekt/detekt-baseline.xml")
-	// Disable all default rulesets so only rules in detekt.yml are active.
-	// Formatting rules (Indentation, MaxLineLength, etc.) are part of default
-	// rulesets and can't be selectively disabled in the Gradle plugin — any
-	// formatting issues present in the codebase are suppressed via the baseline.
-	disableDefaultRuleSets = true
+    buildUponDefaultConfig = true
+    config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+    baseline = file("$rootDir/config/detekt/detekt-baseline.xml")
+    // Disable all default rulesets so only rules in detekt.yml are active.
+    // Formatting rules (Indentation, MaxLineLength, etc.) are part of default
+    // rulesets and can't be selectively disabled in the Gradle plugin — any
+    // formatting issues present in the codebase are suppressed via the baseline.
+    disableDefaultRuleSets = true
 }
 
 // Configure reports on the task level (avoids deprecated extension-level API)
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-	reports {
-		html.required.set(true)
-		xml.required.set(true)
-	}
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
 }
 
 // Paparazzi snapshot tests run in the test JVM. These system properties must be
@@ -39,218 +39,222 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
 // Together these absorb cross-platform rasterisation drift (Linux CI vs
 // Windows/macOS dev machines) without hiding real layout regressions.
 tasks.withType<Test>().configureEach {
-	systemProperty("app.cash.paparazzi.differ", "offbytwo")
-	systemProperty("paparazzi.maxPercentDifferenceDefault", "5.0")
+    systemProperty("app.cash.paparazzi.differ", "offbytwo")
+    systemProperty("paparazzi.maxPercentDifferenceDefault", "5.0")
 }
 
 fun gitOutput(vararg args: String): String? {
-	return runCatching {
-		val process = ProcessBuilder("git", *args)
-			.directory(rootDir)
-			.redirectErrorStream(true)
-			.start()
-		val output = process.inputStream.bufferedReader().readText().trim()
-		if (process.waitFor() == 0) output.takeIf { it.isNotBlank() } else null
-	}.getOrNull()
+    return runCatching {
+        val process = ProcessBuilder("git", *args)
+            .directory(rootDir)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        if (process.waitFor() == 0) output.takeIf { it.isNotBlank() } else null
+    }.getOrNull()
 }
 
 fun normalizedVersionTag(tag: String?): String? {
-	val normalizedTag = tag?.removePrefix("refs/tags/") ?: return null
-	return normalizedTag.takeIf { it.matches(Regex("^v?\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$")) }
+    val normalizedTag = tag?.removePrefix("refs/tags/") ?: return null
+    return normalizedTag.takeIf { it.matches(Regex("^v?\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$")) }
 }
 
 fun releaseVersionName(): String {
-	val tag = normalizedVersionTag(System.getenv("VERSION_TAG"))
-		?: normalizedVersionTag(System.getenv("GITHUB_REF_NAME"))
-		?: normalizedVersionTag(gitOutput("describe", "--tags", "--exact-match"))
-		?: normalizedVersionTag(gitOutput("describe", "--tags", "--abbrev=0"))
-		?: "v0.0.0-dev"
+    val tag = normalizedVersionTag(System.getenv("VERSION_TAG"))
+        ?: normalizedVersionTag(System.getenv("GITHUB_REF_NAME"))
+        ?: normalizedVersionTag(gitOutput("describe", "--tags", "--exact-match"))
+        ?: normalizedVersionTag(gitOutput("describe", "--tags", "--abbrev=0"))
+        ?: "v0.0.0-dev"
 
-	return tag.removePrefix("v")
+    return tag.removePrefix("v")
 }
 
 fun versionCodeFrom(versionName: String): Int {
-	val parts = versionName.split("-", limit = 2).first()
-		.split(".")
-		.map { it.toIntOrNull() ?: 0 }
-	val major = parts.getOrElse(0) { 0 }
-	val minor = parts.getOrElse(1) { 0 }
-	val patch = parts.getOrElse(2) { 0 }
+    val parts = versionName.split("-", limit = 2).first()
+        .split(".")
+        .map { it.toIntOrNull() ?: 0 }
+    val major = parts.getOrElse(0) { 0 }
+    val minor = parts.getOrElse(1) { 0 }
+    val patch = parts.getOrElse(2) { 0 }
 
-	val code = major * 10_000 + minor * 100 + patch
-	return if (code > 0) code else 1
+    val code = major * 10_000 + minor * 100 + patch
+    return if (code > 0) code else 1
 }
 
 val appVersionName = releaseVersionName()
 val appVersionCode = versionCodeFrom(appVersionName)
 
 android {
-	namespace = "com.serranoie.app.minus"
-	compileSdk {
-		version = release(36)
-	}
+    namespace = "com.serranoie.app.minus"
+    compileSdk {
+        version = release(36)
+    }
 
-	val releaseStoreFile = System.getenv("MINUS_RELEASE_STORE_FILE")
-	val hasReleaseSigningConfig = listOf(
-		releaseStoreFile,
-		System.getenv("MINUS_RELEASE_STORE_PASSWORD"),
-		System.getenv("MINUS_RELEASE_KEY_ALIAS"),
-		System.getenv("MINUS_RELEASE_KEY_PASSWORD")
-	).all { !it.isNullOrBlank() }
+    val releaseStoreFile = System.getenv("MINUS_RELEASE_STORE_FILE")
+    val hasReleaseSigningConfig = listOf(
+        releaseStoreFile,
+        System.getenv("MINUS_RELEASE_STORE_PASSWORD"),
+        System.getenv("MINUS_RELEASE_KEY_ALIAS"),
+        System.getenv("MINUS_RELEASE_KEY_PASSWORD")
+    ).all { !it.isNullOrBlank() }
 
-	defaultConfig {
-		applicationId = "com.serranoie.app.minus"
-		minSdk = 27
-		targetSdk = 36
-		versionCode = appVersionCode
-		versionName = appVersionName
+    defaultConfig {
+        applicationId = "com.serranoie.app.minus"
+        minSdk = 27
+        targetSdk = 36
+        versionCode = appVersionCode
+        versionName = appVersionName
 
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-	}
+    }
 
-	flavorDimensions += "distribution"
-	productFlavors {
-		create("foss") {
-			dimension = "distribution"
-		}
-		create("wear") {
-			dimension = "distribution"
-		}
-	}
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("foss") {
+            dimension = "distribution"
+        }
+        create("wear") {
+            dimension = "distribution"
+        }
+    }
 
-	signingConfigs {
-		if (hasReleaseSigningConfig) {
-			create("release") {
-				storeFile = file(releaseStoreFile!!)
-				storePassword = System.getenv("MINUS_RELEASE_STORE_PASSWORD")
-				keyAlias = System.getenv("MINUS_RELEASE_KEY_ALIAS")
-				keyPassword = System.getenv("MINUS_RELEASE_KEY_PASSWORD")
-			}
-		}
-	}
+    signingConfigs {
+        if (hasReleaseSigningConfig) {
+            create("release") {
+                storeFile = file(releaseStoreFile!!)
+                storePassword = System.getenv("MINUS_RELEASE_STORE_PASSWORD")
+                keyAlias = System.getenv("MINUS_RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("MINUS_RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
 
-	buildTypes {
-		debug {
-			buildConfigField("Boolean", "SHOW_LOGS", "true")
-			buildConfigField("Boolean", "DEBUG_FEATURES", "true")
-			isMinifyEnabled = false
-		}
+    buildTypes {
+        debug {
+            buildConfigField("Boolean", "SHOW_LOGS", "true")
+            buildConfigField("Boolean", "DEBUG_FEATURES", "true")
+            isMinifyEnabled = false
+        }
 
-		release {
-			buildConfigField("Boolean", "SHOW_LOGS", "false")
-			buildConfigField("Boolean", "DEBUG_FEATURES", "false")
-			isMinifyEnabled = true
+        release {
+            buildConfigField("Boolean", "SHOW_LOGS", "false")
+            buildConfigField("Boolean", "DEBUG_FEATURES", "false")
+            isMinifyEnabled = true
             isShrinkResources = true
 
-			if (hasReleaseSigningConfig) {
-				signingConfig = signingConfigs.getByName("release")
-			}
-			proguardFiles(
-				getDefaultProguardFile("proguard-android-optimize.txt"),
-				"proguard-rules.pro"
-			)
-		}
-	}
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_17
-		targetCompatibility = JavaVersion.VERSION_17
-	}
-	kotlin {
-		compilerOptions {
-			jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-		}
-	}
-	buildFeatures {
-		compose = true
-		buildConfig = true
-	}
+            if (hasReleaseSigningConfig) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 
-	packaging {
-		resources.excludes += "/META-INF/AL2.0"
-		resources.excludes += "/META-INF/LGPL2.1"
-	}
-	namespace = "com.serranoie.app.minus"
+    packaging {
+        resources.excludes += "/META-INF/AL2.0"
+        resources.excludes += "/META-INF/LGPL2.1"
+    }
+    namespace = "com.serranoie.app.minus"
 
-	dependenciesInfo {
-		// Disables dependency metadata when building APKs (for IzzyOnDroid/F-Droid)
-		includeInApk = false
-		// Disables dependency metadata when building Android App Bundles (for Google Play)
-		includeInBundle = false
-	}
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs (for IzzyOnDroid/F-Droid)
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles (for Google Play)
+        includeInBundle = false
+    }
 }
 
 dependencies {
-	implementation(project(":sync-contract"))
+    implementation(project(":sync-contract"))
 
-	implementation(libs.androidx.core.ktx)
-	implementation(libs.androidx.lifecycle.runtime.ktx)
-	implementation(libs.androidx.lifecycle.process)
-	implementation(libs.androidx.activity.compose)
-	implementation(platform(libs.androidx.compose.bom))
-	implementation(libs.androidx.compose.ui)
-	implementation(libs.androidx.compose.ui.graphics)
-	implementation(libs.androidx.compose.ui.tooling.preview)
-	implementation(libs.androidx.compose.runtime)
-	implementation("androidx.compose.runtime:runtime-saveable")
-	implementation(libs.androidx.compose.material)
-	implementation(libs.androidx.compose.material.icons.extended)
-	implementation(libs.androidx.wear.compose.material)
-	implementation(libs.androidx.ui.graphics)
-	implementation(libs.androidx.compose.foundation.layout)
-	implementation(libs.ui.graphics)
-	implementation(libs.androidx.foundation)
-	implementation(libs.androidx.ui)
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.runtime)
+    implementation("androidx.compose.runtime:runtime-saveable")
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.wear.compose.material)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.compose.foundation.layout)
+    implementation(libs.ui.graphics)
+    implementation(libs.androidx.foundation)
+    implementation(libs.androidx.ui)
 	testImplementation(libs.junit)
 	testImplementation(libs.touchrobot.core)
 	testImplementation(libs.touchrobot.paparazzi)
+	testImplementation(libs.kotlinx.coroutines.test)
+	testImplementation(libs.turbine)
+	testImplementation(libs.google.truth)
 	androidTestImplementation(libs.androidx.junit)
 	androidTestImplementation(libs.androidx.espresso.core)
 	androidTestImplementation(platform(libs.androidx.compose.bom))
 	androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-	debugImplementation(libs.androidx.compose.ui.tooling)
-	debugImplementation(libs.androidx.compose.ui.test.manifest)
+	androidTestImplementation(libs.google.truth)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-	implementation(libs.kotlinx.coroutines.android)
-	implementation(libs.androidx.compose.foundation.old)
-	implementation(libs.androidx.compose.foundation.layout.old)
-	implementation(libs.androidx.compose.ui.util)
-	implementation(libs.androidx.compose.material3)
-	implementation(libs.androidx.compose.material3.windowsize)
-	implementation(libs.androidx.compose.animation)
-	implementation(libs.androidx.compose.ui.tooling.preview.v106)
-	implementation(libs.androidx.datastore.preferences)
-	implementation(libs.androidx.room.runtime)
-	implementation(libs.androidx.room.ktx)
-	implementation(libs.androidx.room.paging)
-	implementation(libs.androidx.hilt.navigationcompose)
-	implementation(libs.androidx.navigationcompose)
-	"wearImplementation"(libs.play.services.wearable)
-	"wearImplementation"(libs.kotlinx.coroutines.playservices)
-	implementation(libs.androidx.lifecycle.viewmodelcompose)
-	implementation(libs.androidx.glance.appwidget)
-	implementation(libs.androidx.glance.appwidget.preview)
-	implementation(libs.androidx.glance.preview)
-	implementation(libs.androidx.glance.material3)
-	implementation(libs.androidx.core.splashscreen)
-	implementation(libs.accompanist.systemuicontroller)
-	implementation(libs.dagger)
-	implementation(libs.hilt.android)
-	implementation(libs.commons.csv)
-	implementation(libs.coil.compose)
-	ksp(libs.androidx.room.compiler)
-	ksp(libs.androidx.hilt.compiler)
-	ksp(libs.dagger.compiler)
-	ksp(libs.hilt.androidcompiler)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.compose.foundation.old)
+    implementation(libs.androidx.compose.foundation.layout.old)
+    implementation(libs.androidx.compose.ui.util)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.windowsize)
+    implementation(libs.androidx.compose.animation)
+    implementation(libs.androidx.compose.ui.tooling.preview.v106)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.room.paging)
+    implementation(libs.androidx.hilt.navigationcompose)
+    implementation(libs.androidx.navigationcompose)
+    "wearImplementation"(libs.play.services.wearable)
+    "wearImplementation"(libs.kotlinx.coroutines.playservices)
+    implementation(libs.androidx.lifecycle.viewmodelcompose)
+    implementation(libs.androidx.glance.appwidget)
+    implementation(libs.androidx.glance.appwidget.preview)
+    implementation(libs.androidx.glance.preview)
+    implementation(libs.androidx.glance.material3)
+    implementation(libs.androidx.core.splashscreen)
+    implementation(libs.accompanist.systemuicontroller)
+    implementation(libs.dagger)
+    implementation(libs.hilt.android)
+    implementation(libs.commons.csv)
+    implementation(libs.coil.compose)
+    ksp(libs.androidx.room.compiler)
+    ksp(libs.androidx.hilt.compiler)
+    ksp(libs.dagger.compiler)
+    ksp(libs.hilt.androidcompiler)
 
-	// WorkManager for notifications
-	implementation(libs.androidx.work.runtime.ktx)
-	implementation(libs.kotlinx.serialization.json)
-	implementation(libs.androidx.hilt.work)
-	ksp(libs.androidx.hilt.compiler)
+    // WorkManager for notifications
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
 
-	// Logcat from Square
-	implementation(libs.logcat)
+    // Logcat from Square
+    implementation(libs.logcat)
 
-	debugImplementation(libs.androidx.compose.ui.tooling.v106)
-	debugImplementation(libs.androidx.compose.ui.testmanifest.v183)
+    debugImplementation(libs.androidx.compose.ui.tooling.v106)
+    debugImplementation(libs.androidx.compose.ui.testmanifest.v183)
 }

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/BudgetPeriodSheetEditModeE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/BudgetPeriodSheetEditModeE2ETest.kt
@@ -1,0 +1,210 @@
+package com.serranoie.app.minus.presentation.ui.e2e
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.R
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.BudgetState
+import com.serranoie.app.minus.presentation.ui.editor.BUDGET_PERIOD_APPLY_BUTTON_TAG
+import com.serranoie.app.minus.presentation.ui.editor.BUDGET_PERIOD_BUDGET_INPUT_TAG
+import com.serranoie.app.minus.presentation.ui.editor.BUDGET_PERIOD_EDIT_BUTTON_TAG
+import com.serranoie.app.minus.presentation.ui.editor.BUDGET_PERIOD_SHEET_TAG
+import com.serranoie.app.minus.presentation.ui.editor.BudgetPeriodSheet
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class BudgetPeriodSheetEditModeE2ETest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun renderSheet(
+        budgetSettings: BudgetSettings? = null,
+        budgetState: BudgetState? = null,
+        startInEditMode: Boolean = false,
+        onSaveBudget: ((BudgetSettings) -> Unit)? = null,
+        onEditBudget: (() -> Unit)? = null,
+        onFinishEarly: (() -> Unit)? = null,
+        selectedPeriod: BudgetPeriod = BudgetPeriod.DAILY,
+    ) {
+        composeTestRule.setContent {
+            MinusTheme {
+                BudgetPeriodSheet(
+                    budgetSettings = budgetSettings,
+                    budgetState = budgetState,
+                    selectedPeriod = selectedPeriod,
+                    currencyCode = "USD",
+                    onPeriodSelected = {},
+                    onSaveBudget = onSaveBudget,
+                    onEditBudget = onEditBudget,
+                    onFinishEarly = onFinishEarly,
+                    startInEditMode = startInEditMode,
+                    pendingExpensesCount = 0,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun when_no_active_budget_then_sheet_opens_in_edit_mode_and_budget_input_is_visible() {
+        // Given — no budget period saved, sheet is forced into edit mode
+        renderSheet(
+            budgetSettings = null,
+            startInEditMode = true,
+            onSaveBudget = {},
+        )
+
+        // Then — the budget input is the primary control
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_BUDGET_INPUT_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_no_active_budget_then_sheet_opens_in_edit_mode_and_apply_button_is_visible() {
+        // Given
+        renderSheet(
+            budgetSettings = null,
+            startInEditMode = true,
+            onSaveBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_APPLY_BUTTON_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_no_active_budget_then_sheet_opens_in_edit_mode_and_view_mode_edit_button_is_hidden() {
+        // Given
+        renderSheet(
+            budgetSettings = null,
+            startInEditMode = true,
+            onSaveBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_EDIT_BUTTON_TAG)
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun when_no_active_budget_then_sheet_opens_in_edit_mode_and_title_is_new_budget_period() {
+        // Given
+        renderSheet(
+            budgetSettings = null,
+            startInEditMode = true,
+            onSaveBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithText(composeTestRule.activity.getString(R.string.new_budget_period))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_no_active_budget_then_sheet_opens_in_edit_mode_and_sheet_root_tag_is_present() {
+        // Given
+        renderSheet(
+            budgetSettings = null,
+            startInEditMode = true,
+            onSaveBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_SHEET_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_existing_budget_then_sheet_opens_in_view_mode_and_edit_button_is_visible() {
+        // Given
+        val settings = sampleBudgetSettings()
+        renderSheet(
+            budgetSettings = settings,
+            startInEditMode = false,
+            onEditBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_EDIT_BUTTON_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_existing_budget_then_sheet_opens_in_view_mode_and_apply_button_is_hidden() {
+        // Given
+        val settings = sampleBudgetSettings()
+        renderSheet(
+            budgetSettings = settings,
+            startInEditMode = false,
+            onEditBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_APPLY_BUTTON_TAG)
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun when_existing_budget_then_sheet_opens_in_view_mode_and_budget_input_is_hidden() {
+        // Given
+        val settings = sampleBudgetSettings()
+        renderSheet(
+            budgetSettings = settings,
+            startInEditMode = false,
+            onEditBudget = {},
+        )
+
+        // Then
+        composeTestRule
+            .onNodeWithTag(BUDGET_PERIOD_BUDGET_INPUT_TAG)
+            .assertIsNotDisplayed()
+    }
+
+    private fun sampleBudgetSettings(
+        totalBudget: BigDecimal = BigDecimal("1000.00"),
+        period: BudgetPeriod = BudgetPeriod.MONTHLY,
+        startDate: LocalDate = LocalDate.of(2026, 1, 1),
+    ): BudgetSettings = BudgetSettings(
+        totalBudget = totalBudget,
+        period = period,
+        startDate = startDate,
+        endDate = startDate.plusDays(period.days().toLong() - 1L),
+        currencyCode = "USD",
+        daysInPeriod = period.days(),
+        rollOverEnabled = false,
+    )
+
+    private fun BudgetPeriod.days(): Int = when (this) {
+        BudgetPeriod.DAILY -> 1
+        BudgetPeriod.WEEKLY -> 7
+        BudgetPeriod.BIWEEKLY -> 14
+        BudgetPeriod.MONTHLY -> 30
+    }
+
+    @Test
+    fun when_sample_budget_settings_built_then_total_budget_and_period_are_defaults() {
+        // Given / When
+        val settings = sampleBudgetSettings()
+
+        // Then
+        assertThat(settings.totalBudget).isEqualTo(BigDecimal("1000.00"))
+        assertThat(settings.period).isEqualTo(BudgetPeriod.MONTHLY)
+    }
+}

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
@@ -1,0 +1,157 @@
+package com.serranoie.app.minus.presentation.ui.e2e
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.R
+import com.serranoie.app.minus.presentation.LocalWindowInsets
+import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingScreen
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.presentation.ui.theme.component.BottomSheetScrollState
+import com.serranoie.app.minus.presentation.ui.theme.component.LocalBottomSheetScrollState
+import org.junit.Rule
+import org.junit.Test
+
+class OnboardingScreenE2ETest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun setOnboardingContent(
+        onSetBudget: () -> Unit = {},
+        onClose: () -> Unit = {},
+        onOnboardingComplete: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalBottomSheetScrollState provides BottomSheetScrollState(0.dp),
+                LocalWindowInsets provides PaddingValues(0.dp),
+            ) {
+                MinusTheme {
+                    OnboardingScreen(
+                        onSetBudget = onSetBudget,
+                        onClose = onClose,
+                        onOnboardingComplete = onOnboardingComplete,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun str(resId: Int): String = composeTestRule.activity.getString(resId)
+
+    private fun setBudgetButton() = composeTestRule
+        .onAllNodes(hasText(str(R.string.onboarding_set_budget_button)) and hasClickAction())
+        .onFirst()
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_welcome_title_is_visible() {
+        // Given / When
+        setOnboardingContent()
+
+        // Then
+        composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_title)).assertIsDisplayed()
+    }
+
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_welcome_subtitle_is_visible() {
+        // Given / When
+        setOnboardingContent()
+
+        // Then
+        composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_subtitle))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_all_three_step_rows_are_visible() {
+        // Given / When
+        setOnboardingContent()
+
+        // Then
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_1_subtitle)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_2_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_set_budget_button_is_visible() {
+        // Given / When
+        setOnboardingContent()
+
+        // Then
+        setBudgetButton().assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_welcome_subtitle_text_matches_resource() {
+        // Given / When
+        setOnboardingContent()
+
+        // Then
+        val expected = str(R.string.onboarding_welcome_subtitle)
+        composeTestRule.onNodeWithText(expected).assertTextEquals(expected)
+    }
+
+    @Test
+    fun when_user_taps_set_budget_button_then_on_set_budget_fires() {
+        // Given
+        var invoked = 0
+        setOnboardingContent(onSetBudget = { invoked++ })
+
+        // When
+        setBudgetButton().performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        assertThat(invoked).isEqualTo(1)
+    }
+
+    @Test
+    fun when_user_taps_set_budget_button_then_on_close_and_on_onboarding_complete_do_not_fire() {
+        // Given
+        var closeCount = 0
+        var completeCount = 0
+        setOnboardingContent(
+            onSetBudget = {},
+            onClose = { closeCount++ },
+            onOnboardingComplete = { completeCount++ },
+        )
+
+        // When
+        setBudgetButton().performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        assertThat(closeCount).isEqualTo(0)
+        assertThat(completeCount).isEqualTo(0)
+    }
+
+    @Test
+    fun when_user_taps_set_budget_button_twice_then_on_set_budget_fires_twice() {
+        // Given
+        var invoked = 0
+        setOnboardingContent(onSetBudget = { invoked++ })
+
+        // When
+        val button = setBudgetButton()
+        button.performClick()
+        composeTestRule.waitForIdle()
+        button.performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        assertThat(invoked).isEqualTo(2)
+    }
+}

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import com.serranoie.app.minus.R
@@ -31,12 +30,6 @@ class OnboardingScreenE2ETest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    /**
-     * Tests construct a [OnboardingViewModel] directly (mocking the
-     * repositories) and pass it to the screen. This avoids the
-     * `@AndroidEntryPoint` requirement on the host Activity, which
-     * would otherwise break `hiltViewModel()` resolution.
-     */
     private fun setOnboardingContent(
         onOnboardingCompleted: () -> Unit = {},
         viewModel: OnboardingViewModel = OnboardingViewModel(
@@ -66,10 +59,6 @@ class OnboardingScreenE2ETest {
         .onAllNodes(hasText(str(R.string.onboarding_set_budget_button)) and hasClickAction())
         .onFirst()
 
-    // -------------------------------------------------------------------------
-    // Hero
-    // -------------------------------------------------------------------------
-
     @Test
     fun when_onboarding_screen_is_rendered_then_welcome_title_is_visible() {
         setOnboardingContent()
@@ -78,24 +67,12 @@ class OnboardingScreenE2ETest {
     }
 
     @Test
-    fun when_onboarding_screen_is_rendered_then_welcome_subtitle_is_visible() {
+    fun when_onboarding_screen_is_rendered_then_welcome_title_text_matches_resource() {
         setOnboardingContent()
 
-        composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_subtitle))
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun when_onboarding_screen_is_rendered_then_welcome_subtitle_text_matches_resource() {
-        setOnboardingContent()
-
-        val expected = str(R.string.onboarding_welcome_subtitle)
+        val expected = str(R.string.onboarding_welcome_title)
         composeTestRule.onNodeWithText(expected).assertTextEquals(expected)
     }
-
-    // -------------------------------------------------------------------------
-    // Intro paragraph — explains what Minus is
-    // -------------------------------------------------------------------------
 
     @Test
     fun when_onboarding_screen_is_rendered_then_intro_paragraph_is_visible() {
@@ -113,16 +90,10 @@ class OnboardingScreenE2ETest {
         composeTestRule.onNodeWithText(expected).assertTextEquals(expected)
     }
 
-    // -------------------------------------------------------------------------
-    // Feature grid — 6 steps covering what the user can do in Minus
-    // -------------------------------------------------------------------------
-
     @Test
     fun when_onboarding_screen_is_rendered_then_all_six_step_titles_are_visible() {
         setOnboardingContent()
 
-        // 6 steps: Set a budget, Track expenses, Recurring expenses,
-        // Calculate on the fly, See your analytics, Spend wisely
         composeTestRule.onNodeWithText(str(R.string.onboarding_step_1_title)).assertIsDisplayed()
         composeTestRule.onNodeWithText(str(R.string.onboarding_step_2_title)).assertIsDisplayed()
         composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_title)).assertIsDisplayed()
@@ -161,35 +132,19 @@ class OnboardingScreenE2ETest {
             .assertIsDisplayed()
     }
 
-    // -------------------------------------------------------------------------
-    // CTA button — "Continue"
-    // -------------------------------------------------------------------------
-
     @Test
     fun when_onboarding_screen_is_rendered_then_continue_button_is_visible() {
         setOnboardingContent()
 
-        continueButton().performScrollTo().assertIsDisplayed()
+        continueButton().assertIsDisplayed()
     }
-
-    // -------------------------------------------------------------------------
-    // Effect wiring — OnWelcomeDismissed → OnboardingCompleted
-    // -------------------------------------------------------------------------
-    //
-    // The welcome step's "Continue" button dispatches
-    // [OnboardingUiIntent.OnWelcomeDismissed]. The VM marks the
-    // onboarding flag as completed in settings and emits
-    // [OnboardingUiEffect.OnboardingCompleted]; the screen forwards
-    // that to the navigation callback. We exercise the same wiring
-    // by dispatching the intent directly (and also by tapping the
-    // button) so the test isn't sensitive to UI flakiness.
 
     @Test
     fun when_user_taps_continue_button_then_on_onboarding_completed_fires() {
         var invoked = 0
         setOnboardingContent(onOnboardingCompleted = { invoked++ })
 
-        continueButton().performScrollTo().performClick()
+        continueButton().performClick()
         composeTestRule.waitForIdle()
 
         assertThat(invoked).isEqualTo(1)
@@ -201,9 +156,9 @@ class OnboardingScreenE2ETest {
         setOnboardingContent(onOnboardingCompleted = { invoked++ })
 
         val button = continueButton()
-        button.performScrollTo().performClick()
+        button.performClick()
         composeTestRule.waitForIdle()
-        button.performScrollTo().performClick()
+        button.performClick()
         composeTestRule.waitForIdle()
 
         assertThat(invoked).isEqualTo(2)

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
@@ -10,12 +10,15 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.LocalWindowInsets
-import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingViewModel
 import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingScreen
+import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent
+import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingViewModel
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.BottomSheetScrollState
 import com.serranoie.app.minus.presentation.ui.theme.component.LocalBottomSheetScrollState
@@ -59,108 +62,166 @@ class OnboardingScreenE2ETest {
 
     private fun str(resId: Int): String = composeTestRule.activity.getString(resId)
 
-    private fun setBudgetButton() = composeTestRule
+    private fun continueButton() = composeTestRule
         .onAllNodes(hasText(str(R.string.onboarding_set_budget_button)) and hasClickAction())
         .onFirst()
 
+    // -------------------------------------------------------------------------
+    // Hero
+    // -------------------------------------------------------------------------
+
     @Test
     fun when_onboarding_screen_is_rendered_then_welcome_title_is_visible() {
-        // Given / When
         setOnboardingContent()
 
-        // Then
         composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_title)).assertIsDisplayed()
     }
 
-
     @Test
     fun when_onboarding_screen_is_rendered_then_welcome_subtitle_is_visible() {
-        // Given / When
         setOnboardingContent()
 
-        // Then
         composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_subtitle))
             .assertIsDisplayed()
     }
 
     @Test
-    fun when_onboarding_screen_is_rendered_then_all_three_step_rows_are_visible() {
-        // Given / When
-        setOnboardingContent()
-
-        // Then
-        composeTestRule.onNodeWithText(str(R.string.onboarding_step_1_subtitle)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(str(R.string.onboarding_step_2_title)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_title)).assertIsDisplayed()
-    }
-
-    @Test
-    fun when_onboarding_screen_is_rendered_then_set_budget_button_is_visible() {
-        // Given / When
-        setOnboardingContent()
-
-        // Then
-        setBudgetButton().assertIsDisplayed()
-    }
-
-    @Test
     fun when_onboarding_screen_is_rendered_then_welcome_subtitle_text_matches_resource() {
-        // Given / When
         setOnboardingContent()
 
-        // Then
         val expected = str(R.string.onboarding_welcome_subtitle)
         composeTestRule.onNodeWithText(expected).assertTextEquals(expected)
     }
 
+    // -------------------------------------------------------------------------
+    // Intro paragraph — explains what Minus is
+    // -------------------------------------------------------------------------
+
     @Test
-    fun when_on_complete_onboarding_intent_dispatched_then_on_onboarding_completed_fires() {
-        // Given — the welcome-step button is wired to dispatch
-        // [OnboardingUiIntent.OnCompleteOnboarding] to the VM. The VM
-        // emits [OnboardingUiEffect.OnboardingCompleted] after the
-        // budget is saved; the screen forwards that to the navigation
-        // callback. The "Set a budget" tap is just a thin shim, so we
-        // dispatch the intent directly here — that exercises the same
-        // wiring the button would.
-        val vm = OnboardingViewModel(
-            budgetRepository = mockk(relaxed = true),
-            notificationScheduler = mockk(relaxed = true),
-            settingsRepository = mockk(relaxed = true),
-        )
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("100"))
+    fun when_onboarding_screen_is_rendered_then_intro_paragraph_is_visible() {
+        setOnboardingContent()
 
+        composeTestRule.onNodeWithText(str(R.string.onboarding_welcome_intro))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_intro_paragraph_text_matches_resource() {
+        setOnboardingContent()
+
+        val expected = str(R.string.onboarding_welcome_intro)
+        composeTestRule.onNodeWithText(expected).assertTextEquals(expected)
+    }
+
+    // -------------------------------------------------------------------------
+    // Feature grid — 6 steps covering what the user can do in Minus
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_all_six_step_titles_are_visible() {
+        setOnboardingContent()
+
+        // 6 steps: Set a budget, Track expenses, Recurring expenses,
+        // Calculate on the fly, See your analytics, Spend wisely
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_1_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_2_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_4_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_5_title)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_6_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_recurring_expenses_step_is_visible() {
+        setOnboardingContent()
+
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_title))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_3_subtitle))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_calculate_on_the_fly_step_is_visible() {
+        setOnboardingContent()
+
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_4_title))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_4_subtitle))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_analytics_step_is_visible() {
+        setOnboardingContent()
+
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_5_title))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.onboarding_step_5_subtitle))
+            .assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // CTA button — "Continue"
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun when_onboarding_screen_is_rendered_then_continue_button_is_visible() {
+        setOnboardingContent()
+
+        continueButton().performScrollTo().assertIsDisplayed()
+    }
+
+    // -------------------------------------------------------------------------
+    // Effect wiring — OnWelcomeDismissed → OnboardingCompleted
+    // -------------------------------------------------------------------------
+    //
+    // The welcome step's "Continue" button dispatches
+    // [OnboardingUiIntent.OnWelcomeDismissed]. The VM marks the
+    // onboarding flag as completed in settings and emits
+    // [OnboardingUiEffect.OnboardingCompleted]; the screen forwards
+    // that to the navigation callback. We exercise the same wiring
+    // by dispatching the intent directly (and also by tapping the
+    // button) so the test isn't sensitive to UI flakiness.
+
+    @Test
+    fun when_user_taps_continue_button_then_on_onboarding_completed_fires() {
         var invoked = 0
-        setOnboardingContent(onOnboardingCompleted = { invoked++ }, viewModel = vm)
+        setOnboardingContent(onOnboardingCompleted = { invoked++ })
 
-        // When
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
+        continueButton().performScrollTo().performClick()
         composeTestRule.waitForIdle()
 
-        // Then
         assertThat(invoked).isEqualTo(1)
     }
 
     @Test
-    fun when_on_complete_onboarding_intent_dispatched_twice_then_on_onboarding_completed_fires_twice() {
-        // Given
+    fun when_user_taps_continue_button_twice_then_on_onboarding_completed_fires_twice() {
+        var invoked = 0
+        setOnboardingContent(onOnboardingCompleted = { invoked++ })
+
+        val button = continueButton()
+        button.performScrollTo().performClick()
+        composeTestRule.waitForIdle()
+        button.performScrollTo().performClick()
+        composeTestRule.waitForIdle()
+
+        assertThat(invoked).isEqualTo(2)
+    }
+
+    @Test
+    fun when_on_welcome_dismissed_intent_is_dispatched_then_on_onboarding_completed_fires() {
         val vm = OnboardingViewModel(
             budgetRepository = mockk(relaxed = true),
             notificationScheduler = mockk(relaxed = true),
             settingsRepository = mockk(relaxed = true),
         )
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("100"))
-
         var invoked = 0
         setOnboardingContent(onOnboardingCompleted = { invoked++ }, viewModel = vm)
 
-        // When
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
-        composeTestRule.waitForIdle()
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("200"))
-        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
+        vm.processIntent(OnboardingUiIntent.OnWelcomeDismissed)
         composeTestRule.waitForIdle()
 
-        // Then
-        assertThat(invoked).isEqualTo(2)
+        assertThat(invoked).isEqualTo(1)
     }
 }

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/OnboardingScreenE2ETest.kt
@@ -10,15 +10,16 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.LocalWindowInsets
+import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingViewModel
 import com.serranoie.app.minus.presentation.ui.onboarding.OnboardingScreen
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.BottomSheetScrollState
 import com.serranoie.app.minus.presentation.ui.theme.component.LocalBottomSheetScrollState
+import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,10 +28,19 @@ class OnboardingScreenE2ETest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+    /**
+     * Tests construct a [OnboardingViewModel] directly (mocking the
+     * repositories) and pass it to the screen. This avoids the
+     * `@AndroidEntryPoint` requirement on the host Activity, which
+     * would otherwise break `hiltViewModel()` resolution.
+     */
     private fun setOnboardingContent(
-        onSetBudget: () -> Unit = {},
-        onClose: () -> Unit = {},
-        onOnboardingComplete: () -> Unit = {},
+        onOnboardingCompleted: () -> Unit = {},
+        viewModel: OnboardingViewModel = OnboardingViewModel(
+            budgetRepository = mockk(relaxed = true),
+            notificationScheduler = mockk(relaxed = true),
+            settingsRepository = mockk(relaxed = true),
+        ),
     ) {
         composeTestRule.setContent {
             CompositionLocalProvider(
@@ -39,9 +49,8 @@ class OnboardingScreenE2ETest {
             ) {
                 MinusTheme {
                     OnboardingScreen(
-                        onSetBudget = onSetBudget,
-                        onClose = onClose,
-                        onOnboardingComplete = onOnboardingComplete,
+                        viewModel = viewModel,
+                        onOnboardingCompleted = onOnboardingCompleted,
                     )
                 }
             }
@@ -105,13 +114,26 @@ class OnboardingScreenE2ETest {
     }
 
     @Test
-    fun when_user_taps_set_budget_button_then_on_set_budget_fires() {
-        // Given
+    fun when_on_complete_onboarding_intent_dispatched_then_on_onboarding_completed_fires() {
+        // Given — the welcome-step button is wired to dispatch
+        // [OnboardingUiIntent.OnCompleteOnboarding] to the VM. The VM
+        // emits [OnboardingUiEffect.OnboardingCompleted] after the
+        // budget is saved; the screen forwards that to the navigation
+        // callback. The "Set a budget" tap is just a thin shim, so we
+        // dispatch the intent directly here — that exercises the same
+        // wiring the button would.
+        val vm = OnboardingViewModel(
+            budgetRepository = mockk(relaxed = true),
+            notificationScheduler = mockk(relaxed = true),
+            settingsRepository = mockk(relaxed = true),
+        )
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("100"))
+
         var invoked = 0
-        setOnboardingContent(onSetBudget = { invoked++ })
+        setOnboardingContent(onOnboardingCompleted = { invoked++ }, viewModel = vm)
 
         // When
-        setBudgetButton().performClick()
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
         composeTestRule.waitForIdle()
 
         // Then
@@ -119,36 +141,23 @@ class OnboardingScreenE2ETest {
     }
 
     @Test
-    fun when_user_taps_set_budget_button_then_on_close_and_on_onboarding_complete_do_not_fire() {
+    fun when_on_complete_onboarding_intent_dispatched_twice_then_on_onboarding_completed_fires_twice() {
         // Given
-        var closeCount = 0
-        var completeCount = 0
-        setOnboardingContent(
-            onSetBudget = {},
-            onClose = { closeCount++ },
-            onOnboardingComplete = { completeCount++ },
+        val vm = OnboardingViewModel(
+            budgetRepository = mockk(relaxed = true),
+            notificationScheduler = mockk(relaxed = true),
+            settingsRepository = mockk(relaxed = true),
         )
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("100"))
 
-        // When
-        setBudgetButton().performClick()
-        composeTestRule.waitForIdle()
-
-        // Then
-        assertThat(closeCount).isEqualTo(0)
-        assertThat(completeCount).isEqualTo(0)
-    }
-
-    @Test
-    fun when_user_taps_set_budget_button_twice_then_on_set_budget_fires_twice() {
-        // Given
         var invoked = 0
-        setOnboardingContent(onSetBudget = { invoked++ })
+        setOnboardingContent(onOnboardingCompleted = { invoked++ }, viewModel = vm)
 
         // When
-        val button = setBudgetButton()
-        button.performClick()
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
         composeTestRule.waitForIdle()
-        button.performClick()
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnBudgetAmountChanged("200"))
+        vm.processIntent(com.serranoie.app.minus.presentation.ui.onboarding.OnboardingUiIntent.OnCompleteOnboarding)
         composeTestRule.waitForIdle()
 
         // Then

--- a/app/src/main/java/com/serranoie/app/minus/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/serranoie/app/minus/navigation/AppNavGraph.kt
@@ -31,12 +31,6 @@ import logcat.logcat
 
 private const val TAG = "AppNavGraph"
 
-/**
- * Direction-aware screen transition animations.
- *
- * Forward navigation  (e.g. Onboarding -> Main):  slide + fade in from right, out to left
- * Backward navigation (e.g. Settings -> Analytics): slide + fade in from left, out to right
- */
 private fun getScreenTransitions(
     initialState: NavBackStackEntry,
     targetState: NavBackStackEntry,
@@ -56,21 +50,6 @@ private fun getScreenTransitions(
     return enter to exit
 }
 
-/**
- * Root navigation graph for the app.
- *
- * App flow:
- *  - First launch:       Onboarding → Main (with wallet setup)
- *  - Regular launch:     Main (wallet editing is a bottom sheet within Main)
- *  - Period ended:       Analytics → Main (with wallet setup)
- *
- * All state management and business logic is delegated to screen-specific
- * ViewModels and thin composable wrappers. This graph is purely responsible
- * for navigation composition.
- *
- * @param startDestination Route to start on – [Screen.Onboarding], [Screen.Main], or [Screen.Analytics].
- * @param onOnboardingComplete Called when onboarding finishes so the caller can persist the flag.
- */
 @Composable
 fun AppNavGraph(
     activityResultRegistryOwner: ActivityResultRegistryOwner?,
@@ -91,16 +70,7 @@ fun AppNavGraph(
     ) {
         composable(Screen.Onboarding.route) {
             OnboardingScreen(
-                onSetBudget = {
-                    onOnboardingComplete()
-                    navController.navigate(
-                        Screen.Main.createRoute(openWallet = true, forceWalletSetup = true),
-                    ) { popUpTo(Screen.Onboarding.route) { inclusive = true } }
-                },
-                onOnboardingComplete = {
-                    onOnboardingComplete()
-                },
-                onClose = {
+                onOnboardingCompleted = {
                     onOnboardingComplete()
                     navController.navigate(
                         Screen.Main.createRoute(openWallet = true, forceWalletSetup = true),
@@ -179,7 +149,6 @@ fun AppNavGraph(
             val forceWalletSetup =
                 backStackEntry.arguments?.getBoolean(Screen.Main.ARG_FORCE_WALLET_SETUP) ?: false
 
-            // Consume navigation arguments so they don't persist on back navigation
             LaunchedEffect(backStackEntry.id) {
                 if (openWallet || forceWalletSetup) {
                     backStackEntry.arguments?.putBoolean(Screen.Main.ARG_OPEN_WALLET, false)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.serranoie.app.minus.data.repository.BudgetRepository
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetState
+import com.serranoie.app.minus.domain.model.Category
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.usecase.ClearEarlyFinishStateUseCase
@@ -17,6 +18,16 @@ import com.serranoie.app.minus.domain.usecase.PersistBudgetSettingsUseCase
 import com.serranoie.app.minus.domain.usecase.UpdatePeriodEndNotificationTimeUseCase
 import com.serranoie.app.minus.presentation.notification.NotificationHelper
 import com.serranoie.app.minus.presentation.notification.NotificationScheduler
+import com.serranoie.app.minus.presentation.ui.budget.controller.EditorIntent
+import com.serranoie.app.minus.presentation.ui.budget.controller.EditorStateController
+import com.serranoie.app.minus.presentation.ui.budget.controller.NumpadController
+import com.serranoie.app.minus.presentation.ui.budget.controller.NumpadIntent
+import com.serranoie.app.minus.presentation.ui.budget.controller.PeriodActions
+import com.serranoie.app.minus.presentation.ui.budget.controller.PeriodActionsController
+import com.serranoie.app.minus.presentation.ui.budget.controller.PeriodActionsController.PeriodAction
+import com.serranoie.app.minus.presentation.ui.budget.controller.TransactionActionsController
+import com.serranoie.app.minus.presentation.ui.budget.controller.TransactionActionsController.TransactionAction
+import com.serranoie.app.minus.presentation.ui.budget.controller.TransactionHandler
 import com.serranoie.app.minus.presentation.ui.budget.mvi.BudgetUiEffect
 import com.serranoie.app.minus.presentation.ui.budget.mvi.BudgetUiIntent
 import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetEditorIntent
@@ -24,7 +35,6 @@ import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadInt
 import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetSystemIntent
 import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetTransactionIntent
 import com.serranoie.app.minus.presentation.ui.editor.AnimState
-import com.serranoie.app.minus.presentation.ui.editor.EditMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,7 +65,7 @@ class BudgetViewModel @Inject constructor(
     private val transactionHandler: BudgetTransactionHandler,
     private val budgetStateCalculator: BudgetStateCalculator,
     private val budgetWidgetUpdater: BudgetWidgetUpdater,
-    private val budgetExpressionEvaluator: BudgetExpressionEvaluator,
+    budgetExpressionEvaluator: BudgetExpressionEvaluator,
     private val observeCurrentPeriodBoundaryUseCase: ObserveCurrentPeriodBoundaryUseCase,
     private val observeCurrentPeriodRolloverUseCase: ObserveCurrentPeriodRolloverUseCase,
     private val getCurrentPeriodIdUseCase: GetCurrentPeriodIdUseCase,
@@ -66,8 +76,20 @@ class BudgetViewModel @Inject constructor(
     private val markOnboardingCompletedUseCase: MarkOnboardingCompletedUseCase,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(BudgetUiState.INITIAL)
+    private val numpadController = NumpadController(budgetExpressionEvaluator)
 
+    private val editorStateController = EditorStateController()
+
+    private val transactionActionsController = TransactionActionsController(
+        handler = TransactionHandlerImpl(
+            delegate = transactionHandler,
+            resolveActivePeriodId = ::resolveActivePeriodId,
+        ),
+    )
+
+    private val periodActionsController = PeriodActionsController(NoopPeriodActions)
+
+    private val _uiState = MutableStateFlow(BudgetUiState.INITIAL)
     val uiState: StateFlow<BudgetUiState> = _uiState.asStateFlow()
 
     private val _transactions = MutableStateFlow<List<Transaction>>(emptyList())
@@ -80,15 +102,11 @@ class BudgetViewModel @Inject constructor(
     val budgetState: StateFlow<BudgetState?> = _budgetState.asStateFlow()
 
     private val _categories =
-        MutableStateFlow<List<com.serranoie.app.minus.domain.model.Category>>(emptyList())
-    val categories: StateFlow<List<com.serranoie.app.minus.domain.model.Category>> =
-        _categories.asStateFlow()
+        MutableStateFlow<List<Category>>(emptyList())
 
     private val _effects = MutableSharedFlow<BudgetUiEffect>()
     val effects: SharedFlow<BudgetUiEffect> = _effects.asSharedFlow()
 
-    private val _numpadInput = MutableStateFlow("")
-    private val _currentComment = MutableStateFlow("")
     private val _pendingPeriodBoundaryOverride = MutableStateFlow<Pair<Long, Long>?>(null)
 
     init {
@@ -131,15 +149,28 @@ class BudgetViewModel @Inject constructor(
 
     private fun observeEditorState() {
         viewModelScope.launch {
-            combine(_numpadInput, _currentComment) { numpadInput, currentComment ->
-                numpadInput to currentComment
-            }.collect { (numpadInput, currentComment) ->
+            combine(
+                numpadController.input,
+                editorStateController.state,
+            ) { numpadInput, editorState ->
+                numpadInput to editorState
+            }.collect { (numpadInput, editorState) ->
                 _uiState.update {
                     it.copy(
                         numpadInput = numpadInput,
                         isNumpadValid = validateNumpadInput(numpadInput),
                         animState = if (numpadInput.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-                        currentComment = currentComment
+                        currentComment = editorState.currentComment,
+                        editMode = editorState.editMode,
+                        lockSwipeable = editorState.lockSwipeable,
+                        lockDraggable = editorState.lockDraggable,
+                        isRecurrentEnabled = editorState.isRecurrentEnabled,
+                        isCreditEnabled = editorState.isCreditEnabled,
+                        showRecurrentDialog = editorState.showRecurrentDialog,
+                        showCreditCutoffDialog = editorState.showCreditCutoffDialog,
+                        pendingRecurrentAmount = editorState.pendingRecurrentAmount,
+                        pendingRecurrentComment = editorState.pendingRecurrentComment,
+                        selectedDate = editorState.selectedDate,
                     )
                 }
             }
@@ -193,43 +224,53 @@ class BudgetViewModel @Inject constructor(
             budgetStateCalculator.calculateBudgetState(s, periodTransactions, today)
         }
 
+        val numpadInput = numpadController.input.value
+        val editorState = editorStateController.state.value
+
         return BudgetUiState(
             isLoading = false,
             budgetSettings = settingsWithRollover,
             budgetState = budgetState,
             transactions = transactions,
-            selectedDate = LocalDate.now(),
+            selectedDate = editorState.selectedDate,
             error = null,
-            numpadInput = _numpadInput.value,
-            isNumpadValid = validateNumpadInput(_numpadInput.value),
-            editMode = _uiState.value.editMode,
-            animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-            currentComment = _currentComment.value,
+            numpadInput = numpadInput,
+            isNumpadValid = validateNumpadInput(numpadInput),
+            editMode = editorState.editMode,
+            animState = if (numpadInput.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+            currentComment = editorState.currentComment,
             tags = _categories.value.map { it.name },
             isFirstLaunch = settings == null,
-            isCreditEnabled = _uiState.value.isCreditEnabled,
-            showCreditCutoffDialog = _uiState.value.showCreditCutoffDialog,
+            isCreditEnabled = editorState.isCreditEnabled,
+            showCreditCutoffDialog = editorState.showCreditCutoffDialog,
             pendingExpensesForNextPeriod = queuedTransactions,
             currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
             currentPeriodId = currentPeriodId,
-            isCalculation = _uiState.value.isCalculation,
-            dragProgress = _uiState.value.dragProgress,
-            lockSwipeable = _uiState.value.lockSwipeable,
-            lockDraggable = _uiState.value.lockDraggable,
+            isCalculation = numpadController.isCalculation.value,
+            dragProgress = numpadController.dragProgress.value,
+            lockSwipeable = editorState.lockSwipeable,
+            lockDraggable = editorState.lockDraggable,
         )
     }
 
     private suspend fun applyBaseState(baseState: BudgetUiState) {
         _uiState.update { current ->
             baseState.copy(
-                numpadInput = _numpadInput.value,
-                isNumpadValid = validateNumpadInput(_numpadInput.value),
-                animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-                currentComment = _currentComment.value,
+                numpadInput = numpadController.input.value,
+                isNumpadValid = validateNumpadInput(numpadController.input.value),
+                animState = if (numpadController.input.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+                currentComment = editorStateController.state.value.currentComment,
+                editMode = editorStateController.state.value.editMode,
+                lockSwipeable = editorStateController.state.value.lockSwipeable,
+                lockDraggable = editorStateController.state.value.lockDraggable,
+                isRecurrentEnabled = editorStateController.state.value.isRecurrentEnabled,
+                isCreditEnabled = editorStateController.state.value.isCreditEnabled,
+                showRecurrentDialog = editorStateController.state.value.showRecurrentDialog,
+                showCreditCutoffDialog = editorStateController.state.value.showCreditCutoffDialog,
+                pendingRecurrentAmount = editorStateController.state.value.pendingRecurrentAmount,
+                pendingRecurrentComment = editorStateController.state.value.pendingRecurrentComment,
                 isCalculation = current.isCalculation,
                 dragProgress = current.dragProgress,
-                lockSwipeable = current.lockSwipeable,
-                lockDraggable = current.lockDraggable,
                 pendingExpensesForNextPeriod = baseState.pendingExpensesForNextPeriod,
             )
         }
@@ -248,41 +289,79 @@ class BudgetViewModel @Inject constructor(
         logcat(TAG) {
             "saveBudgetSettings called: settings=$settings forceNewPeriodBoundary=$forceNewPeriodBoundary"
         }
-        viewModelScope.launch {
-            persistBudgetSettings(settings, forceNewPeriodBoundary = forceNewPeriodBoundary)
+        val actions = periodActionsController.saveBudgetSettings(settings)
+        for (action in actions) {
+            when (action) {
+                is PeriodAction.PersistBudgetSettings -> viewModelScope.launch {
+                    persistBudgetSettings(
+                        action.settings,
+                        forceNewPeriodBoundary = forceNewPeriodBoundary
+                    )
+                }
+
+                PeriodAction.MarkOnboardingCompleted -> markFirstLaunchComplete()
+                else -> Unit
+            }
         }
     }
 
     fun updatePeriodEndNotificationTime(hour: Int, minute: Int) {
-        viewModelScope.launch {
-            updatePeriodEndNotificationTimeUseCase(hour, minute)
-            logcat(TAG) { "Updated period end notification time to %02d:%02d".format(hour, minute) }
+        for (action in periodActionsController.updatePeriodEndNotificationTime(hour, minute)) {
+            if (action is PeriodAction.UpdatePeriodEndNotification) {
+                viewModelScope.launch {
+                    updatePeriodEndNotificationTimeUseCase(action.hour, action.minute)
+                    logcat(TAG) {
+                        "Updated period end notification time to %02d:%02d".format(
+                            action.hour,
+                            action.minute
+                        )
+                    }
+                }
+            }
         }
     }
 
     fun updateRecurrentNotificationTime(hour: Int, minute: Int) {
-        viewModelScope.launch {
-            updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(hour, minute)
-            logcat(TAG) { "Updated recurrent notification time to %02d:%02d".format(hour, minute) }
+        for (action in periodActionsController.updateRecurrentNotificationTime(hour, minute)) {
+            if (action is PeriodAction.UpdateRecurrentNotification) {
+                viewModelScope.launch {
+                    updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(
+                        action.hour,
+                        action.minute
+                    )
+                    logcat(TAG) {
+                        "Updated recurrent notification time to %02d:%02d".format(
+                            action.hour,
+                            action.minute
+                        )
+                    }
+                }
+            }
         }
     }
 
     fun finishBudgetEarly() {
-        viewModelScope.launch {
-            finishBudgetEarlyUseCase()
+        for (action in periodActionsController.finishBudgetEarly()) {
+            if (action is PeriodAction.FinishBudgetEarly) {
+                viewModelScope.launch { finishBudgetEarlyUseCase() }
+            }
         }
     }
 
     fun clearEarlyFinishState() {
-        viewModelScope.launch {
-            clearEarlyFinishStateUseCase()
+        for (action in periodActionsController.clearEarlyFinishState()) {
+            if (action is PeriodAction.ClearEarlyFinish) {
+                viewModelScope.launch { clearEarlyFinishStateUseCase() }
+            }
         }
     }
 
     fun markFirstLaunchComplete() {
-        _uiState.update { it.copy(isFirstLaunch = false) }
-        viewModelScope.launch {
-            markOnboardingCompletedUseCase()
+        for (action in periodActionsController.markFirstLaunchComplete()) {
+            if (action is PeriodAction.MarkOnboardingCompleted) {
+                _uiState.update { it.copy(isFirstLaunch = false) }
+                viewModelScope.launch { markOnboardingCompletedUseCase() }
+            }
         }
     }
 
@@ -344,40 +423,112 @@ class BudgetViewModel @Inject constructor(
     }
 
     private fun handleNumpadIntent(intent: BudgetNumpadIntent) {
-        when (intent) {
-            is BudgetNumpadIntent.NumberTapped -> handleNumberInput(intent.digit)
-            is BudgetNumpadIntent.DotTapped -> handleDotInput()
-            is BudgetNumpadIntent.BackspaceTapped -> handleBackspace()
-            is BudgetNumpadIntent.ApplyTapped -> handleApply()
-            is BudgetNumpadIntent.ResetInputTapped -> handleResetInput()
-            is BudgetNumpadIntent.OperatorTapped -> handleOperatorInput(intent.operator)
-            is BudgetNumpadIntent.EqualsTapped -> handleEqualsInput()
-            is BudgetNumpadIntent.SetCalculationMode -> handleSetCalculationMode(intent.enabled)
-            is BudgetNumpadIntent.SetDragProgress -> handleDragProgress(intent.progress)
-            is BudgetNumpadIntent.TriggerTestNotifications -> triggerTestNotifications()
+        val controllerIntent = when (intent) {
+            is BudgetNumpadIntent.NumberTapped -> NumpadIntent.NumberTapped(intent.digit)
+            BudgetNumpadIntent.DotTapped -> NumpadIntent.DotTapped
+            BudgetNumpadIntent.BackspaceTapped -> NumpadIntent.BackspaceTapped
+            BudgetNumpadIntent.ApplyTapped -> NumpadIntent.ApplyTapped
+            BudgetNumpadIntent.ResetInputTapped -> NumpadIntent.ResetInputTapped
+            is BudgetNumpadIntent.OperatorTapped -> NumpadIntent.OperatorTapped(intent.operator)
+            BudgetNumpadIntent.EqualsTapped -> NumpadIntent.EqualsTapped
+            is BudgetNumpadIntent.SetCalculationMode -> NumpadIntent.SetCalculationMode(intent.enabled)
+            is BudgetNumpadIntent.SetDragProgress -> NumpadIntent.SetDragProgress(intent.progress)
+            BudgetNumpadIntent.TriggerTestNotifications -> NumpadIntent.TriggerTestNotifications
         }
+        val changes = numpadController.process(
+            intent = controllerIntent,
+            currentIsCalculation = _uiState.value.isCalculation,
+        )
+        for (change in changes) {
+            when (change) {
+                is NumpadController.NumpadChange.InputChanged -> _uiState.update {
+                    it.copy(
+                        numpadInput = change.newInput,
+                        isNumpadValid = validateNumpadInput(change.newInput),
+                        animState = if (change.newInput.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+                    )
+                }
+
+                is NumpadController.NumpadChange.CalculationModeChanged -> _uiState.update {
+                    it.copy(isCalculation = change.enabled)
+                }
+
+                is NumpadController.NumpadChange.DragProgressChanged -> _uiState.update {
+                    it.copy(dragProgress = change.progress)
+                }
+            }
+        }
+
+        if (intent is BudgetNumpadIntent.ApplyTapped) handleApply()
+        if (intent is BudgetNumpadIntent.TriggerTestNotifications) triggerTestNotifications()
     }
 
     private fun handleTransactionIntent(intent: BudgetTransactionIntent) {
         when (intent) {
-            is BudgetTransactionIntent.DeleteTransactionTapped -> handleDeleteTransaction(intent.transaction)
-            is BudgetTransactionIntent.RestoreTransactionTapped -> handleRestoreTransaction(intent.transaction)
-            is BudgetTransactionIntent.EditTransactionTapped -> handleEditTransaction(intent.updatedTransaction)
+            is BudgetTransactionIntent.DeleteTransactionTapped -> {
+                viewModelScope.launch {
+                    applyTransactionActions(transactionActionsController.delete(intent.transaction))
+                }
+            }
+
+            is BudgetTransactionIntent.RestoreTransactionTapped -> {
+                viewModelScope.launch {
+                    applyTransactionActions(transactionActionsController.restore(intent.transaction))
+                }
+            }
+
+            is BudgetTransactionIntent.EditTransactionTapped -> {
+                viewModelScope.launch {
+                    transactionActionsController.edit(intent.updatedTransaction)
+                }
+            }
         }
     }
 
     private fun handleEditorIntent(intent: BudgetEditorIntent) {
         when (intent) {
-            is BudgetEditorIntent.DateSelected -> handleDateSelected(intent.date)
+            is BudgetEditorIntent.SetEditMode -> editorStateController.process(
+                EditorIntent.SetEditMode(intent.mode),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.SetAnimState -> editorStateController.process(
+                EditorIntent.SetAnimState(intent.state),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.CommentUpdated -> editorStateController.process(
+                EditorIntent.CommentUpdated(intent.comment),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.SetRecurrentEnabled -> editorStateController.process(
+                EditorIntent.SetRecurrentEnabled(intent.enabled),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.SetCreditEnabled -> editorStateController.process(
+                EditorIntent.SetCreditEnabled(intent.enabled),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.DismissRecurrentDialog -> editorStateController.process(
+                EditorIntent.DismissRecurrentDialog,
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.DismissCreditCutoffDialog -> editorStateController.process(
+                EditorIntent.DismissCreditCutoffDialog,
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetEditorIntent.DateSelected -> editorStateController.process(
+                EditorIntent.DateSelected(intent.date),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
             is BudgetEditorIntent.UpdateSettings -> handleUpdateSettings(intent.settings)
-            is BudgetEditorIntent.SetEditMode -> handleSetEditMode(intent.mode)
-            is BudgetEditorIntent.SetAnimState -> handleSetAnimState(intent.state)
-            is BudgetEditorIntent.CommentUpdated -> handleCommentUpdate(intent.comment)
             is BudgetEditorIntent.DeleteTag -> handleDeleteTag(intent.tag)
-            is BudgetEditorIntent.SetRecurrentEnabled -> handleSetRecurrentEnabled(intent.enabled)
-            is BudgetEditorIntent.SetCreditEnabled -> handleSetCreditEnabled(intent.enabled)
-            is BudgetEditorIntent.DismissRecurrentDialog -> handleDismissRecurrentDialog()
-            is BudgetEditorIntent.DismissCreditCutoffDialog -> handleDismissCreditCutoffDialog()
             is BudgetEditorIntent.RecurrentExpenseApplied -> handleRecurrentExpenseApply(
                 intent.frequency,
                 intent.endDate,
@@ -385,7 +536,6 @@ class BudgetViewModel @Inject constructor(
             )
 
             is BudgetEditorIntent.CreditCutoffDayConfirmed -> handleCreditCutoffDayConfirmed(intent.cutoffDay)
-
             is BudgetEditorIntent.FinishBudgetEarly -> handleFinishBudgetEarly()
         }
     }
@@ -393,187 +543,67 @@ class BudgetViewModel @Inject constructor(
     private fun handleSystemIntent(intent: BudgetSystemIntent) {
         when (intent) {
             is BudgetSystemIntent.MarkFirstLaunchComplete -> markFirstLaunchComplete()
-            is BudgetSystemIntent.SetLockSwipeable -> handleSetLockSwipeable(intent.locked)
-            is BudgetSystemIntent.SetLockDraggable -> handleSetLockDraggable(intent.locked)
+            is BudgetSystemIntent.SetLockSwipeable -> editorStateController.process(
+                EditorIntent.SetLockSwipeable(intent.locked),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+
+            is BudgetSystemIntent.SetLockDraggable -> editorStateController.process(
+                EditorIntent.SetLockDraggable(intent.locked),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
         }
-    }
-
-    private fun handleNumberInput(digit: String) {
-        val currentInput = _numpadInput.value
-
-        _numpadInput.value = currentInput + digit
-    }
-
-    private fun handleDotInput() {
-        val currentInput = _numpadInput.value
-
-        val lastChar = currentInput.lastOrNull()
-        val isOperator = { c: Char? -> c != null && c in "+-×÷" }
-
-        if (currentInput.isEmpty() || isOperator(lastChar)) {
-            _numpadInput.value = currentInput + "0."
-            return
-        }
-
-        val lastOperatorIndex = currentInput.indexOfLast { it in "+-×÷" }
-        val currentSegment = currentInput.substring(lastOperatorIndex + 1)
-        if (currentSegment.contains(".")) return
-
-        _numpadInput.value = "$currentInput."
-    }
-
-    private fun handleBackspace() {
-        val updatedInput = _numpadInput.value.dropLast(1)
-        _numpadInput.value = updatedInput
-        if (updatedInput.isEmpty() && _uiState.value.isCalculation) {
-            _uiState.update { it.copy(isCalculation = false) }
-        }
-    }
-
-    private fun handleOperatorInput(operator: Char) {
-        val currentInput = _numpadInput.value
-        if (currentInput.isEmpty()) return
-
-        val lastChar = currentInput.lastOrNull() ?: return
-        if (lastChar in "+-×÷" || lastChar == '.') return
-
-        _numpadInput.value = "$currentInput$operator"
-        if (!_uiState.value.isCalculation) {
-            _uiState.update { it.copy(isCalculation = true) }
-        }
-    }
-
-    private fun handleEqualsInput() {
-        val currentInput = _numpadInput.value
-        if (currentInput.isEmpty()) return
-
-        val result = budgetExpressionEvaluator.evaluate(currentInput)
-        if (result != null) {
-            _numpadInput.value = result
-            if (!_uiState.value.isCalculation) {
-                _uiState.update { it.copy(isCalculation = true) }
-            }
-        }
-    }
-
-    private fun handleSetCalculationMode(enabled: Boolean) {
-        _uiState.update { it.copy(isCalculation = enabled, dragProgress = 0f) }
-    }
-
-    private fun handleDragProgress(progress: Float) {
-        _uiState.update { it.copy(dragProgress = progress) }
-    }
-
-    private fun handleSetLockSwipeable(locked: Boolean) {
-        _uiState.update { it.copy(lockSwipeable = locked) }
-    }
-
-    private fun handleSetLockDraggable(locked: Boolean) {
-        _uiState.update { it.copy(lockDraggable = locked) }
     }
 
     private fun handleApply() {
         viewModelScope.launch {
-            when (
-                val result = transactionHandler.applyTransaction(
-                    input = _numpadInput.value,
-                    isCalculation = _uiState.value.isCalculation,
-                    isRecurrentEnabled = _uiState.value.isRecurrentEnabled,
-                    isCreditEnabled = _uiState.value.isCreditEnabled,
-                    comment = _currentComment.value,
-                    budgetSettings = _uiState.value.budgetSettings,
-                    resolveActivePeriodId = ::resolveActivePeriodId,
-                )
-            ) {
-                is ApplyTransactionResult.InvalidInput -> Unit
-                is ApplyTransactionResult.ShowRecurrentDialog -> {
-                    _numpadInput.value = result.normalizedInput
-                    _uiState.update {
-                        it.copy(
-                            showRecurrentDialog = true,
-                            pendingRecurrentAmount = result.amount,
-                            pendingRecurrentComment = _currentComment.value,
-                        )
-                    }
-                }
-
-                is ApplyTransactionResult.QueuedForNextPeriod -> {
-                    _numpadInput.value = ""
-                    _currentComment.value = ""
-                    _uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
-                    _effects.emit(BudgetUiEffect.ShowMessage("Gasto en cola para el proximo periodo"))
-                }
-
-                is ApplyTransactionResult.Added -> {
-                    _numpadInput.value = ""
-                    _currentComment.value = ""
-                    _uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
-                }
-            }
-        }
-    }
-
-    private fun handleSetRecurrentEnabled(enabled: Boolean) {
-        _uiState.update { it.copy(isRecurrentEnabled = enabled) }
-    }
-
-    private fun handleSetCreditEnabled(enabled: Boolean) {
-        if (!enabled) {
-            _uiState.update { it.copy(isCreditEnabled = false, showCreditCutoffDialog = false) }
-            return
-        }
-
-        val hasCutoff = _uiState.value.budgetSettings?.creditCardCutoffDay != null
-        _uiState.update {
-            it.copy(
-                isCreditEnabled = enabled,
-                showCreditCutoffDialog = !hasCutoff
+            val actions = transactionActionsController.apply(
+                input = numpadController.input.value,
+                isCalculation = numpadController.isCalculation.value,
+                isRecurrentEnabled = editorStateController.state.value.isRecurrentEnabled,
+                isCreditEnabled = editorStateController.state.value.isCreditEnabled,
+                comment = editorStateController.state.value.currentComment,
+                budgetSettings = _uiState.value.budgetSettings,
+                resolveActivePeriodId = ::resolveActivePeriodId,
             )
+            applyTransactionActions(actions)
         }
     }
 
-    private fun handleDismissRecurrentDialog() {
-        _uiState.update {
-            it.copy(
-                showRecurrentDialog = false,
-                pendingRecurrentAmount = null,
-                pendingRecurrentComment = ""
-            )
+    private fun handleUpdateSettings(settings: BudgetSettings) {
+        logcat(TAG) { "handleUpdateSettings called with settings=$settings" }
+        viewModelScope.launch {
+            persistBudgetSettings(settings)
         }
-    }
-
-    private fun handleDismissCreditCutoffDialog() {
-        _uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = false) }
     }
 
     private fun handleRecurrentExpenseApply(
         frequency: RecurrentFrequency,
         endDate: LocalDate,
-        subscriptionDay: Int?
+        subscriptionDay: Int?,
     ) {
         viewModelScope.launch {
-            val applied = transactionHandler.applyRecurrentExpense(
-                pendingAmount = _uiState.value.pendingRecurrentAmount,
-                pendingComment = _uiState.value.pendingRecurrentComment,
+            val actions = transactionActionsController.applyRecurrent(
                 frequency = frequency,
                 endDate = endDate,
                 subscriptionDay = subscriptionDay,
+                pendingAmount = editorStateController.state.value.pendingRecurrentAmount,
+                pendingComment = editorStateController.state.value.pendingRecurrentComment,
                 resolveActivePeriodId = ::resolveActivePeriodId,
-                isCredit = _uiState.value.isCreditEnabled,
+                isCredit = editorStateController.state.value.isCreditEnabled,
             )
-            if (!applied) return@launch
-
-            _uiState.update {
-                it.copy(
-                    showRecurrentDialog = false,
-                    pendingRecurrentAmount = null,
-                    pendingRecurrentComment = "",
-                    isRecurrentEnabled = false,
-                    isCreditEnabled = false,
-                )
+            if (actions.isNotEmpty()) {
+                editorStateController.applyRecurrentDialog()
+                _uiState.update {
+                    it.copy(
+                        numpadInput = "",
+                        currentComment = "",
+                        isCalculation = false,
+                        isRecurrentEnabled = false,
+                        isCreditEnabled = false,
+                    )
+                }
             }
-            _numpadInput.value = ""
-            _currentComment.value = ""
         }
     }
 
@@ -585,6 +615,7 @@ class BudgetViewModel @Inject constructor(
                 currentSettings.copy(creditCardCutoffDay = cutoffDay),
                 forceNewPeriodBoundary = false,
             )
+            editorStateController.applyCreditCutoffDay()
             _uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = true) }
         }
     }
@@ -593,74 +624,74 @@ class BudgetViewModel @Inject constructor(
         finishBudgetEarly()
     }
 
-    private fun handleDeleteTransaction(transaction: Transaction) {
-        logcat(TAG) { "handleDeleteTransaction called for transaction ${transaction.id}" }
-        viewModelScope.launch {
-            transactionHandler.deleteTransaction(transaction).onSuccess {
-                logcat(TAG) { "Transaction ${transaction.id} deleted successfully" }
-            }.onFailure { error ->
-                logcat(TAG) { error.asLog() }
-                _effects.emit(BudgetUiEffect.ShowMessage("Could not delete transaction"))
-            }
-        }
-    }
-
-    private fun handleRestoreTransaction(transaction: Transaction) {
-        viewModelScope.launch {
-            transactionHandler.restoreTransaction(transaction).onSuccess {
-                logcat(TAG) { "Transaction ${transaction.id} restored successfully" }
-            }.onFailure { error ->
-                logcat(TAG) { error.asLog() }
-                _effects.emit(BudgetUiEffect.ShowMessage("Could not restore transaction"))
-            }
-        }
-    }
-
-    private fun handleEditTransaction(updatedTransaction: Transaction) {
-        viewModelScope.launch {
-            transactionHandler.editTransaction(updatedTransaction)
-        }
-    }
-
-    private fun handleDateSelected(date: LocalDate) {
-        _uiState.update { it.copy(selectedDate = date) }
-    }
-
-    private fun handleUpdateSettings(settings: BudgetSettings) {
-        logcat(TAG) { "handleUpdateSettings called with settings=$settings" }
-        viewModelScope.launch {
-            persistBudgetSettings(settings)
-        }
-    }
-
-    private fun handleResetInput() {
-        _numpadInput.value = ""
-        if (_uiState.value.isCalculation) {
-            _uiState.update { it.copy(isCalculation = false) }
-        }
-    }
-
-    private fun handleSetEditMode(mode: EditMode) {
-        _uiState.update { it.copy(editMode = mode) }
-    }
-
-    private fun handleSetAnimState(state: AnimState) {
-        _uiState.update { it.copy(animState = state) }
-    }
-
-    private fun handleCommentUpdate(comment: String) {
-        _currentComment.value = comment
-    }
-
     private fun handleDeleteTag(tag: String) {
-        _categories.update { categories ->
-            categories.filterNot { it.name == tag }
+        _categories.update { categories -> categories.filterNot { it.name == tag } }
+        _uiState.update { state -> state.copy(tags = state.tags.filterNot { it == tag }) }
+        viewModelScope.launch { budgetRepository.hideCategory(tag) }
+    }
+
+    private suspend fun applyTransactionActions(actions: List<TransactionAction>) {
+        var needClear = false
+        for (action in actions) {
+            when (action) {
+                TransactionAction.ClearInput -> {
+                    needClear = true
+                }
+
+                TransactionAction.ClearEditorFlags -> {
+                    _uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
+                }
+
+                TransactionAction.TransactionAdded -> {
+                    // The transaction list is refreshed by the observation
+                    // pipeline, so no explicit refresh is needed.
+                }
+
+                TransactionAction.TransactionQueuedForNextPeriod -> {
+                    // Same — refreshed by observation.
+                }
+
+                is TransactionAction.OpenRecurrentDialog -> {
+                    editorStateController.showRecurrentDialog(
+                        amount = action.amount,
+                        comment = action.comment,
+                    )
+                    numpadController.clearInput()
+                    _uiState.update {
+                        it.copy(
+                            numpadInput = action.normalizedInput,
+                            isNumpadValid = validateNumpadInput(action.normalizedInput),
+                        )
+                    }
+                }
+
+                is TransactionAction.ShowMessage -> {
+                    _effects.emit(BudgetUiEffect.ShowMessage(action.message))
+                }
+
+                TransactionAction.DeleteFailed -> {
+                    _effects.emit(BudgetUiEffect.ShowMessage("Could not delete transaction"))
+                }
+
+                TransactionAction.RestoreFailed -> {
+                    _effects.emit(BudgetUiEffect.ShowMessage("Could not restore transaction"))
+                }
+            }
         }
-        _uiState.update { state ->
-            state.copy(tags = state.tags.filterNot { it == tag })
-        }
-        viewModelScope.launch {
-            budgetRepository.hideCategory(tag)
+        if (needClear) {
+            numpadController.clearInput()
+            editorStateController.process(
+                EditorIntent.CommentUpdated(""),
+                hasCreditCardCutoffDay = _uiState.value.budgetSettings?.creditCardCutoffDay != null,
+            )
+            _uiState.update {
+                it.copy(
+                    numpadInput = "",
+                    currentComment = "",
+                    isCalculation = false,
+                    isCreditEnabled = false,
+                )
+            }
         }
     }
 
@@ -710,4 +741,59 @@ class BudgetViewModel @Inject constructor(
             false
         }
     }
+}
+
+private class TransactionHandlerImpl(
+    private val delegate: BudgetTransactionHandler,
+    private val resolveActivePeriodId: suspend () -> Long,
+) : TransactionHandler {
+    override suspend fun apply(
+        input: String,
+        isCalculation: Boolean,
+        isRecurrentEnabled: Boolean,
+        isCreditEnabled: Boolean,
+        comment: String,
+        budgetSettings: BudgetSettings?,
+        resolveActivePeriodId: suspend () -> Long,
+    ): ApplyTransactionResult = delegate.applyTransaction(
+        input = input,
+        isCalculation = isCalculation,
+        isRecurrentEnabled = isRecurrentEnabled,
+        isCreditEnabled = isCreditEnabled,
+        comment = comment,
+        budgetSettings = budgetSettings,
+        resolveActivePeriodId = this.resolveActivePeriodId,
+    )
+
+    override suspend fun applyRecurrent(
+        pendingAmount: BigDecimal?,
+        pendingComment: String,
+        frequency: RecurrentFrequency,
+        endDate: LocalDate,
+        subscriptionDay: Int?,
+        resolveActivePeriodId: suspend () -> Long,
+        isCredit: Boolean,
+    ): Boolean = delegate.applyRecurrentExpense(
+        pendingAmount = pendingAmount,
+        pendingComment = pendingComment,
+        frequency = frequency,
+        endDate = endDate,
+        subscriptionDay = subscriptionDay,
+        resolveActivePeriodId = this.resolveActivePeriodId,
+        isCredit = isCredit,
+    )
+
+    override suspend fun delete(transaction: Transaction): kotlin.Result<Unit> =
+        delegate.deleteTransaction(transaction)
+
+    override suspend fun restore(transaction: Transaction): kotlin.Result<Unit> =
+        delegate.restoreTransaction(transaction)
+
+    override suspend fun edit(transaction: Transaction) {
+        delegate.editTransaction(transaction)
+    }
+}
+
+private object NoopPeriodActions : PeriodActions {
+    override suspend fun noop() = Unit
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
@@ -49,664 +49,665 @@ private const val TAG = "BudgetViewModel - ISAAC"
 
 @HiltViewModel
 class BudgetViewModel @Inject constructor(
-	private val budgetRepository: BudgetRepository,
-	private val notificationHelper: NotificationHelper,
-	private val notificationScheduler: NotificationScheduler,
-	private val transactionHandler: BudgetTransactionHandler,
-	private val budgetStateCalculator: BudgetStateCalculator,
-	private val budgetWidgetUpdater: BudgetWidgetUpdater,
-	private val budgetExpressionEvaluator: BudgetExpressionEvaluator,
-	private val observeCurrentPeriodBoundaryUseCase: ObserveCurrentPeriodBoundaryUseCase,
-	private val observeCurrentPeriodRolloverUseCase: ObserveCurrentPeriodRolloverUseCase,
-	private val getCurrentPeriodIdUseCase: GetCurrentPeriodIdUseCase,
-	private val persistBudgetSettingsUseCase: PersistBudgetSettingsUseCase,
-	private val updatePeriodEndNotificationTimeUseCase: UpdatePeriodEndNotificationTimeUseCase,
-	private val finishBudgetEarlyUseCase: FinishBudgetEarlyUseCase,
-	private val clearEarlyFinishStateUseCase: ClearEarlyFinishStateUseCase,
-	private val markOnboardingCompletedUseCase: MarkOnboardingCompletedUseCase,
+    private val budgetRepository: BudgetRepository,
+    private val notificationHelper: NotificationHelper,
+    private val notificationScheduler: NotificationScheduler,
+    private val transactionHandler: BudgetTransactionHandler,
+    private val budgetStateCalculator: BudgetStateCalculator,
+    private val budgetWidgetUpdater: BudgetWidgetUpdater,
+    private val budgetExpressionEvaluator: BudgetExpressionEvaluator,
+    private val observeCurrentPeriodBoundaryUseCase: ObserveCurrentPeriodBoundaryUseCase,
+    private val observeCurrentPeriodRolloverUseCase: ObserveCurrentPeriodRolloverUseCase,
+    private val getCurrentPeriodIdUseCase: GetCurrentPeriodIdUseCase,
+    private val persistBudgetSettingsUseCase: PersistBudgetSettingsUseCase,
+    private val updatePeriodEndNotificationTimeUseCase: UpdatePeriodEndNotificationTimeUseCase,
+    private val finishBudgetEarlyUseCase: FinishBudgetEarlyUseCase,
+    private val clearEarlyFinishStateUseCase: ClearEarlyFinishStateUseCase,
+    private val markOnboardingCompletedUseCase: MarkOnboardingCompletedUseCase,
 ) : ViewModel() {
 
-	private val _uiState = MutableStateFlow(BudgetUiState.INITIAL)
-
-	val uiState: StateFlow<BudgetUiState> = _uiState.asStateFlow()
-
-	private val _transactions = MutableStateFlow<List<Transaction>>(emptyList())
-	val transactions: StateFlow<List<Transaction>> = _transactions.asStateFlow()
-
-	private val _budgetSettings = MutableStateFlow<BudgetSettings?>(null)
-	val budgetSettings: StateFlow<BudgetSettings?> = _budgetSettings.asStateFlow()
-
-	private val _budgetState = MutableStateFlow<BudgetState?>(null)
-	val budgetState: StateFlow<BudgetState?> = _budgetState.asStateFlow()
-
-	private val _categories =
-		MutableStateFlow<List<com.serranoie.app.minus.domain.model.Category>>(emptyList())
-	val categories: StateFlow<List<com.serranoie.app.minus.domain.model.Category>> =
-		_categories.asStateFlow()
-
-	private val _effects = MutableSharedFlow<BudgetUiEffect>()
-	val effects: SharedFlow<BudgetUiEffect> = _effects.asSharedFlow()
-
-	private val _numpadInput = MutableStateFlow("")
-	private val _currentComment = MutableStateFlow("")
-	private val _pendingPeriodBoundaryOverride = MutableStateFlow<Pair<Long, Long>?>(null)
-
-	init {
-		observeBudgetData()
-		observeEditorState()
-		observeInitialBudgetCheck()
-		observeCategories()
-	}
-
-	private fun observeBudgetData() {
-		viewModelScope.launch {
-			combine(
-				budgetRepository.getBudgetSettings(),
-				budgetRepository.getTransactions(),
-				buildPeriodBoundaryFlow(),
-				budgetRepository.getQueuedTransactions(),
-				observeCurrentPeriodRolloverUseCase()
-			) { settings, transactions, periodBoundary, queuedTransactions, rolloverInfo ->
-				createBaseUiState(
-					settings = settings,
-					transactions = transactions,
-					periodBoundary = periodBoundary,
-					queuedTransactions = queuedTransactions,
-					rolloverAmount = rolloverInfo.first,
-					rolloverCarryForward = rolloverInfo.second,
-				)
-			}.catch { error ->
-				emit(
-					BudgetUiState(
-						isLoading = false,
-						error = error.message ?: "Unknown error",
-						isFirstLaunch = true
-					)
-				)
-			}.collect { baseState ->
-				applyBaseState(baseState)
-			}
-		}
-	}
-
-	private fun observeEditorState() {
-		viewModelScope.launch {
-			combine(_numpadInput, _currentComment) { numpadInput, currentComment ->
-				numpadInput to currentComment
-			}.collect { (numpadInput, currentComment) ->
-				_uiState.update {
-					it.copy(
-						numpadInput = numpadInput,
-						isNumpadValid = validateNumpadInput(numpadInput),
-						animState = if (numpadInput.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-						currentComment = currentComment
-					)
-				}
-			}
-		}
-	}
-
-	private fun observeInitialBudgetCheck() {
-		viewModelScope.launch {
-			val settings = budgetRepository.getBudgetSettingsSync()
-			if (settings == null) {
-				_uiState.update { it.copy(isFirstLaunch = true) }
-			}
-		}
-	}
-
-	private fun observeCategories() {
-		viewModelScope.launch {
-			budgetRepository.getActiveCategories().collect { categories ->
-				_categories.value = categories
-				_uiState.update { it.copy(tags = categories.map { c -> c.name }) }
-			}
-		}
-	}
-
-	private fun buildPeriodBoundaryFlow() = observeCurrentPeriodBoundaryUseCase().map { boundary ->
-		_pendingPeriodBoundaryOverride.value ?: boundary
-	}
-
-	private fun createBaseUiState(
-		settings: BudgetSettings?,
-		transactions: List<Transaction>,
-		periodBoundary: Pair<Long, Long>,
-		queuedTransactions: List<Transaction>,
-		rolloverAmount: BigDecimal,
-		rolloverCarryForward: Boolean,
-	): BudgetUiState {
-		val currentPeriodStartedAtMillis = periodBoundary.first
-		val currentPeriodId = periodBoundary.second
-		val settingsWithRollover = settings?.copy(
-			rollOverLimit = if (rolloverAmount > BigDecimal.ZERO) rolloverAmount else null,
-			rollOverCarryForward = rolloverCarryForward,
-		)
-		val budgetState = settingsWithRollover?.let { s ->
-			val today = LocalDate.now()
-			val periodTransactions = budgetStateCalculator.filterPeriodTransactions(
-				transactions = transactions,
-				settings = s,
-				currentPeriodId = currentPeriodId,
-				currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
-			)
-			budgetStateCalculator.calculateBudgetState(s, periodTransactions, today)
-		}
-
-		return BudgetUiState(
-			isLoading = false,
-			budgetSettings = settingsWithRollover,
-			budgetState = budgetState,
-			transactions = transactions,
-			selectedDate = LocalDate.now(),
-			error = null,
-			numpadInput = _numpadInput.value,
-			isNumpadValid = validateNumpadInput(_numpadInput.value),
-			editMode = _uiState.value.editMode,
-			animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-			currentComment = _currentComment.value,
-			tags = _categories.value.map { it.name },
-			isFirstLaunch = settings == null,
-			isCreditEnabled = _uiState.value.isCreditEnabled,
-			showCreditCutoffDialog = _uiState.value.showCreditCutoffDialog,
-			pendingExpensesForNextPeriod = queuedTransactions,
-			currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
-			currentPeriodId = currentPeriodId,
-			isCalculation = _uiState.value.isCalculation,
-			dragProgress = _uiState.value.dragProgress,
-			lockSwipeable = _uiState.value.lockSwipeable,
-			lockDraggable = _uiState.value.lockDraggable,
-		)
-	}
-
-	private suspend fun applyBaseState(baseState: BudgetUiState) {
-		_uiState.update { current ->
-			baseState.copy(
-				numpadInput = _numpadInput.value,
-				isNumpadValid = validateNumpadInput(_numpadInput.value),
-				animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
-				currentComment = _currentComment.value,
-				isCalculation = current.isCalculation,
-				dragProgress = current.dragProgress,
-				lockSwipeable = current.lockSwipeable,
-				lockDraggable = current.lockDraggable,
-				pendingExpensesForNextPeriod = baseState.pendingExpensesForNextPeriod,
-			)
-		}
-
-		_transactions.value = baseState.transactions
-		_budgetSettings.value = baseState.budgetSettings
-		_budgetState.value = baseState.budgetState
-
-		budgetWidgetUpdater.update(baseState)
-	}
-
-	fun saveBudgetSettings(
-		settings: BudgetSettings,
-		forceNewPeriodBoundary: Boolean = false,
-	) {
-		logcat(TAG) {
-			"saveBudgetSettings called: settings=$settings forceNewPeriodBoundary=$forceNewPeriodBoundary"
-		}
-		viewModelScope.launch {
-			persistBudgetSettings(settings, forceNewPeriodBoundary = forceNewPeriodBoundary)
-		}
-	}
-
-	fun updatePeriodEndNotificationTime(hour: Int, minute: Int) {
-		viewModelScope.launch {
-			updatePeriodEndNotificationTimeUseCase(hour, minute)
-			logcat(TAG) { "Updated period end notification time to %02d:%02d".format(hour, minute) }
-		}
-	}
-
-	fun updateRecurrentNotificationTime(hour: Int, minute: Int) {
-		viewModelScope.launch {
-			updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(hour, minute)
-			logcat(TAG) { "Updated recurrent notification time to %02d:%02d".format(hour, minute) }
-		}
-	}
-
-	fun finishBudgetEarly() {
-		viewModelScope.launch {
-			finishBudgetEarlyUseCase()
-		}
-	}
-
-	fun clearEarlyFinishState() {
-		viewModelScope.launch {
-			clearEarlyFinishStateUseCase()
-		}
-	}
-
-	fun markFirstLaunchComplete() {
-		_uiState.update { it.copy(isFirstLaunch = false) }
-		viewModelScope.launch {
-			markOnboardingCompletedUseCase()
-		}
-	}
-
-
-	fun triggerTestNotifications() {
-		viewModelScope.launch {
-			val settings = budgetRepository.getBudgetSettingsSync()
-			val currency = settings?.currencyCode ?: "USD"
-
-			try {
-				notificationHelper.showPeriodEndNotification(
-					remainingBudget = "150.00", currency = currency
-				)
-			} catch (e: Exception) {
-				logcat(TAG) { e.asLog() }
-			}
-
-			try {
-				notificationHelper.showRecurrentExpenseNotification(
-					amount = "50.00",
-					comment = "Test expense"
-				)
-			} catch (e: Exception) {
-				logcat(TAG) { e.asLog() }
-			}
-
-			try {
-				val cutoffDay = settings?.creditCardCutoffDay
-				if (cutoffDay != null) {
-					val today = LocalDate.now()
-					val cutoffDate = runCatching { today.withDayOfMonth(cutoffDay) }
-						.getOrElse { today.withDayOfMonth(today.lengthOfMonth()) }
-					val formatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault())
-					notificationHelper.showCreditCutoffNotification(
-						totalAmount = "123.45",
-						cutoffDateText = cutoffDate.format(formatter),
-						currency = currency
-					)
-				}
-			} catch (e: Exception) {
-				logcat(TAG) { e.asLog() }
-			}
-
-			try {
-				notificationScheduler.runRecurrentExpenseCheckNow()
-			} catch (e: Exception) {
-				logcat(TAG) { e.asLog() }
-			}
-		}
-	}
-
-	fun processIntent(intent: BudgetUiIntent) {
-		when (intent) {
-			is BudgetNumpadIntent -> handleNumpadIntent(intent)
-			is BudgetTransactionIntent -> handleTransactionIntent(intent)
-			is BudgetEditorIntent -> handleEditorIntent(intent)
-			is BudgetSystemIntent -> handleSystemIntent(intent)
-		}
-	}
-
-	private fun handleNumpadIntent(intent: BudgetNumpadIntent) {
-		when (intent) {
-			is BudgetNumpadIntent.NumberTapped -> handleNumberInput(intent.digit)
-			is BudgetNumpadIntent.DotTapped -> handleDotInput()
-			is BudgetNumpadIntent.BackspaceTapped -> handleBackspace()
-			is BudgetNumpadIntent.ApplyTapped -> handleApply()
-			is BudgetNumpadIntent.ResetInputTapped -> handleResetInput()
-			is BudgetNumpadIntent.OperatorTapped -> handleOperatorInput(intent.operator)
-			is BudgetNumpadIntent.EqualsTapped -> handleEqualsInput()
-			is BudgetNumpadIntent.SetCalculationMode -> handleSetCalculationMode(intent.enabled)
-			is BudgetNumpadIntent.SetDragProgress -> handleDragProgress(intent.progress)
-			is BudgetNumpadIntent.TriggerTestNotifications -> triggerTestNotifications()
-		}
-	}
-
-	private fun handleTransactionIntent(intent: BudgetTransactionIntent) {
-		when (intent) {
-			is BudgetTransactionIntent.DeleteTransactionTapped -> handleDeleteTransaction(intent.transaction)
-			is BudgetTransactionIntent.RestoreTransactionTapped -> handleRestoreTransaction(intent.transaction)
-			is BudgetTransactionIntent.EditTransactionTapped -> handleEditTransaction(intent.updatedTransaction)
-		}
-	}
-
-	private fun handleEditorIntent(intent: BudgetEditorIntent) {
-		when (intent) {
-			is BudgetEditorIntent.DateSelected -> handleDateSelected(intent.date)
-			is BudgetEditorIntent.UpdateSettings -> handleUpdateSettings(intent.settings)
-			is BudgetEditorIntent.SetEditMode -> handleSetEditMode(intent.mode)
-			is BudgetEditorIntent.SetAnimState -> handleSetAnimState(intent.state)
-			is BudgetEditorIntent.CommentUpdated -> handleCommentUpdate(intent.comment)
-			is BudgetEditorIntent.DeleteTag -> handleDeleteTag(intent.tag)
-			is BudgetEditorIntent.SetRecurrentEnabled -> handleSetRecurrentEnabled(intent.enabled)
-			is BudgetEditorIntent.SetCreditEnabled -> handleSetCreditEnabled(intent.enabled)
-			is BudgetEditorIntent.DismissRecurrentDialog -> handleDismissRecurrentDialog()
-			is BudgetEditorIntent.DismissCreditCutoffDialog -> handleDismissCreditCutoffDialog()
-			is BudgetEditorIntent.RecurrentExpenseApplied -> handleRecurrentExpenseApply(
-				intent.frequency,
-				intent.endDate,
-				intent.subscriptionDay,
-			)
-			is BudgetEditorIntent.CreditCutoffDayConfirmed -> handleCreditCutoffDayConfirmed(intent.cutoffDay)
-
-			is BudgetEditorIntent.FinishBudgetEarly -> handleFinishBudgetEarly()
-		}
-	}
-
-	private fun handleSystemIntent(intent: BudgetSystemIntent) {
-		when (intent) {
-			is BudgetSystemIntent.MarkFirstLaunchComplete -> markFirstLaunchComplete()
-			is BudgetSystemIntent.SetLockSwipeable -> handleSetLockSwipeable(intent.locked)
-			is BudgetSystemIntent.SetLockDraggable -> handleSetLockDraggable(intent.locked)
-		}
-	}
-
-
-	private fun handleNumberInput(digit: String) {
-		val currentInput = _numpadInput.value
-
-		_numpadInput.value = currentInput + digit
-	}
-
-	private fun handleDotInput() {
-		val currentInput = _numpadInput.value
-
-		val lastChar = currentInput.lastOrNull()
-		val isOperator = { c: Char? -> c != null && c in "+-×÷" }
-
-		if (currentInput.isEmpty() || isOperator(lastChar)) {
-			_numpadInput.value = currentInput + "0."
-			return
-		}
-
-		val lastOperatorIndex = currentInput.indexOfLast { it in "+-×÷" }
-		val currentSegment = currentInput.substring(lastOperatorIndex + 1)
-		if (currentSegment.contains(".")) return
-
-		_numpadInput.value = "$currentInput."
-	}
-
-	private fun handleBackspace() {
-		val updatedInput = _numpadInput.value.dropLast(1)
-		_numpadInput.value = updatedInput
-		if (updatedInput.isEmpty() && _uiState.value.isCalculation) {
-			_uiState.update { it.copy(isCalculation = false) }
-		}
-	}
-
-	private fun handleOperatorInput(operator: Char) {
-		val currentInput = _numpadInput.value
-		if (currentInput.isEmpty()) return
-
-		val lastChar = currentInput.lastOrNull() ?: return
-		if (lastChar in "+-×÷" || lastChar == '.') return
-
-		_numpadInput.value = "$currentInput$operator"
-		if (!_uiState.value.isCalculation) {
-			_uiState.update { it.copy(isCalculation = true) }
-		}
-	}
-
-	private fun handleEqualsInput() {
-		val currentInput = _numpadInput.value
-		if (currentInput.isEmpty()) return
-
-		val result = budgetExpressionEvaluator.evaluate(currentInput)
-		if (result != null) {
-			_numpadInput.value = result
-			if (!_uiState.value.isCalculation) {
-				_uiState.update { it.copy(isCalculation = true) }
-			}
-		}
-	}
-
-
-	private fun handleSetCalculationMode(enabled: Boolean) {
-		_uiState.update { it.copy(isCalculation = enabled, dragProgress = 0f) }
-	}
-
-	private fun handleDragProgress(progress: Float) {
-		_uiState.update { it.copy(dragProgress = progress) }
-	}
-
-	private fun handleSetLockSwipeable(locked: Boolean) {
-		_uiState.update { it.copy(lockSwipeable = locked) }
-	}
-
-	private fun handleSetLockDraggable(locked: Boolean) {
-		_uiState.update { it.copy(lockDraggable = locked) }
-	}
-
-	private fun handleApply() {
-		viewModelScope.launch {
-			when (val result = transactionHandler.applyTransaction(
-				input = _numpadInput.value,
-				isCalculation = _uiState.value.isCalculation,
-				isRecurrentEnabled = _uiState.value.isRecurrentEnabled,
-				isCreditEnabled = _uiState.value.isCreditEnabled,
-				comment = _currentComment.value,
-				budgetSettings = _uiState.value.budgetSettings,
-				resolveActivePeriodId = ::resolveActivePeriodId,
-			)) {
-				is ApplyTransactionResult.InvalidInput -> Unit
-				is ApplyTransactionResult.ShowRecurrentDialog -> {
-					_numpadInput.value = result.normalizedInput
-					_uiState.update {
-						it.copy(
-							showRecurrentDialog = true,
-							pendingRecurrentAmount = result.amount,
-							pendingRecurrentComment = _currentComment.value,
-						)
-					}
-				}
-
-				is ApplyTransactionResult.QueuedForNextPeriod -> {
-					_numpadInput.value = ""
-					_currentComment.value = ""
-					_uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
-					_effects.emit(BudgetUiEffect.ShowMessage("Gasto en cola para el proximo periodo"))
-				}
-
-				is ApplyTransactionResult.Added -> {
-					_numpadInput.value = ""
-					_currentComment.value = ""
-					_uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
-				}
-			}
-		}
-	}
-
-	private fun handleSetRecurrentEnabled(enabled: Boolean) {
-		_uiState.update { it.copy(isRecurrentEnabled = enabled) }
-	}
-
-	private fun handleSetCreditEnabled(enabled: Boolean) {
-		if (!enabled) {
-			_uiState.update { it.copy(isCreditEnabled = false, showCreditCutoffDialog = false) }
-			return
-		}
-
-		val hasCutoff = _uiState.value.budgetSettings?.creditCardCutoffDay != null
-		_uiState.update {
-			it.copy(
-				isCreditEnabled = enabled,
-				showCreditCutoffDialog = !hasCutoff
-			)
-		}
-	}
-
-	private fun handleDismissRecurrentDialog() {
-		_uiState.update {
-			it.copy(
-				showRecurrentDialog = false,
-				pendingRecurrentAmount = null,
-				pendingRecurrentComment = ""
-			)
-		}
-	}
-
-	private fun handleDismissCreditCutoffDialog() {
-		_uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = false) }
-	}
-
-	private fun handleRecurrentExpenseApply(
-		frequency: RecurrentFrequency, endDate: LocalDate, subscriptionDay: Int?
-	) {
-		viewModelScope.launch {
-			val applied = transactionHandler.applyRecurrentExpense(
-				pendingAmount = _uiState.value.pendingRecurrentAmount,
-				pendingComment = _uiState.value.pendingRecurrentComment,
-				frequency = frequency,
-				endDate = endDate,
-				subscriptionDay = subscriptionDay,
-				resolveActivePeriodId = ::resolveActivePeriodId,
-				isCredit = _uiState.value.isCreditEnabled,
-			)
-			if (!applied) return@launch
-
-			_uiState.update {
-				it.copy(
-					showRecurrentDialog = false,
-					pendingRecurrentAmount = null,
-					pendingRecurrentComment = "",
-					isRecurrentEnabled = false,
-					isCreditEnabled = false,
-				)
-			}
-			_numpadInput.value = ""
-			_currentComment.value = ""
-		}
-	}
-
-	private fun handleCreditCutoffDayConfirmed(cutoffDay: Int) {
-		if (cutoffDay !in 1..31) return
-		val currentSettings = _uiState.value.budgetSettings ?: return
-		viewModelScope.launch {
-			persistBudgetSettings(
-				currentSettings.copy(creditCardCutoffDay = cutoffDay),
-				forceNewPeriodBoundary = false,
-			)
-			_uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = true) }
-		}
-	}
-
-	private fun handleFinishBudgetEarly() {
-		finishBudgetEarly()
-	}
-
-	private fun handleDeleteTransaction(transaction: Transaction) {
-		logcat(TAG) { "handleDeleteTransaction called for transaction ${transaction.id}" }
-		viewModelScope.launch {
-			transactionHandler.deleteTransaction(transaction).onSuccess {
-					logcat(TAG) { "Transaction ${transaction.id} deleted successfully" }
-				}.onFailure { error ->
-					logcat(TAG) { error.asLog() }
-					_effects.emit(BudgetUiEffect.ShowMessage("Could not delete transaction"))
-				}
-		}
-	}
-
-	private fun handleRestoreTransaction(transaction: Transaction) {
-		viewModelScope.launch {
-			transactionHandler.restoreTransaction(transaction).onSuccess {
-					logcat(TAG) { "Transaction ${transaction.id} restored successfully" }
-				}.onFailure { error ->
-					logcat(TAG) { error.asLog() }
-					_effects.emit(BudgetUiEffect.ShowMessage("Could not restore transaction"))
-				}
-		}
-	}
-
-	private fun handleEditTransaction(updatedTransaction: Transaction) {
-		viewModelScope.launch {
-			transactionHandler.editTransaction(updatedTransaction)
-		}
-	}
-
-	private fun handleDateSelected(date: LocalDate) {
-		_uiState.update { it.copy(selectedDate = date) }
-	}
-
-	private fun handleUpdateSettings(settings: BudgetSettings) {
-		logcat(TAG) { "handleUpdateSettings called with settings=$settings" }
-		viewModelScope.launch {
-			persistBudgetSettings(settings)
-		}
-	}
-
-	private fun handleResetInput() {
-		_numpadInput.value = ""
-		if (_uiState.value.isCalculation) {
-			_uiState.update { it.copy(isCalculation = false) }
-		}
-	}
-
-	private fun handleSetEditMode(mode: EditMode) {
-		_uiState.update { it.copy(editMode = mode) }
-	}
-
-	private fun handleSetAnimState(state: AnimState) {
-		_uiState.update { it.copy(animState = state) }
-	}
-
-	private fun handleCommentUpdate(comment: String) {
-		_currentComment.value = comment
-	}
-
-	private fun handleDeleteTag(tag: String) {
-		_categories.update { categories ->
-			categories.filterNot { it.name == tag }
-		}
-		_uiState.update { state ->
-			state.copy(tags = state.tags.filterNot { it == tag })
-		}
-		viewModelScope.launch {
-			budgetRepository.hideCategory(tag)
-		}
-	}
-
-
-	private suspend fun persistBudgetSettings(
-		settings: BudgetSettings,
-		forceNewPeriodBoundary: Boolean = false,
-	) {
-		logcat(TAG) {
-			"persistBudgetSettings START settings=$settings forceNewPeriodBoundary=$forceNewPeriodBoundary"
-		}
-		val periodBoundary = persistBudgetSettingsUseCase(
-			settings = settings,
-			forceNewPeriodBoundary = forceNewPeriodBoundary,
-		)
-		_pendingPeriodBoundaryOverride.value =
-			periodBoundary.periodStartMillis to periodBoundary.periodId
-		_uiState.update {
-			it.copy(
-				currentPeriodStartedAtMillis = periodBoundary.periodStartMillis,
-				currentPeriodId = periodBoundary.periodId,
-			)
-		}
-		_pendingPeriodBoundaryOverride.value = null
-		logcat(TAG) {
-			"persistBudgetSettings END periodStartMillis=${periodBoundary.periodStartMillis} periodId=${periodBoundary.periodId}"
-		}
-	}
-
-	private suspend fun resolveActivePeriodId(): Long {
-		_pendingPeriodBoundaryOverride.value?.second?.let { pendingPeriodId ->
-			if (pendingPeriodId > 0L) return pendingPeriodId
-		}
-
-		val dataStorePeriodId = getCurrentPeriodIdUseCase()
-		if (dataStorePeriodId > 0L) return dataStorePeriodId
-
-		return _uiState.value.currentPeriodId
-	}
-
-	private fun validateNumpadInput(input: String): Boolean {
-		if (input.isEmpty()) return false
-		if (input == ".") return false
-		return try {
-			val value = BigDecimal(input)
-			value > BigDecimal.ZERO
-		} catch (_: NumberFormatException) {
-			false
-		}
-	}
-
+    private val _uiState = MutableStateFlow(BudgetUiState.INITIAL)
+
+    val uiState: StateFlow<BudgetUiState> = _uiState.asStateFlow()
+
+    private val _transactions = MutableStateFlow<List<Transaction>>(emptyList())
+    val transactions: StateFlow<List<Transaction>> = _transactions.asStateFlow()
+
+    private val _budgetSettings = MutableStateFlow<BudgetSettings?>(null)
+    val budgetSettings: StateFlow<BudgetSettings?> = _budgetSettings.asStateFlow()
+
+    private val _budgetState = MutableStateFlow<BudgetState?>(null)
+    val budgetState: StateFlow<BudgetState?> = _budgetState.asStateFlow()
+
+    private val _categories =
+        MutableStateFlow<List<com.serranoie.app.minus.domain.model.Category>>(emptyList())
+    val categories: StateFlow<List<com.serranoie.app.minus.domain.model.Category>> =
+        _categories.asStateFlow()
+
+    private val _effects = MutableSharedFlow<BudgetUiEffect>()
+    val effects: SharedFlow<BudgetUiEffect> = _effects.asSharedFlow()
+
+    private val _numpadInput = MutableStateFlow("")
+    private val _currentComment = MutableStateFlow("")
+    private val _pendingPeriodBoundaryOverride = MutableStateFlow<Pair<Long, Long>?>(null)
+
+    init {
+        observeBudgetData()
+        observeEditorState()
+        observeInitialBudgetCheck()
+        observeCategories()
+    }
+
+    private fun observeBudgetData() {
+        viewModelScope.launch {
+            combine(
+                budgetRepository.getBudgetSettings(),
+                budgetRepository.getTransactions(),
+                buildPeriodBoundaryFlow(),
+                budgetRepository.getQueuedTransactions(),
+                observeCurrentPeriodRolloverUseCase()
+            ) { settings, transactions, periodBoundary, queuedTransactions, rolloverInfo ->
+                createBaseUiState(
+                    settings = settings,
+                    transactions = transactions,
+                    periodBoundary = periodBoundary,
+                    queuedTransactions = queuedTransactions,
+                    rolloverAmount = rolloverInfo.first,
+                    rolloverCarryForward = rolloverInfo.second,
+                )
+            }.catch { error ->
+                emit(
+                    BudgetUiState(
+                        isLoading = false,
+                        error = error.message ?: "Unknown error",
+                        isFirstLaunch = true
+                    )
+                )
+            }.collect { baseState ->
+                applyBaseState(baseState)
+            }
+        }
+    }
+
+    private fun observeEditorState() {
+        viewModelScope.launch {
+            combine(_numpadInput, _currentComment) { numpadInput, currentComment ->
+                numpadInput to currentComment
+            }.collect { (numpadInput, currentComment) ->
+                _uiState.update {
+                    it.copy(
+                        numpadInput = numpadInput,
+                        isNumpadValid = validateNumpadInput(numpadInput),
+                        animState = if (numpadInput.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+                        currentComment = currentComment
+                    )
+                }
+            }
+        }
+    }
+
+    private fun observeInitialBudgetCheck() {
+        viewModelScope.launch {
+            val settings = budgetRepository.getBudgetSettingsSync()
+            if (settings == null) {
+                _uiState.update { it.copy(isFirstLaunch = true) }
+            }
+        }
+    }
+
+    private fun observeCategories() {
+        viewModelScope.launch {
+            budgetRepository.getActiveCategories().collect { categories ->
+                _categories.value = categories
+                _uiState.update { it.copy(tags = categories.map { c -> c.name }) }
+            }
+        }
+    }
+
+    private fun buildPeriodBoundaryFlow() = observeCurrentPeriodBoundaryUseCase().map { boundary ->
+        _pendingPeriodBoundaryOverride.value ?: boundary
+    }
+
+    private fun createBaseUiState(
+        settings: BudgetSettings?,
+        transactions: List<Transaction>,
+        periodBoundary: Pair<Long, Long>,
+        queuedTransactions: List<Transaction>,
+        rolloverAmount: BigDecimal,
+        rolloverCarryForward: Boolean,
+    ): BudgetUiState {
+        val currentPeriodStartedAtMillis = periodBoundary.first
+        val currentPeriodId = periodBoundary.second
+        val settingsWithRollover = settings?.copy(
+            rollOverLimit = if (rolloverAmount > BigDecimal.ZERO) rolloverAmount else null,
+            rollOverCarryForward = rolloverCarryForward,
+        )
+        val budgetState = settingsWithRollover?.let { s ->
+            val today = LocalDate.now()
+            val periodTransactions = budgetStateCalculator.filterPeriodTransactions(
+                transactions = transactions,
+                settings = s,
+                currentPeriodId = currentPeriodId,
+                currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
+            )
+            budgetStateCalculator.calculateBudgetState(s, periodTransactions, today)
+        }
+
+        return BudgetUiState(
+            isLoading = false,
+            budgetSettings = settingsWithRollover,
+            budgetState = budgetState,
+            transactions = transactions,
+            selectedDate = LocalDate.now(),
+            error = null,
+            numpadInput = _numpadInput.value,
+            isNumpadValid = validateNumpadInput(_numpadInput.value),
+            editMode = _uiState.value.editMode,
+            animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+            currentComment = _currentComment.value,
+            tags = _categories.value.map { it.name },
+            isFirstLaunch = settings == null,
+            isCreditEnabled = _uiState.value.isCreditEnabled,
+            showCreditCutoffDialog = _uiState.value.showCreditCutoffDialog,
+            pendingExpensesForNextPeriod = queuedTransactions,
+            currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
+            currentPeriodId = currentPeriodId,
+            isCalculation = _uiState.value.isCalculation,
+            dragProgress = _uiState.value.dragProgress,
+            lockSwipeable = _uiState.value.lockSwipeable,
+            lockDraggable = _uiState.value.lockDraggable,
+        )
+    }
+
+    private suspend fun applyBaseState(baseState: BudgetUiState) {
+        _uiState.update { current ->
+            baseState.copy(
+                numpadInput = _numpadInput.value,
+                isNumpadValid = validateNumpadInput(_numpadInput.value),
+                animState = if (_numpadInput.value.isNotEmpty()) AnimState.EDITING else AnimState.IDLE,
+                currentComment = _currentComment.value,
+                isCalculation = current.isCalculation,
+                dragProgress = current.dragProgress,
+                lockSwipeable = current.lockSwipeable,
+                lockDraggable = current.lockDraggable,
+                pendingExpensesForNextPeriod = baseState.pendingExpensesForNextPeriod,
+            )
+        }
+
+        _transactions.value = baseState.transactions
+        _budgetSettings.value = baseState.budgetSettings
+        _budgetState.value = baseState.budgetState
+
+        budgetWidgetUpdater.update(baseState)
+    }
+
+    fun saveBudgetSettings(
+        settings: BudgetSettings,
+        forceNewPeriodBoundary: Boolean = false,
+    ) {
+        logcat(TAG) {
+            "saveBudgetSettings called: settings=$settings forceNewPeriodBoundary=$forceNewPeriodBoundary"
+        }
+        viewModelScope.launch {
+            persistBudgetSettings(settings, forceNewPeriodBoundary = forceNewPeriodBoundary)
+        }
+    }
+
+    fun updatePeriodEndNotificationTime(hour: Int, minute: Int) {
+        viewModelScope.launch {
+            updatePeriodEndNotificationTimeUseCase(hour, minute)
+            logcat(TAG) { "Updated period end notification time to %02d:%02d".format(hour, minute) }
+        }
+    }
+
+    fun updateRecurrentNotificationTime(hour: Int, minute: Int) {
+        viewModelScope.launch {
+            updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(hour, minute)
+            logcat(TAG) { "Updated recurrent notification time to %02d:%02d".format(hour, minute) }
+        }
+    }
+
+    fun finishBudgetEarly() {
+        viewModelScope.launch {
+            finishBudgetEarlyUseCase()
+        }
+    }
+
+    fun clearEarlyFinishState() {
+        viewModelScope.launch {
+            clearEarlyFinishStateUseCase()
+        }
+    }
+
+    fun markFirstLaunchComplete() {
+        _uiState.update { it.copy(isFirstLaunch = false) }
+        viewModelScope.launch {
+            markOnboardingCompletedUseCase()
+        }
+    }
+
+    fun triggerTestNotifications() {
+        viewModelScope.launch {
+            val settings = budgetRepository.getBudgetSettingsSync()
+            val currency = settings?.currencyCode ?: "USD"
+
+            try {
+                notificationHelper.showPeriodEndNotification(
+                    remainingBudget = "150.00",
+                    currency = currency
+                )
+            } catch (e: Exception) {
+                logcat(TAG) { e.asLog() }
+            }
+
+            try {
+                notificationHelper.showRecurrentExpenseNotification(
+                    amount = "50.00",
+                    comment = "Test expense"
+                )
+            } catch (e: Exception) {
+                logcat(TAG) { e.asLog() }
+            }
+
+            try {
+                val cutoffDay = settings?.creditCardCutoffDay
+                if (cutoffDay != null) {
+                    val today = LocalDate.now()
+                    val cutoffDate = runCatching { today.withDayOfMonth(cutoffDay) }
+                        .getOrElse { today.withDayOfMonth(today.lengthOfMonth()) }
+                    val formatter = DateTimeFormatter.ofPattern("dd MMM", Locale.getDefault())
+                    notificationHelper.showCreditCutoffNotification(
+                        totalAmount = "123.45",
+                        cutoffDateText = cutoffDate.format(formatter),
+                        currency = currency
+                    )
+                }
+            } catch (e: Exception) {
+                logcat(TAG) { e.asLog() }
+            }
+
+            try {
+                notificationScheduler.runRecurrentExpenseCheckNow()
+            } catch (e: Exception) {
+                logcat(TAG) { e.asLog() }
+            }
+        }
+    }
+
+    fun processIntent(intent: BudgetUiIntent) {
+        when (intent) {
+            is BudgetNumpadIntent -> handleNumpadIntent(intent)
+            is BudgetTransactionIntent -> handleTransactionIntent(intent)
+            is BudgetEditorIntent -> handleEditorIntent(intent)
+            is BudgetSystemIntent -> handleSystemIntent(intent)
+        }
+    }
+
+    private fun handleNumpadIntent(intent: BudgetNumpadIntent) {
+        when (intent) {
+            is BudgetNumpadIntent.NumberTapped -> handleNumberInput(intent.digit)
+            is BudgetNumpadIntent.DotTapped -> handleDotInput()
+            is BudgetNumpadIntent.BackspaceTapped -> handleBackspace()
+            is BudgetNumpadIntent.ApplyTapped -> handleApply()
+            is BudgetNumpadIntent.ResetInputTapped -> handleResetInput()
+            is BudgetNumpadIntent.OperatorTapped -> handleOperatorInput(intent.operator)
+            is BudgetNumpadIntent.EqualsTapped -> handleEqualsInput()
+            is BudgetNumpadIntent.SetCalculationMode -> handleSetCalculationMode(intent.enabled)
+            is BudgetNumpadIntent.SetDragProgress -> handleDragProgress(intent.progress)
+            is BudgetNumpadIntent.TriggerTestNotifications -> triggerTestNotifications()
+        }
+    }
+
+    private fun handleTransactionIntent(intent: BudgetTransactionIntent) {
+        when (intent) {
+            is BudgetTransactionIntent.DeleteTransactionTapped -> handleDeleteTransaction(intent.transaction)
+            is BudgetTransactionIntent.RestoreTransactionTapped -> handleRestoreTransaction(intent.transaction)
+            is BudgetTransactionIntent.EditTransactionTapped -> handleEditTransaction(intent.updatedTransaction)
+        }
+    }
+
+    private fun handleEditorIntent(intent: BudgetEditorIntent) {
+        when (intent) {
+            is BudgetEditorIntent.DateSelected -> handleDateSelected(intent.date)
+            is BudgetEditorIntent.UpdateSettings -> handleUpdateSettings(intent.settings)
+            is BudgetEditorIntent.SetEditMode -> handleSetEditMode(intent.mode)
+            is BudgetEditorIntent.SetAnimState -> handleSetAnimState(intent.state)
+            is BudgetEditorIntent.CommentUpdated -> handleCommentUpdate(intent.comment)
+            is BudgetEditorIntent.DeleteTag -> handleDeleteTag(intent.tag)
+            is BudgetEditorIntent.SetRecurrentEnabled -> handleSetRecurrentEnabled(intent.enabled)
+            is BudgetEditorIntent.SetCreditEnabled -> handleSetCreditEnabled(intent.enabled)
+            is BudgetEditorIntent.DismissRecurrentDialog -> handleDismissRecurrentDialog()
+            is BudgetEditorIntent.DismissCreditCutoffDialog -> handleDismissCreditCutoffDialog()
+            is BudgetEditorIntent.RecurrentExpenseApplied -> handleRecurrentExpenseApply(
+                intent.frequency,
+                intent.endDate,
+                intent.subscriptionDay,
+            )
+
+            is BudgetEditorIntent.CreditCutoffDayConfirmed -> handleCreditCutoffDayConfirmed(intent.cutoffDay)
+
+            is BudgetEditorIntent.FinishBudgetEarly -> handleFinishBudgetEarly()
+        }
+    }
+
+    private fun handleSystemIntent(intent: BudgetSystemIntent) {
+        when (intent) {
+            is BudgetSystemIntent.MarkFirstLaunchComplete -> markFirstLaunchComplete()
+            is BudgetSystemIntent.SetLockSwipeable -> handleSetLockSwipeable(intent.locked)
+            is BudgetSystemIntent.SetLockDraggable -> handleSetLockDraggable(intent.locked)
+        }
+    }
+
+    private fun handleNumberInput(digit: String) {
+        val currentInput = _numpadInput.value
+
+        _numpadInput.value = currentInput + digit
+    }
+
+    private fun handleDotInput() {
+        val currentInput = _numpadInput.value
+
+        val lastChar = currentInput.lastOrNull()
+        val isOperator = { c: Char? -> c != null && c in "+-×÷" }
+
+        if (currentInput.isEmpty() || isOperator(lastChar)) {
+            _numpadInput.value = currentInput + "0."
+            return
+        }
+
+        val lastOperatorIndex = currentInput.indexOfLast { it in "+-×÷" }
+        val currentSegment = currentInput.substring(lastOperatorIndex + 1)
+        if (currentSegment.contains(".")) return
+
+        _numpadInput.value = "$currentInput."
+    }
+
+    private fun handleBackspace() {
+        val updatedInput = _numpadInput.value.dropLast(1)
+        _numpadInput.value = updatedInput
+        if (updatedInput.isEmpty() && _uiState.value.isCalculation) {
+            _uiState.update { it.copy(isCalculation = false) }
+        }
+    }
+
+    private fun handleOperatorInput(operator: Char) {
+        val currentInput = _numpadInput.value
+        if (currentInput.isEmpty()) return
+
+        val lastChar = currentInput.lastOrNull() ?: return
+        if (lastChar in "+-×÷" || lastChar == '.') return
+
+        _numpadInput.value = "$currentInput$operator"
+        if (!_uiState.value.isCalculation) {
+            _uiState.update { it.copy(isCalculation = true) }
+        }
+    }
+
+    private fun handleEqualsInput() {
+        val currentInput = _numpadInput.value
+        if (currentInput.isEmpty()) return
+
+        val result = budgetExpressionEvaluator.evaluate(currentInput)
+        if (result != null) {
+            _numpadInput.value = result
+            if (!_uiState.value.isCalculation) {
+                _uiState.update { it.copy(isCalculation = true) }
+            }
+        }
+    }
+
+    private fun handleSetCalculationMode(enabled: Boolean) {
+        _uiState.update { it.copy(isCalculation = enabled, dragProgress = 0f) }
+    }
+
+    private fun handleDragProgress(progress: Float) {
+        _uiState.update { it.copy(dragProgress = progress) }
+    }
+
+    private fun handleSetLockSwipeable(locked: Boolean) {
+        _uiState.update { it.copy(lockSwipeable = locked) }
+    }
+
+    private fun handleSetLockDraggable(locked: Boolean) {
+        _uiState.update { it.copy(lockDraggable = locked) }
+    }
+
+    private fun handleApply() {
+        viewModelScope.launch {
+            when (
+                val result = transactionHandler.applyTransaction(
+                    input = _numpadInput.value,
+                    isCalculation = _uiState.value.isCalculation,
+                    isRecurrentEnabled = _uiState.value.isRecurrentEnabled,
+                    isCreditEnabled = _uiState.value.isCreditEnabled,
+                    comment = _currentComment.value,
+                    budgetSettings = _uiState.value.budgetSettings,
+                    resolveActivePeriodId = ::resolveActivePeriodId,
+                )
+            ) {
+                is ApplyTransactionResult.InvalidInput -> Unit
+                is ApplyTransactionResult.ShowRecurrentDialog -> {
+                    _numpadInput.value = result.normalizedInput
+                    _uiState.update {
+                        it.copy(
+                            showRecurrentDialog = true,
+                            pendingRecurrentAmount = result.amount,
+                            pendingRecurrentComment = _currentComment.value,
+                        )
+                    }
+                }
+
+                is ApplyTransactionResult.QueuedForNextPeriod -> {
+                    _numpadInput.value = ""
+                    _currentComment.value = ""
+                    _uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
+                    _effects.emit(BudgetUiEffect.ShowMessage("Gasto en cola para el proximo periodo"))
+                }
+
+                is ApplyTransactionResult.Added -> {
+                    _numpadInput.value = ""
+                    _currentComment.value = ""
+                    _uiState.update { it.copy(isCalculation = false, isCreditEnabled = false) }
+                }
+            }
+        }
+    }
+
+    private fun handleSetRecurrentEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(isRecurrentEnabled = enabled) }
+    }
+
+    private fun handleSetCreditEnabled(enabled: Boolean) {
+        if (!enabled) {
+            _uiState.update { it.copy(isCreditEnabled = false, showCreditCutoffDialog = false) }
+            return
+        }
+
+        val hasCutoff = _uiState.value.budgetSettings?.creditCardCutoffDay != null
+        _uiState.update {
+            it.copy(
+                isCreditEnabled = enabled,
+                showCreditCutoffDialog = !hasCutoff
+            )
+        }
+    }
+
+    private fun handleDismissRecurrentDialog() {
+        _uiState.update {
+            it.copy(
+                showRecurrentDialog = false,
+                pendingRecurrentAmount = null,
+                pendingRecurrentComment = ""
+            )
+        }
+    }
+
+    private fun handleDismissCreditCutoffDialog() {
+        _uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = false) }
+    }
+
+    private fun handleRecurrentExpenseApply(
+        frequency: RecurrentFrequency,
+        endDate: LocalDate,
+        subscriptionDay: Int?
+    ) {
+        viewModelScope.launch {
+            val applied = transactionHandler.applyRecurrentExpense(
+                pendingAmount = _uiState.value.pendingRecurrentAmount,
+                pendingComment = _uiState.value.pendingRecurrentComment,
+                frequency = frequency,
+                endDate = endDate,
+                subscriptionDay = subscriptionDay,
+                resolveActivePeriodId = ::resolveActivePeriodId,
+                isCredit = _uiState.value.isCreditEnabled,
+            )
+            if (!applied) return@launch
+
+            _uiState.update {
+                it.copy(
+                    showRecurrentDialog = false,
+                    pendingRecurrentAmount = null,
+                    pendingRecurrentComment = "",
+                    isRecurrentEnabled = false,
+                    isCreditEnabled = false,
+                )
+            }
+            _numpadInput.value = ""
+            _currentComment.value = ""
+        }
+    }
+
+    private fun handleCreditCutoffDayConfirmed(cutoffDay: Int) {
+        if (cutoffDay !in 1..31) return
+        val currentSettings = _uiState.value.budgetSettings ?: return
+        viewModelScope.launch {
+            persistBudgetSettings(
+                currentSettings.copy(creditCardCutoffDay = cutoffDay),
+                forceNewPeriodBoundary = false,
+            )
+            _uiState.update { it.copy(showCreditCutoffDialog = false, isCreditEnabled = true) }
+        }
+    }
+
+    private fun handleFinishBudgetEarly() {
+        finishBudgetEarly()
+    }
+
+    private fun handleDeleteTransaction(transaction: Transaction) {
+        logcat(TAG) { "handleDeleteTransaction called for transaction ${transaction.id}" }
+        viewModelScope.launch {
+            transactionHandler.deleteTransaction(transaction).onSuccess {
+                logcat(TAG) { "Transaction ${transaction.id} deleted successfully" }
+            }.onFailure { error ->
+                logcat(TAG) { error.asLog() }
+                _effects.emit(BudgetUiEffect.ShowMessage("Could not delete transaction"))
+            }
+        }
+    }
+
+    private fun handleRestoreTransaction(transaction: Transaction) {
+        viewModelScope.launch {
+            transactionHandler.restoreTransaction(transaction).onSuccess {
+                logcat(TAG) { "Transaction ${transaction.id} restored successfully" }
+            }.onFailure { error ->
+                logcat(TAG) { error.asLog() }
+                _effects.emit(BudgetUiEffect.ShowMessage("Could not restore transaction"))
+            }
+        }
+    }
+
+    private fun handleEditTransaction(updatedTransaction: Transaction) {
+        viewModelScope.launch {
+            transactionHandler.editTransaction(updatedTransaction)
+        }
+    }
+
+    private fun handleDateSelected(date: LocalDate) {
+        _uiState.update { it.copy(selectedDate = date) }
+    }
+
+    private fun handleUpdateSettings(settings: BudgetSettings) {
+        logcat(TAG) { "handleUpdateSettings called with settings=$settings" }
+        viewModelScope.launch {
+            persistBudgetSettings(settings)
+        }
+    }
+
+    private fun handleResetInput() {
+        _numpadInput.value = ""
+        if (_uiState.value.isCalculation) {
+            _uiState.update { it.copy(isCalculation = false) }
+        }
+    }
+
+    private fun handleSetEditMode(mode: EditMode) {
+        _uiState.update { it.copy(editMode = mode) }
+    }
+
+    private fun handleSetAnimState(state: AnimState) {
+        _uiState.update { it.copy(animState = state) }
+    }
+
+    private fun handleCommentUpdate(comment: String) {
+        _currentComment.value = comment
+    }
+
+    private fun handleDeleteTag(tag: String) {
+        _categories.update { categories ->
+            categories.filterNot { it.name == tag }
+        }
+        _uiState.update { state ->
+            state.copy(tags = state.tags.filterNot { it == tag })
+        }
+        viewModelScope.launch {
+            budgetRepository.hideCategory(tag)
+        }
+    }
+
+    private suspend fun persistBudgetSettings(
+        settings: BudgetSettings,
+        forceNewPeriodBoundary: Boolean = false,
+    ) {
+        logcat(TAG) {
+            "persistBudgetSettings START settings=$settings forceNewPeriodBoundary=$forceNewPeriodBoundary"
+        }
+        val periodBoundary = persistBudgetSettingsUseCase(
+            settings = settings,
+            forceNewPeriodBoundary = forceNewPeriodBoundary,
+        )
+        _pendingPeriodBoundaryOverride.value =
+            periodBoundary.periodStartMillis to periodBoundary.periodId
+        _uiState.update {
+            it.copy(
+                currentPeriodStartedAtMillis = periodBoundary.periodStartMillis,
+                currentPeriodId = periodBoundary.periodId,
+            )
+        }
+        _pendingPeriodBoundaryOverride.value = null
+        logcat(TAG) {
+            "persistBudgetSettings END periodStartMillis=${periodBoundary.periodStartMillis} periodId=${periodBoundary.periodId}"
+        }
+    }
+
+    private suspend fun resolveActivePeriodId(): Long {
+        _pendingPeriodBoundaryOverride.value?.second?.let { pendingPeriodId ->
+            if (pendingPeriodId > 0L) return pendingPeriodId
+        }
+
+        val dataStorePeriodId = getCurrentPeriodIdUseCase()
+        if (dataStorePeriodId > 0L) return dataStorePeriodId
+
+        return _uiState.value.currentPeriodId
+    }
+
+    private fun validateNumpadInput(input: String): Boolean {
+        if (input.isEmpty()) return false
+        if (input == ".") return false
+        return try {
+            val value = BigDecimal(input)
+            value > BigDecimal.ZERO
+        } catch (_: NumberFormatException) {
+            false
+        }
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/EditorStateController.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/EditorStateController.kt
@@ -1,0 +1,212 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.serranoie.app.minus.presentation.ui.editor.AnimState
+import com.serranoie.app.minus.presentation.ui.editor.EditMode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class EditorStateController {
+
+    private val _state = MutableStateFlow(EditorLocalState())
+    val state: StateFlow<EditorLocalState> = _state.asStateFlow()
+
+    sealed interface EditorChange {
+        data class EditModeChanged(val mode: EditMode) : EditorChange
+        data class AnimStateChanged(val state: AnimState) : EditorChange
+        data class CommentChanged(val comment: String) : EditorChange
+        data class LockSwipeableChanged(val locked: Boolean) : EditorChange
+        data class LockDraggableChanged(val locked: Boolean) : EditorChange
+        data class RecurrentEnabledChanged(val enabled: Boolean) : EditorChange
+        data class CreditEnabledChanged(val enabled: Boolean) : EditorChange
+        data class RecurrentDialogVisibilityChanged(val visible: Boolean) : EditorChange
+        data class CreditCutoffDialogVisibilityChanged(val visible: Boolean) : EditorChange
+        data class PendingRecurrentAmountChanged(val amount: BigDecimal?) : EditorChange
+        data class PendingRecurrentCommentChanged(val comment: String) : EditorChange
+        data class SelectedDateChanged(val date: LocalDate) : EditorChange
+    }
+
+    fun process(
+        intent: EditorIntent,
+        hasCreditCardCutoffDay: Boolean,
+    ): List<EditorChange> = when (intent) {
+        is EditorIntent.SetEditMode -> setEditMode(intent.mode)
+        is EditorIntent.SetAnimState -> setAnimState(intent.state)
+        is EditorIntent.CommentUpdated -> setComment(intent.comment)
+        is EditorIntent.SetLockSwipeable -> setLockSwipeable(intent.locked)
+        is EditorIntent.SetLockDraggable -> setLockDraggable(intent.locked)
+        is EditorIntent.SetRecurrentEnabled -> setRecurrentEnabled(intent.enabled)
+        is EditorIntent.SetCreditEnabled -> setCreditEnabled(intent.enabled, hasCreditCardCutoffDay)
+        is EditorIntent.DismissRecurrentDialog -> dismissRecurrentDialog()
+        is EditorIntent.DismissCreditCutoffDialog -> dismissCreditCutoffDialog()
+        is EditorIntent.DateSelected -> setSelectedDate(intent.date)
+    }
+
+    private fun setEditMode(mode: EditMode): List<EditorChange> {
+        _state.value = _state.value.copy(editMode = mode)
+        return listOf(EditorChange.EditModeChanged(mode))
+    }
+
+    private fun setAnimState(animState: AnimState): List<EditorChange> {
+        _state.value = _state.value.copy(animState = animState)
+        return listOf(EditorChange.AnimStateChanged(animState))
+    }
+
+    private fun setComment(comment: String): List<EditorChange> {
+        _state.value = _state.value.copy(currentComment = comment)
+        return listOf(EditorChange.CommentChanged(comment))
+    }
+
+    private fun setLockSwipeable(locked: Boolean): List<EditorChange> {
+        _state.value = _state.value.copy(lockSwipeable = locked)
+        return listOf(EditorChange.LockSwipeableChanged(locked))
+    }
+
+    private fun setLockDraggable(locked: Boolean): List<EditorChange> {
+        _state.value = _state.value.copy(lockDraggable = locked)
+        return listOf(EditorChange.LockDraggableChanged(locked))
+    }
+
+    private fun setRecurrentEnabled(enabled: Boolean): List<EditorChange> {
+        _state.value = _state.value.copy(isRecurrentEnabled = enabled)
+        return listOf(EditorChange.RecurrentEnabledChanged(enabled))
+    }
+
+    private fun setCreditEnabled(enabled: Boolean, hasCutoff: Boolean): List<EditorChange> {
+        if (!enabled) {
+            val cleared = _state.value.copy(
+                isCreditEnabled = false,
+                showCreditCutoffDialog = false,
+            )
+            _state.value = cleared
+            return listOf(
+                EditorChange.CreditEnabledChanged(false),
+                EditorChange.CreditCutoffDialogVisibilityChanged(false),
+            )
+        }
+        val showDialog = !hasCutoff
+        val updated = _state.value.copy(
+            isCreditEnabled = enabled,
+            showCreditCutoffDialog = showDialog,
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.CreditEnabledChanged(enabled),
+            EditorChange.CreditCutoffDialogVisibilityChanged(showDialog),
+        )
+    }
+
+    private fun dismissRecurrentDialog(): List<EditorChange> {
+        val updated = _state.value.copy(
+            showRecurrentDialog = false,
+            pendingRecurrentAmount = null,
+            pendingRecurrentComment = "",
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.RecurrentDialogVisibilityChanged(false),
+            EditorChange.PendingRecurrentAmountChanged(null),
+            EditorChange.PendingRecurrentCommentChanged(""),
+        )
+    }
+
+    private fun dismissCreditCutoffDialog(): List<EditorChange> {
+        val updated = _state.value.copy(
+            showCreditCutoffDialog = false,
+            isCreditEnabled = false,
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+            EditorChange.CreditEnabledChanged(false),
+        )
+    }
+
+    private fun setSelectedDate(date: LocalDate): List<EditorChange> {
+        _state.value = _state.value.copy(selectedDate = date)
+        return listOf(EditorChange.SelectedDateChanged(date))
+    }
+
+    fun showRecurrentDialog(amount: BigDecimal, comment: String): List<EditorChange> {
+        val updated = _state.value.copy(
+            showRecurrentDialog = true,
+            pendingRecurrentAmount = amount,
+            pendingRecurrentComment = comment,
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.RecurrentDialogVisibilityChanged(true),
+            EditorChange.PendingRecurrentAmountChanged(amount),
+            EditorChange.PendingRecurrentCommentChanged(comment),
+        )
+    }
+
+    fun applyRecurrentDialog(): List<EditorChange> {
+        val updated = _state.value.copy(
+            showRecurrentDialog = false,
+            pendingRecurrentAmount = null,
+            pendingRecurrentComment = "",
+            isRecurrentEnabled = false,
+            isCreditEnabled = false,
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.RecurrentDialogVisibilityChanged(false),
+            EditorChange.PendingRecurrentAmountChanged(null),
+            EditorChange.PendingRecurrentCommentChanged(""),
+            EditorChange.RecurrentEnabledChanged(false),
+            EditorChange.CreditEnabledChanged(false),
+        )
+    }
+
+    fun applyCreditCutoffDay(): List<EditorChange> {
+        val updated = _state.value.copy(
+            showCreditCutoffDialog = false,
+            isCreditEnabled = true,
+        )
+        _state.value = updated
+        return listOf(
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+            EditorChange.CreditEnabledChanged(true),
+        )
+    }
+
+    fun deleteTag(tag: String): EditorChange.PendingRecurrentCommentChanged {
+        // Tag management is handled in the parent VM (it persists the
+        // hide via BudgetRepository). The controller only clears the
+        // pendingComment to keep its state consistent. This is a
+        // minimal hook — full tag list management stays in the VM
+        // for now.
+        return EditorChange.PendingRecurrentCommentChanged(_state.value.currentComment)
+    }
+}
+
+data class EditorLocalState(
+    val editMode: EditMode = EditMode.ADD,
+    val animState: AnimState = AnimState.IDLE,
+    val currentComment: String = "",
+    val lockSwipeable: Boolean = false,
+    val lockDraggable: Boolean = false,
+    val isRecurrentEnabled: Boolean = false,
+    val isCreditEnabled: Boolean = false,
+    val showRecurrentDialog: Boolean = false,
+    val showCreditCutoffDialog: Boolean = false,
+    val pendingRecurrentAmount: BigDecimal? = null,
+    val pendingRecurrentComment: String = "",
+    val selectedDate: LocalDate = LocalDate.now(),
+)
+
+sealed interface EditorIntent {
+    data class SetEditMode(val mode: EditMode) : EditorIntent
+    data class SetAnimState(val state: AnimState) : EditorIntent
+    data class CommentUpdated(val comment: String) : EditorIntent
+    data class SetLockSwipeable(val locked: Boolean) : EditorIntent
+    data class SetLockDraggable(val locked: Boolean) : EditorIntent
+    data class SetRecurrentEnabled(val enabled: Boolean) : EditorIntent
+    data class SetCreditEnabled(val enabled: Boolean) : EditorIntent
+    data object DismissRecurrentDialog : EditorIntent
+    data object DismissCreditCutoffDialog : EditorIntent
+    data class DateSelected(val date: LocalDate) : EditorIntent
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/NumpadController.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/NumpadController.kt
@@ -1,0 +1,181 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.serranoie.app.minus.presentation.ui.budget.BudgetExpressionEvaluator
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Owns the numpad input string and the calculation-mode toggle. Pure business
+ * logic — no Android dependencies, no coroutine launches, no side effects
+ * beyond its own [input] / [isCalculation] state.
+ *
+ * The controller's [process] method takes the current `isCalculation` flag
+ * as a read-only input (so it can clear it on backspace) and returns a
+ * [NumpadChange] describing the state diff for the parent ViewModel to
+ * apply. This keeps the controller a pure state machine that can be
+ * exhaustively unit-tested without any Android or coroutine scaffolding.
+ */
+class NumpadController(
+    private val expressionEvaluator: BudgetExpressionEvaluator = BudgetExpressionEvaluator(),
+) {
+    private val _input = MutableStateFlow("")
+    val input: StateFlow<String> = _input.asStateFlow()
+
+    private val _isCalculation = MutableStateFlow(false)
+    val isCalculation: StateFlow<Boolean> = _isCalculation.asStateFlow()
+
+    private val _dragProgress = MutableStateFlow(0f)
+    val dragProgress: StateFlow<Float> = _dragProgress.asStateFlow()
+
+    /**
+     * The result of processing one numpad intent. The parent ViewModel
+     * applies these as patches to its own UI state.
+     */
+    sealed interface NumpadChange {
+        /** The numpad input string changed. */
+        data class InputChanged(val newInput: String) : NumpadChange
+        /** The calculation-mode flag changed. */
+        data class CalculationModeChanged(val enabled: Boolean) : NumpadChange
+        /** The drag progress changed (e.g. for the editor sheet expand). */
+        data class DragProgressChanged(val progress: Float) : NumpadChange
+    }
+
+    /**
+     * Process one numpad intent. The `currentIsCalculation` is the parent's
+     * current value of the calculation flag (used to decide whether to clear
+     * it on backspace / reset). The returned [NumpadChange]s are the
+     * authoritative state diff for this call — the parent MUST apply them.
+     */
+    fun process(
+        intent: NumpadIntent,
+        currentIsCalculation: Boolean,
+    ): List<NumpadChange> = when (intent) {
+        is NumpadIntent.NumberTapped -> listOf(appendDigit(intent.digit))
+        is NumpadIntent.DotTapped -> handleDot()
+        is NumpadIntent.BackspaceTapped -> handleBackspace(currentIsCalculation)
+        NumpadIntent.ApplyTapped -> emptyList() // Side effect handled by the parent VM
+        is NumpadIntent.OperatorTapped -> handleOperator(intent.operator, currentIsCalculation)
+        is NumpadIntent.EqualsTapped -> handleEquals(currentIsCalculation)
+        is NumpadIntent.ResetInputTapped -> handleReset(currentIsCalculation)
+        is NumpadIntent.SetCalculationMode -> setCalculationMode(intent.enabled)
+        is NumpadIntent.SetDragProgress -> setDragProgress(intent.progress)
+        is NumpadIntent.TriggerTestNotifications -> emptyList()
+    }
+
+    private fun appendDigit(digit: String): NumpadChange {
+        val updated = _input.value + digit
+        _input.value = updated
+        return NumpadChange.InputChanged(updated)
+    }
+
+    private fun handleDot(): List<NumpadChange> {
+        val current = _input.value
+        val lastChar = current.lastOrNull()
+        val isOperator = { c: Char? -> c != null && c in "+-×÷" }
+
+        val updated = when {
+            current.isEmpty() || isOperator(lastChar) -> current + "0."
+            else -> {
+                val lastOpIndex = current.indexOfLast { it in "+-×÷" }
+                val segment = current.substring(lastOpIndex + 1)
+                if (segment.contains(".")) return emptyList() // ignore extra dots in segment
+                "$current."
+            }
+        }
+        _input.value = updated
+        return listOf(NumpadChange.InputChanged(updated))
+    }
+
+    private fun handleBackspace(currentIsCalculation: Boolean): List<NumpadChange> {
+        val updated = _input.value.dropLast(1)
+        _input.value = updated
+        return buildList {
+            add(NumpadChange.InputChanged(updated))
+            if (updated.isEmpty() && currentIsCalculation) {
+                add(NumpadChange.CalculationModeChanged(false))
+            }
+        }
+    }
+
+    private fun handleOperator(operator: Char, currentIsCalculation: Boolean): List<NumpadChange> {
+        val current = _input.value
+        if (current.isEmpty()) return emptyList()
+        val lastChar = current.lastOrNull() ?: return emptyList()
+        if (lastChar in "+-×÷" || lastChar == '.') return emptyList()
+
+        val updated = "$current$operator"
+        _input.value = updated
+        return buildList {
+            add(NumpadChange.InputChanged(updated))
+            if (!currentIsCalculation) {
+                add(NumpadChange.CalculationModeChanged(true))
+            }
+        }
+    }
+
+    private fun handleEquals(currentIsCalculation: Boolean): List<NumpadChange> {
+        val current = _input.value
+        if (current.isEmpty()) return emptyList()
+        val result = expressionEvaluator.evaluate(current) ?: return emptyList()
+        _input.value = result
+        return buildList {
+            add(NumpadChange.InputChanged(result))
+            if (!currentIsCalculation) {
+                add(NumpadChange.CalculationModeChanged(true))
+            }
+        }
+    }
+
+    private fun handleReset(currentIsCalculation: Boolean): List<NumpadChange> {
+        _input.value = ""
+        return buildList {
+            add(NumpadChange.InputChanged(""))
+            if (currentIsCalculation) {
+                add(NumpadChange.CalculationModeChanged(false))
+            }
+        }
+    }
+
+    private fun setCalculationMode(enabled: Boolean): List<NumpadChange> {
+        _isCalculation.value = enabled
+        _dragProgress.value = 0f
+        return listOf(
+            NumpadChange.CalculationModeChanged(enabled),
+            NumpadChange.DragProgressChanged(0f),
+        )
+    }
+
+    private fun setDragProgress(progress: Float): List<NumpadChange> {
+        _dragProgress.value = progress
+        return listOf(NumpadChange.DragProgressChanged(progress))
+    }
+
+    /**
+     * Reset the input to an empty string. Called by the parent ViewModel
+     * after a successful apply / restore action.
+     */
+    fun clearInput(): NumpadChange {
+        _input.value = ""
+        return NumpadChange.InputChanged("")
+    }
+}
+
+/**
+ * The set of numpad intents the controller understands. Mirrors the
+ * production [com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadIntent]
+ * but kept as a controller-local sealed interface so the controller has no
+ * dependency on the MVI intent types.
+ */
+sealed interface NumpadIntent {
+    data class NumberTapped(val digit: String) : NumpadIntent
+    data object DotTapped : NumpadIntent
+    data object BackspaceTapped : NumpadIntent
+    data object ApplyTapped : NumpadIntent
+    data class OperatorTapped(val operator: Char) : NumpadIntent
+    data object EqualsTapped : NumpadIntent
+    data object ResetInputTapped : NumpadIntent
+    data class SetCalculationMode(val enabled: Boolean) : NumpadIntent
+    data class SetDragProgress(val progress: Float) : NumpadIntent
+    data object TriggerTestNotifications : NumpadIntent
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/PeriodActionsController.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/PeriodActionsController.kt
@@ -1,0 +1,53 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class PeriodActionsController(
+    private val actions: PeriodActions,
+) {
+
+    private val _isFirstLaunch = MutableStateFlow(true)
+    val isFirstLaunch: StateFlow<Boolean> = _isFirstLaunch.asStateFlow()
+
+    sealed interface PeriodAction {
+        data object MarkOnboardingCompleted : PeriodAction
+        data class PersistBudgetSettings(val settings: BudgetSettings) : PeriodAction
+        data class UpdatePeriodEndNotification(val hour: Int, val minute: Int) : PeriodAction
+        data class UpdateRecurrentNotification(val hour: Int, val minute: Int) : PeriodAction
+        data object FinishBudgetEarly : PeriodAction
+        data object ClearEarlyFinish : PeriodAction
+        data object TriggerTestNotifications : PeriodAction
+    }
+
+    fun markFirstLaunchComplete(): List<PeriodAction> {
+        _isFirstLaunch.value = false
+        return listOf(PeriodAction.MarkOnboardingCompleted)
+    }
+
+    fun saveBudgetSettings(settings: BudgetSettings): List<PeriodAction> {
+        if (_isFirstLaunch.value) {
+            _isFirstLaunch.value = false
+        }
+        return listOf(PeriodAction.PersistBudgetSettings(settings))
+    }
+
+    fun updatePeriodEndNotificationTime(hour: Int, minute: Int): List<PeriodAction> =
+        listOf(PeriodAction.UpdatePeriodEndNotification(hour, minute))
+
+    fun updateRecurrentNotificationTime(hour: Int, minute: Int): List<PeriodAction> =
+        listOf(PeriodAction.UpdateRecurrentNotification(hour, minute))
+
+    fun finishBudgetEarly(): List<PeriodAction> = listOf(PeriodAction.FinishBudgetEarly)
+
+    fun clearEarlyFinishState(): List<PeriodAction> = listOf(PeriodAction.ClearEarlyFinish)
+
+    fun triggerTestNotifications(): List<PeriodAction> =
+        listOf(PeriodAction.TriggerTestNotifications)
+}
+
+interface PeriodActions {
+    suspend fun noop()
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/TransactionActionsController.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/controller/TransactionActionsController.kt
@@ -1,0 +1,151 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.presentation.ui.budget.ApplyTransactionResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class TransactionActionsController(
+    private val handler: TransactionHandler,
+) {
+
+    private val _categories = MutableStateFlow<List<String>>(emptyList())
+    val categories: StateFlow<List<String>> = _categories.asStateFlow()
+
+    sealed interface TransactionAction {
+        data object ClearInput : TransactionAction
+        data object ClearEditorFlags : TransactionAction
+        data object TransactionAdded : TransactionAction
+        data object TransactionQueuedForNextPeriod : TransactionAction
+        data class OpenRecurrentDialog(
+            val normalizedInput: String,
+            val amount: BigDecimal,
+            val comment: String,
+        ) : TransactionAction
+
+        data class ShowMessage(val message: String) : TransactionAction
+        data object DeleteFailed : TransactionAction
+        data object RestoreFailed : TransactionAction
+    }
+
+    suspend fun apply(
+        input: String,
+        isCalculation: Boolean,
+        isRecurrentEnabled: Boolean,
+        isCreditEnabled: Boolean,
+        comment: String,
+        budgetSettings: BudgetSettings?,
+        resolveActivePeriodId: suspend () -> Long,
+    ): List<TransactionAction> {
+        val result = handler.apply(
+            input = input,
+            isCalculation = isCalculation,
+            isRecurrentEnabled = isRecurrentEnabled,
+            isCreditEnabled = isCreditEnabled,
+            comment = comment,
+            budgetSettings = budgetSettings,
+            resolveActivePeriodId = resolveActivePeriodId,
+        )
+        return when (result) {
+            is ApplyTransactionResult.InvalidInput -> emptyList()
+            is ApplyTransactionResult.ShowRecurrentDialog -> listOf(
+                TransactionAction.OpenRecurrentDialog(
+                    normalizedInput = result.normalizedInput,
+                    amount = result.amount,
+                    comment = comment,
+                ),
+            )
+
+            is ApplyTransactionResult.QueuedForNextPeriod -> listOf(
+                TransactionAction.ClearInput,
+                TransactionAction.ClearEditorFlags,
+                TransactionAction.TransactionQueuedForNextPeriod,
+                TransactionAction.ShowMessage("Gasto en cola para el proximo periodo"),
+            )
+
+            is ApplyTransactionResult.Added -> listOf(
+                TransactionAction.ClearInput,
+                TransactionAction.ClearEditorFlags,
+                TransactionAction.TransactionAdded,
+            )
+        }
+    }
+
+    suspend fun applyRecurrent(
+        frequency: RecurrentFrequency,
+        endDate: LocalDate,
+        subscriptionDay: Int?,
+        pendingAmount: BigDecimal?,
+        pendingComment: String,
+        resolveActivePeriodId: suspend () -> Long,
+        isCredit: Boolean,
+    ): List<TransactionAction> {
+        val applied = handler.applyRecurrent(
+            pendingAmount = pendingAmount,
+            pendingComment = pendingComment,
+            frequency = frequency,
+            endDate = endDate,
+            subscriptionDay = subscriptionDay,
+            resolveActivePeriodId = resolveActivePeriodId,
+            isCredit = isCredit,
+        )
+        return if (applied) {
+            listOf(TransactionAction.ClearInput)
+        } else {
+            emptyList()
+        }
+    }
+
+    suspend fun delete(transaction: Transaction): List<TransactionAction> {
+        val result = handler.delete(transaction)
+        return if (result.isSuccess) {
+            emptyList()
+        } else {
+            listOf(TransactionAction.DeleteFailed)
+        }
+    }
+
+    suspend fun restore(transaction: Transaction): List<TransactionAction> {
+        val result = handler.restore(transaction)
+        return if (result.isSuccess) {
+            emptyList()
+        } else {
+            listOf(TransactionAction.RestoreFailed)
+        }
+    }
+
+    suspend fun edit(transaction: Transaction) {
+        handler.edit(transaction)
+    }
+}
+
+interface TransactionHandler {
+    suspend fun apply(
+        input: String,
+        isCalculation: Boolean,
+        isRecurrentEnabled: Boolean,
+        isCreditEnabled: Boolean,
+        comment: String,
+        budgetSettings: BudgetSettings?,
+        resolveActivePeriodId: suspend () -> Long,
+    ): ApplyTransactionResult
+
+    suspend fun applyRecurrent(
+        pendingAmount: BigDecimal?,
+        pendingComment: String,
+        frequency: RecurrentFrequency,
+        endDate: LocalDate,
+        subscriptionDay: Int?,
+        resolveActivePeriodId: suspend () -> Long,
+        isCredit: Boolean,
+    ): Boolean
+
+    suspend fun delete(transaction: Transaction): kotlin.Result<Unit>
+    suspend fun restore(transaction: Transaction): kotlin.Result<Unit>
+    suspend fun edit(transaction: Transaction)
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/BudgetPeriodSheet.kt
@@ -122,1126 +122,1165 @@ fun budgetPeriodCardTag(period: BudgetPeriod) = "BudgetPeriodSheet.Period.${peri
 
 @Composable
 fun BudgetPeriodSheet(
-	budgetSettings: BudgetSettings?,
-	budgetState: BudgetState?,
-	selectedPeriod: BudgetPeriod = budgetSettings?.period ?: BudgetPeriod.DAILY,
-	currencyCode: String,
-	onPeriodSelected: (BudgetPeriod) -> Unit,
-	onSaveBudget: ((BudgetSettings) -> Unit)? = null,
-	onEditBudget: (() -> Unit)? = null,
-	onFinishEarly: (() -> Unit)? = null,
-	startInEditMode: Boolean = false,
-	pendingExpensesCount: Int = 0,
+    budgetSettings: BudgetSettings?,
+    budgetState: BudgetState?,
+    selectedPeriod: BudgetPeriod = budgetSettings?.period ?: BudgetPeriod.DAILY,
+    currencyCode: String,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
+    onSaveBudget: ((BudgetSettings) -> Unit)? = null,
+    onEditBudget: (() -> Unit)? = null,
+    onFinishEarly: (() -> Unit)? = null,
+    startInEditMode: Boolean = false,
+    pendingExpensesCount: Int = 0,
 ) {
-	val haptic = LocalHapticFeedback.current
-	val currencyFormat = remember(currencyCode) {
-		symbolOnlyCurrencyFormat(currencyCode, maximumFractionDigits = 0)
-	}
+    val haptic = LocalHapticFeedback.current
+    val currencyFormat = remember(currencyCode) {
+        symbolOnlyCurrencyFormat(currencyCode, maximumFractionDigits = 0)
+    }
 
-	val startDate = budgetSettings?.startDate ?: LocalDate.now()
-	val endDate = budgetSettings?.endDate
-	val totalBudget = budgetSettings?.totalBudget ?: BigDecimal.ZERO
-	var periodCache by remember(selectedPeriod) { mutableStateOf(selectedPeriod) }
+    val startDate = budgetSettings?.startDate ?: LocalDate.now()
+    val endDate = budgetSettings?.endDate
+    val totalBudget = budgetSettings?.totalBudget ?: BigDecimal.ZERO
+    var periodCache by remember(selectedPeriod) { mutableStateOf(selectedPeriod) }
 
-	var isEditMode by remember(startInEditMode) { mutableStateOf(startInEditMode) }
-	var showFinishConfirm by remember { mutableStateOf(false) }
+    var isEditMode by remember(startInEditMode) { mutableStateOf(startInEditMode) }
+    var showFinishConfirm by remember { mutableStateOf(false) }
 
-	val totalDays = remember(startDate, endDate) {
-		if (endDate != null) ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1 else 30
-	}
+    val totalDays = remember(startDate, endDate) {
+        if (endDate != null) ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1 else 30
+    }
 
-	fun LocalDate.toDate(): Date = Date.from(this.atStartOfDay(ZoneId.systemDefault()).toInstant())
+    fun LocalDate.toDate(): Date = Date.from(this.atStartOfDay(ZoneId.systemDefault()).toInstant())
 
-	val startDateAsDate = remember(startDate) { startDate.toDate() }
-	val endDateAsDate = remember(endDate) { endDate?.toDate() }
-	val totalSpent = budgetState?.totalSpentInPeriod ?: BigDecimal.ZERO
+    val startDateAsDate = remember(startDate) { startDate.toDate() }
+    val endDateAsDate = remember(endDate) { endDate?.toDate() }
+    val totalSpent = budgetState?.totalSpentInPeriod ?: BigDecimal.ZERO
 
-	val available =
-		if (totalDays > 0) availablePeriodsFor(totalDays) else listOf(BudgetPeriod.DAILY)
+    val available =
+        if (totalDays > 0) availablePeriodsFor(totalDays) else listOf(BudgetPeriod.DAILY)
 
-	LaunchedEffect(available, totalDays) {
-		logcat {
-			"reconcilePeriodCache: current=$periodCache, available=$available, totalDays=$totalDays, start=$startDate, end=$endDate"
-		}
-		if (periodCache !in available && available.isNotEmpty()) {
-			val previous = periodCache
-			periodCache = available.first()
-			logcat {
-				"periodCache auto-adjusted from $previous to $periodCache because previous is not available for totalDays=$totalDays"
-			}
-			onPeriodSelected(periodCache)
-		}
-	}
+    LaunchedEffect(available, totalDays) {
+        logcat {
+            "reconcilePeriodCache: current=$periodCache, available=$available, totalDays=$totalDays, start=$startDate, end=$endDate"
+        }
+        if (periodCache !in available && available.isNotEmpty()) {
+            val previous = periodCache
+            periodCache = available.first()
+            logcat {
+                "periodCache auto-adjusted from $previous to $periodCache because previous is not available for totalDays=$totalDays"
+            }
+            onPeriodSelected(periodCache)
+        }
+    }
 
-	AnimatedContent(
-		modifier = Modifier.testTag(BUDGET_PERIOD_SHEET_TAG),
-		targetState = isEditMode, transitionSpec = {
-			if (targetState) {
-				// Forward: entering edit mode
-				(slideInHorizontally(
-					initialOffsetX = { it / 3 }, animationSpec = tween(300)
-				) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
-					slideOutHorizontally(
-						targetOffsetX = { -it / 3 }, animationSpec = tween(300)
-					) + fadeOut(tween(200))
-				)
-			} else {
-				// Backward: exiting edit mode
-				(slideInHorizontally(
-					initialOffsetX = { -it / 3 }, animationSpec = tween(300)
-				) + fadeIn(tween(250, delayMillis = 50))).togetherWith(
-					slideOutHorizontally(
-						targetOffsetX = { it / 3 }, animationSpec = tween(300)
-					) + fadeOut(tween(200))
-				)
-			}
-		}, label = "sheetContent"
-	) { editMode ->
-		if (editMode) {
-			EditBudgetContent(
-				budgetSettings = budgetSettings,
-				onBack = { isEditMode = false },
-				onApply = { newSettings ->
-					onSaveBudget?.invoke(newSettings)
-					isEditMode = false
-				},
-				pendingExpensesCount = pendingExpensesCount,
-			)
-		} else {
-			ViewBudgetContent(
-				budgetSettings = budgetSettings,
-				budgetState = budgetState,
-				periodCache = periodCache,
-				currencyFormat = currencyFormat,
-				currencyCode = currencyCode,
-				totalBudget = totalBudget,
-				totalSpent = totalSpent,
-				totalDays = totalDays,
-				startDateAsDate = startDateAsDate,
-				endDateAsDate = endDateAsDate,
-				available = available,
-				onPeriodSelected = { p ->
-					logcat { "User selected period chip: $p (previous=$periodCache)" }
-					periodCache = p
-					onPeriodSelected(p)
-				},
-				onEditClick = {
-					if (onSaveBudget != null) {
-						isEditMode = true
-					} else {
-						onEditBudget?.invoke()
-					}
-				},
-				onFinishEarlyClick = { showFinishConfirm = true },
-				showFinishEarly = onFinishEarly != null && budgetSettings != null,
-			)
-		}
-	}
+    AnimatedContent(
+        modifier = Modifier.testTag(BUDGET_PERIOD_SHEET_TAG),
+        targetState = isEditMode,
+        transitionSpec = {
+            if (targetState) {
+                (
+                        slideInHorizontally(
+                            initialOffsetX = { it / 3 }, animationSpec = tween(300)
+                        ) + fadeIn(tween(250, delayMillis = 50))
+                        ).togetherWith(
+                        slideOutHorizontally(
+                            targetOffsetX = { -it / 3 }, animationSpec = tween(300)
+                        ) + fadeOut(tween(200))
+                    )
+            } else {
+                (
+                        slideInHorizontally(
+                            initialOffsetX = { -it / 3 }, animationSpec = tween(300)
+                        ) + fadeIn(tween(250, delayMillis = 50))
+                        ).togetherWith(
+                        slideOutHorizontally(
+                            targetOffsetX = { it / 3 }, animationSpec = tween(300)
+                        ) + fadeOut(tween(200))
+                    )
+            }
+        },
+        label = "sheetContent"
+    ) { editMode ->
+        if (editMode) {
+            EditBudgetContent(
+                budgetSettings = budgetSettings,
+                onBack = { isEditMode = false },
+                onApply = { newSettings ->
+                    onSaveBudget?.invoke(newSettings)
+                    isEditMode = false
+                },
+                pendingExpensesCount = pendingExpensesCount,
+            )
+        } else {
+            ViewBudgetContent(
+                budgetSettings = budgetSettings,
+                budgetState = budgetState,
+                periodCache = periodCache,
+                currencyFormat = currencyFormat,
+                currencyCode = currencyCode,
+                totalBudget = totalBudget,
+                totalSpent = totalSpent,
+                totalDays = totalDays,
+                startDateAsDate = startDateAsDate,
+                endDateAsDate = endDateAsDate,
+                available = available,
+                onPeriodSelected = { p ->
+                    logcat { "User selected period chip: $p (previous=$periodCache)" }
+                    periodCache = p
+                    onPeriodSelected(p)
+                },
+                onEditClick = {
+                    if (onSaveBudget != null) {
+                        isEditMode = true
+                    } else {
+                        onEditBudget?.invoke()
+                    }
+                },
+                onFinishEarlyClick = { showFinishConfirm = true },
+                showFinishEarly = onFinishEarly != null && budgetSettings != null,
+            )
+        }
+    }
 
-	// Finish Early Confirmation Dialog
-	if (showFinishConfirm) {
-		AlertDialog(
-			onDismissRequest = { showFinishConfirm = false },
-			title = {
-				Text(
-					stringResource(R.string.finalize_period_question),
-					style = MaterialTheme.typography.titleMediumEmphasized
-				)
-			},
-			text = { Text(stringResource(R.string.finalize_period_confirm)) },
-			confirmButton = {
-				TextButton(
-					onClick = {
-						showFinishConfirm = false
-						haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-						onFinishEarly?.invoke()
-					},
-				) {
-					Text(
-						stringResource(R.string.finalize_action),
-						color = MaterialTheme.colorScheme.error,
-						style = MaterialTheme.typography.labelMediumEmphasized
-					)
-				}
-			},
-			dismissButton = {
-				TextButton(onClick = { showFinishConfirm = false }) {
-					Text(
-						stringResource(R.string.cancel),
-						style = MaterialTheme.typography.labelMediumEmphasized
-					)
-				}
-			},
-		)
-	}
+    if (showFinishConfirm) {
+        AlertDialog(
+            onDismissRequest = { showFinishConfirm = false },
+            title = {
+                Text(
+                    stringResource(R.string.finalize_period_question),
+                    style = MaterialTheme.typography.titleMediumEmphasized
+                )
+            },
+            text = { Text(stringResource(R.string.finalize_period_confirm)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showFinishConfirm = false
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        onFinishEarly?.invoke()
+                    },
+                ) {
+                    Text(
+                        stringResource(R.string.finalize_action),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.labelMediumEmphasized
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showFinishConfirm = false }) {
+                    Text(
+                        stringResource(R.string.cancel),
+                        style = MaterialTheme.typography.labelMediumEmphasized
+                    )
+                }
+            },
+        )
+    }
 }
 
 @Composable
 private fun ViewBudgetContent(
-	budgetSettings: BudgetSettings?,
-	budgetState: BudgetState?,
-	periodCache: BudgetPeriod,
-	currencyFormat: NumberFormat,
-	currencyCode: String,
-	totalBudget: BigDecimal,
-	totalSpent: BigDecimal,
-	totalDays: Int,
-	startDateAsDate: Date,
-	endDateAsDate: Date?,
-	available: List<BudgetPeriod>,
-	onPeriodSelected: (BudgetPeriod) -> Unit,
-	onEditClick: () -> Unit,
-	onFinishEarlyClick: () -> Unit,
-	showFinishEarly: Boolean,
+    budgetSettings: BudgetSettings?,
+    budgetState: BudgetState?,
+    periodCache: BudgetPeriod,
+    currencyFormat: NumberFormat,
+    currencyCode: String,
+    totalBudget: BigDecimal,
+    totalSpent: BigDecimal,
+    totalDays: Int,
+    startDateAsDate: Date,
+    endDateAsDate: Date?,
+    available: List<BudgetPeriod>,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
+    onEditClick: () -> Unit,
+    onFinishEarlyClick: () -> Unit,
+    showFinishEarly: Boolean,
 ) {
-	Column(
-		modifier = Modifier
-			.fillMaxWidth()
-			.padding(horizontal = 16.dp)
-			.padding(top = 4.dp, bottom = 32.dp)
-			.navigationBarsPadding(),
-	) {
-		Row(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(vertical = 12.dp),
-			horizontalArrangement = Arrangement.SpaceBetween,
-			verticalAlignment = Alignment.CenterVertically,
-		) {
-			Text(
-				text = stringResource(R.string.total_budget),
-				style = MaterialTheme.typography.titleLargeEmphasized,
-				fontWeight = FontWeight.W500,
-			)
-			IconButton(
-				onClick = onEditClick,
-				modifier = Modifier
-					.size(40.dp)
-					.testTag(BUDGET_PERIOD_EDIT_BUTTON_TAG)
-			) {
-				Icon(
-					imageVector = Icons.Default.Edit,
-					contentDescription = stringResource(R.string.edit_budget),
-					tint = MaterialTheme.colorScheme.onSurface,
-				)
-			}
-		}
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(top = 4.dp, bottom = 32.dp)
+            .navigationBarsPadding(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.total_budget),
+                style = MaterialTheme.typography.titleLargeEmphasized,
+                fontWeight = FontWeight.W500,
+            )
+            IconButton(
+                onClick = onEditClick,
+                modifier = Modifier
+                    .size(40.dp)
+                    .testTag(BUDGET_PERIOD_EDIT_BUTTON_TAG)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(R.string.edit_budget),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
 
-		Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
-		logcat(BUDGET_PERIOD_SHEET_TAG) {
-			"BudgetDisplay input totalBudget=$totalBudget budgetStateTotal=${budgetState?.totalBudget} budgetSettingsTotal=${budgetSettings?.totalBudget} rollOverLimit=${budgetSettings?.rollOverLimit} rollOverCarry=${budgetSettings?.rollOverCarryForward}"
-		}
+        logcat(BUDGET_PERIOD_SHEET_TAG) {
+            "BudgetDisplay input totalBudget=$totalBudget budgetStateTotal=${budgetState?.totalBudget} budgetSettingsTotal=${budgetSettings?.totalBudget} rollOverLimit=${budgetSettings?.rollOverLimit} rollOverCarry=${budgetSettings?.rollOverCarryForward}"
+        }
 
-		SpendBudgetCard(
-			modifier = Modifier
-				.fillMaxWidth()
-				.height(IntrinsicSize.Min)
-				.padding(bottom = 8.dp),
-			budget = totalBudget,
-			spend = totalSpent,
-		)
+        SpendBudgetCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+                .padding(bottom = 8.dp),
+            budget = totalBudget,
+            spend = totalSpent,
+        )
 
-		Row(
-			modifier = Modifier
-				.fillMaxWidth()
-				.height(120.dp),
-			horizontalArrangement = Arrangement.spacedBy(8.dp),
-			verticalAlignment = Alignment.CenterVertically,
-		) {
-			BudgetDisplay(
-				budget = totalBudget,
-				budgetState = budgetState,
-				budgetSettings = budgetSettings,
-				currencyCode = currencyCode,
-				bigVariant = false,
-				modifier = Modifier
-					.weight(1.5f)
-					.height(120.dp),
-				startDate = startDateAsDate,
-				finishDate = endDateAsDate
-			)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BudgetDisplay(
+                budget = totalBudget,
+                budgetState = budgetState,
+                budgetSettings = budgetSettings,
+                currencyCode = currencyCode,
+                bigVariant = false,
+                modifier = Modifier
+                    .weight(1.5f)
+                    .height(120.dp),
+                startDate = startDateAsDate,
+                finishDate = endDateAsDate
+            )
 
-			if (endDateAsDate != null) {
-				Box(
-					modifier = Modifier
-						.weight(1f)
-						.height(120.dp),
-					contentAlignment = Alignment.Center,
-				) {
-					DaysLeftCard(
-						startDate = startDateAsDate,
-						finishDate = endDateAsDate,
-					)
-				}
-			} else {
-				Card(
-					modifier = Modifier
-						.weight(1f)
-						.height(120.dp),
-					colors = CardDefaults.cardColors(
-						containerColor = MaterialTheme.colorScheme.surfaceVariant
-					),
-					shape = RoundedCornerShape(12.dp)
-				) {
-					Box(
-						modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center
-					) {
-						Text(
-							text = stringResource(R.string.no_ending_date),
-							style = MaterialTheme.typography.bodySmallEmphasized,
-							textAlign = TextAlign.Center,
-							color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-							modifier = Modifier.padding(16.dp)
-						)
-					}
-				}
-			}
-		}
+            if (endDateAsDate != null) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(120.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    DaysLeftCard(
+                        startDate = startDateAsDate,
+                        finishDate = endDateAsDate,
+                    )
+                }
+            } else {
+                Card(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(120.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.no_ending_date),
+                            style = MaterialTheme.typography.bodySmallEmphasized,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
 
-		Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-		Text(
-			text = stringResource(R.string.budget_split_logic),
-			style = MaterialTheme.typography.titleMediumCondensed,
-			fontWeight = FontWeight.Medium,
-			modifier = Modifier.padding(bottom = 12.dp),
-		)
+        Text(
+            text = stringResource(R.string.budget_split_logic),
+            style = MaterialTheme.typography.titleMediumCondensed,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
 
-		if (totalDays > 0) {
-			Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-				available.chunked(2).forEach { rowPeriods ->
-					Row(
-						horizontalArrangement = Arrangement.spacedBy(8.dp),
-						modifier = Modifier.fillMaxWidth()
-					) {
-						rowPeriods.forEach { p ->
-							val isSelected = p == periodCache
-							val preview = if (totalBudget > BigDecimal.ZERO && totalDays > 0) {
-								budgetForPeriod(totalBudget, totalDays, p)
-							} else BigDecimal.ZERO
+        if (totalDays > 0) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                available.chunked(2).forEach { rowPeriods ->
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        rowPeriods.forEach { p ->
+                            val isSelected = p == periodCache
+                            val preview = if (totalBudget > BigDecimal.ZERO && totalDays > 0) {
+                                budgetForPeriod(totalBudget, totalDays, p)
+                            } else {
+                                BigDecimal.ZERO
+                            }
 
-							CompactPeriodCard(
-								period = p,
-								budgetAmount = preview,
-								currencyFormat = currencyFormat,
-								isSelected = isSelected,
-								onClick = { onPeriodSelected(p) },
-								modifier = Modifier
-									.weight(1f)
-									.testTag(budgetPeriodCardTag(p))
-							)
-						}
-						if (rowPeriods.size == 1) {
-							Spacer(modifier = Modifier.weight(1f))
-						}
-					}
-				}
-			}
-		}
+                            CompactPeriodCard(
+                                period = p,
+                                budgetAmount = preview,
+                                currencyFormat = currencyFormat,
+                                isSelected = isSelected,
+                                onClick = { onPeriodSelected(p) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .testTag(budgetPeriodCardTag(p))
+                            )
+                        }
+                        if (rowPeriods.size == 1) {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        }
 
-		Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
-		HorizontalDivider()
+        HorizontalDivider()
 
-		Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-		if (showFinishEarly) {
-			OutlinedButton(
-				onClick = onFinishEarlyClick,
-				modifier = Modifier
-					.fillMaxWidth()
-					.testTag(BUDGET_PERIOD_FINISH_EARLY_BUTTON_TAG),
-				colors = ButtonDefaults.outlinedButtonColors(
-					contentColor = MaterialTheme.colorScheme.error,
-				),
-			) {
-				Text(
-					text = stringResource(R.string.finalize_period),
-					style = MaterialTheme.typography.labelMediumEmphasized,
-				)
-			}
-		}
-	}
+        if (showFinishEarly) {
+            OutlinedButton(
+                onClick = onFinishEarlyClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(BUDGET_PERIOD_FINISH_EARLY_BUTTON_TAG),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Text(
+                    text = stringResource(R.string.finalize_period),
+                    style = MaterialTheme.typography.labelMediumEmphasized,
+                )
+            }
+        }
+    }
 }
-
 
 @Composable
 fun EditBudgetContent(
-	budgetSettings: BudgetSettings?,
-	onBack: () -> Unit = {},
-	onApply: (BudgetSettings) -> Unit,
-	title: String = stringResource(R.string.new_budget_period),
-	buttonLabel: String = stringResource(R.string.apply),
-	showPreviousValuesChip: Boolean = true,
-	pendingExpensesCount: Int = 0,
+    budgetSettings: BudgetSettings?,
+    onBack: () -> Unit = {},
+    onApply: (BudgetSettings) -> Unit,
+    title: String = stringResource(R.string.new_budget_period),
+    buttonLabel: String = stringResource(R.string.apply),
+    showPreviousValuesChip: Boolean = true,
+    pendingExpensesCount: Int = 0,
 ) {
-	val haptic = LocalHapticFeedback.current
-	val resources = LocalContext.current.resources
-	val dateFormatter = remember {
-		DateTimeFormatter.ofPattern("d MMMM", Locale("es", "ES"))
-	}
+    val haptic = LocalHapticFeedback.current
+    val resources = LocalContext.current.resources
+    val dateFormatter = remember {
+        DateTimeFormatter.ofPattern("d MMMM", Locale("es", "ES"))
+    }
 
-	val pendingNotificationText = resources.getQuantityString(
-		R.plurals.pending_expense, pendingExpensesCount, pendingExpensesCount
-	)
+    val pendingNotificationText = resources.getQuantityString(
+        R.plurals.pending_expense,
+        pendingExpensesCount,
+        pendingExpensesCount
+    )
 
-	val currentBudget = budgetSettings?.totalBudget ?: BigDecimal.ZERO
-	val currentStart = budgetSettings?.startDate ?: LocalDate.now()
-	val currentEnd = budgetSettings?.endDate
-	val currentCurrency = budgetSettings?.currencyCode ?: "USD"
-	val currentStrategy =
-		budgetSettings?.remainingBudgetStrategy ?: RemainingBudgetStrategy.ASK_ALWAYS
+    val currentBudget = budgetSettings?.totalBudget ?: BigDecimal.ZERO
+    val currentStart = budgetSettings?.startDate ?: LocalDate.now()
+    val currentEnd = budgetSettings?.endDate
+    val currentCurrency = budgetSettings?.currencyCode ?: "USD"
+    val currentStrategy =
+        budgetSettings?.remainingBudgetStrategy ?: RemainingBudgetStrategy.ASK_ALWAYS
 
-	val previousPeriodDays = remember(currentStart, currentEnd) {
-		if (currentEnd != null) ChronoUnit.DAYS.between(currentStart, currentEnd).toInt() + 1 else 0
-	}
+    val previousPeriodDays = remember(currentStart, currentEnd) {
+        if (currentEnd != null) ChronoUnit.DAYS.between(currentStart, currentEnd).toInt() + 1 else 0
+    }
 
-	val currencySymbol = remember(currentCurrency) {
-		SupportedCurrency.findByCode(currentCurrency)?.symbol ?: "$"
-	}
+    val currencySymbol = remember(currentCurrency) {
+        SupportedCurrency.findByCode(currentCurrency)?.symbol ?: "$"
+    }
 
-	var budgetText by remember(currentBudget) {
-		mutableStateOf(
-			if (currentBudget > BigDecimal.ZERO) {
-				(currentBudget.multiply(BigDecimal(100)).toBigInteger()).toString()
-			} else ""
-		)
-	}
-	var startCache by remember(currentStart) { mutableStateOf(currentStart) }
-	var endCache by remember(currentEnd) { mutableStateOf(currentEnd) }
-	var currencyCache by remember(currentCurrency) { mutableStateOf(currentCurrency) }
-	var strategyCache by remember(currentStrategy) { mutableStateOf(currentStrategy) }
+    var budgetText by remember(currentBudget) {
+        mutableStateOf(
+            if (currentBudget > BigDecimal.ZERO) {
+                (currentBudget.multiply(BigDecimal(100)).toBigInteger()).toString()
+            } else {
+                ""
+            }
+        )
+    }
+    var startCache by remember(currentStart) { mutableStateOf(currentStart) }
+    var endCache by remember(currentEnd) { mutableStateOf(currentEnd) }
+    var currencyCache by remember(currentCurrency) { mutableStateOf(currentCurrency) }
+    var strategyCache by remember(currentStrategy) { mutableStateOf(currentStrategy) }
 
-	var showDateSelector by remember { mutableStateOf(false) }
-	var showCurrencyPicker by remember { mutableStateOf(false) }
-	var showStrategyPicker by remember { mutableStateOf(false) }
-	var showPreviousValues by remember { mutableStateOf(false) }
+    var showDateSelector by remember { mutableStateOf(false) }
+    var showCurrencyPicker by remember { mutableStateOf(false) }
+    var showStrategyPicker by remember { mutableStateOf(false) }
+    var showPreviousValues by remember { mutableStateOf(false) }
 
-	val parsedBudget = budgetText.toBigDecimalOrNull()?.divide(BigDecimal(100)) ?: BigDecimal.ZERO
-	val totalDays = endCache?.let { ChronoUnit.DAYS.between(startCache, it).toInt() + 1 } ?: 0
-	val canApply = parsedBudget > BigDecimal.ZERO && totalDays > 0
+    val parsedBudget = budgetText.toBigDecimalOrNull()?.divide(BigDecimal(100)) ?: BigDecimal.ZERO
+    val totalDays = endCache?.let { ChronoUnit.DAYS.between(startCache, it).toInt() + 1 } ?: 0
+    val canApply = parsedBudget > BigDecimal.ZERO && totalDays > 0
 
-	val validationMessage = when {
-		parsedBudget <= BigDecimal.ZERO && budgetText.isNotEmpty() -> stringResource(R.string.budget_validation_major_zero)
-		endCache == null -> stringResource(R.string.budget_no_days_defined)
-		totalDays < 1 -> stringResource(R.string.budget_less_than_one_day_validation)
-		else -> null
-	}
+    val validationMessage = when {
+        parsedBudget <= BigDecimal.ZERO && budgetText.isNotEmpty() -> stringResource(
+            R.string.budget_validation_major_zero
+        )
 
-	Column(
-		modifier = Modifier
-			.fillMaxWidth()
-			.padding(horizontal = 16.dp)
-			.navigationBarsPadding(),
-	) {
-		Text(
-			text = title,
-			style = MaterialTheme.typography.titleLargeEmphasized,
-			fontWeight = FontWeight.W500,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 16.dp),
-			textAlign = TextAlign.Center,
-		)
+        endCache == null -> stringResource(R.string.budget_no_days_defined)
+        totalDays < 1 -> stringResource(R.string.budget_less_than_one_day_validation)
+        else -> null
+    }
 
-		Box(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(vertical = 24.dp),
-			contentAlignment = Alignment.Center,
-		) {
-			BasicTextField(
-				value = budgetText,
-				onValueChange = { newValue ->
-					val filtered = newValue.filter { it.isDigit() }
-					budgetText = filtered
-				},
-				visualTransformation = CurrencyAmountInputVisualTransformation(),
-				textStyle = MaterialTheme.typography.titleMediumCondensed.copy(
-					fontSize = 48.sp,
-					fontWeight = FontWeight.Bold,
-					color = MaterialTheme.colorScheme.onSurface,
-					textAlign = TextAlign.Center,
-				),
-				singleLine = true,
-				keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-				cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-				decorationBox = { innerTextField ->
-					Row(
-						modifier = Modifier.fillMaxWidth(),
-						horizontalArrangement = Arrangement.Center,
-						verticalAlignment = Alignment.CenterVertically,
-					) {
-						Box {
-							if (budgetText.isEmpty()) {
-								Text(
-									text = currencySymbol + "",
-									style = MaterialTheme.typography.titleMediumCondensed.copy(
-										fontSize = 48.sp
-									),
-									color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-								)
-							}
-							innerTextField()
-						}
-					}
-				},
-				modifier = Modifier
-					.fillMaxWidth()
-					.testTag(BUDGET_PERIOD_BUDGET_INPUT_TAG),
-			)
-		}
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .navigationBarsPadding(),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLargeEmphasized,
+            fontWeight = FontWeight.W500,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            textAlign = TextAlign.Center,
+        )
 
-		if (showPreviousValuesChip && currentBudget > BigDecimal.ZERO) {
-			Row(
-				modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start
-			) {
-				AssistChip(
-					onClick = { showPreviousValues = !showPreviousValues },
-					modifier = Modifier.testTag(BUDGET_PERIOD_PREVIOUS_VALUES_TAG),
-					label = {
-						Text(
-							stringResource(R.string.previous_values),
-							style = MaterialTheme.typography.labelMediumCondensed
-						)
-					},
-					leadingIcon = {
-						Icon(
-							imageVector = Icons.Rounded.Sync,
-							contentDescription = null,
-							modifier = Modifier.size(18.dp)
-						)
-					},
-					colors = AssistChipDefaults.assistChipColors(
-						containerColor = MaterialTheme.colorScheme.secondaryContainer,
-						labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
-					),
-				)
-			}
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            BasicTextField(
+                value = budgetText,
+                onValueChange = { newValue ->
+                    val filtered = newValue.filter { it.isDigit() }
+                    budgetText = filtered
+                },
+                visualTransformation = CurrencyAmountInputVisualTransformation(),
+                textStyle = MaterialTheme.typography.titleMediumCondensed.copy(
+                    fontSize = 48.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                ),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                decorationBox = { innerTextField ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Box {
+                            if (budgetText.isEmpty()) {
+                                Text(
+                                    text = currencySymbol + "",
+                                    style = MaterialTheme.typography.titleMediumCondensed.copy(
+                                        fontSize = 48.sp
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(BUDGET_PERIOD_BUDGET_INPUT_TAG),
+            )
+        }
 
-			if (showPreviousValues) {
-				Spacer(modifier = Modifier.height(8.dp))
-				Card(
-					modifier = Modifier.fillMaxWidth(),
-					colors = CardDefaults.cardColors(
-						containerColor = colorButton,
-					),
-					shape = RoundedCornerShape(16.dp),
-				) {
-					Row(
-						modifier = Modifier
-							.fillMaxWidth()
-							.padding(16.dp),
-						horizontalArrangement = Arrangement.SpaceBetween,
-						verticalAlignment = Alignment.CenterVertically
-					) {
-						Column(modifier = Modifier.weight(1f)) {
-							Text(
-								text = "Presupuesto",
-								style = MaterialTheme.typography.labelSmallCondensed,
-								color = MaterialTheme.colorScheme.onSurfaceVariant
-							)
-							Text(
-								text = "$currencySymbol${currentBudget.toPlainString()}",
-								style = MaterialTheme.typography.titleMediumCondensed,
-								fontWeight = FontWeight.Bold
-							)
-						}
+        if (showPreviousValuesChip && currentBudget > BigDecimal.ZERO) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start
+            ) {
+                AssistChip(
+                    onClick = { showPreviousValues = !showPreviousValues },
+                    modifier = Modifier.testTag(BUDGET_PERIOD_PREVIOUS_VALUES_TAG),
+                    label = {
+                        Text(
+                            stringResource(R.string.previous_values),
+                            style = MaterialTheme.typography.labelMediumCondensed
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Rounded.Sync,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+                )
+            }
 
-						Column(
-							modifier = Modifier.weight(1f),
-							horizontalAlignment = Alignment.CenterHorizontally
-						) {
-							Text(
-								text = stringResource(R.string.period),
-								style = MaterialTheme.typography.labelSmallCondensed,
-								color = MaterialTheme.colorScheme.onSurfaceVariant
-							)
-							Text(
-								text = "$previousPeriodDays días",
-								style = MaterialTheme.typography.titleMediumCondensed,
-								fontWeight = FontWeight.Bold
-							)
-						}
+            if (showPreviousValues) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = colorButton,
+                    ),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Presupuesto",
+                                style = MaterialTheme.typography.labelSmallCondensed,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "$currencySymbol${currentBudget.toPlainString()}",
+                                style = MaterialTheme.typography.titleMediumCondensed,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
 
-						Box(
-							modifier = Modifier.weight(0.5f), contentAlignment = Alignment.CenterEnd
-						) {
-							IconButton(
-								onClick = {
-									budgetText = if (currentBudget > BigDecimal.ZERO) {
-										(currentBudget.multiply(BigDecimal(100))
-											.toBigInteger()).toString()
-									} else ""
-									if (previousPeriodDays > 0) {
-										startCache = LocalDate.now()
-										endCache = LocalDate.now()
-											.plusDays(previousPeriodDays.toLong() - 1)
-									}
-									currencyCache = currentCurrency
-									strategyCache = currentStrategy
-									showPreviousValues = false
-								}, modifier = Modifier.size(40.dp)
-							) {
-								Icon(
-									imageVector = Icons.Default.Check,
-									contentDescription = "Aplicar",
-								)
-							}
-						}
-					}
-				}
-			}
-		}
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = stringResource(R.string.period),
+                                style = MaterialTheme.typography.labelSmallCondensed,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "$previousPeriodDays días",
+                                style = MaterialTheme.typography.titleMediumCondensed,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
 
-		Spacer(modifier = Modifier.height(16.dp))
+                        Box(
+                            modifier = Modifier.weight(0.5f),
+                            contentAlignment = Alignment.CenterEnd
+                        ) {
+                            IconButton(
+                                onClick = {
+                                    budgetText = if (currentBudget > BigDecimal.ZERO) {
+                                        (
+                                                currentBudget.multiply(BigDecimal(100))
+                                                    .toBigInteger()
+                                                ).toString()
+                                    } else {
+                                        ""
+                                    }
+                                    if (previousPeriodDays > 0) {
+                                        startCache = LocalDate.now()
+                                        endCache = LocalDate.now()
+                                            .plusDays(previousPeriodDays.toLong() - 1)
+                                    }
+                                    currencyCache = currentCurrency
+                                    strategyCache = currentStrategy
+                                    showPreviousValues = false
+                                },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = "Aplicar",
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		SettingsRow(
-			modifier = Modifier.testTag(BUDGET_PERIOD_DATE_ROW_TAG),
-			icon = Icons.Outlined.DateRange,
-			label = if (endCache != null) {
-				"${startCache.format(dateFormatter)} — ${endCache?.format(dateFormatter)}"
-			} else {
-				stringResource(R.string.budget_no_date_defined)
-			},
-			onClick = { showDateSelector = true },
-		)
+        Spacer(modifier = Modifier.height(16.dp))
 
-		if (previousPeriodDays > 0 && endCache == null) {
-			Spacer(modifier = Modifier.height(4.dp))
-			Row(modifier = Modifier.fillMaxWidth()) {
-				AssistChip(
-					onClick = {
-						startCache = LocalDate.now()
-						endCache = LocalDate.now().plusDays(previousPeriodDays.toLong() - 1)
-					},
-					label = {
-						Text(
-							stringResource(
-								R.string.use_previous_period_days, previousPeriodDays
-							)
-						)
-					},
-					leadingIcon = {
-						Icon(
-							Icons.Rounded.Sync,
-							contentDescription = null,
-							modifier = Modifier.size(18.dp)
-						)
-					},
-					colors = AssistChipDefaults.assistChipColors(
-						containerColor = MaterialTheme.colorScheme.secondaryContainer,
-						labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
-					),
-				)
-			}
-		}
+        SettingsRow(
+            modifier = Modifier.testTag(BUDGET_PERIOD_DATE_ROW_TAG),
+            icon = Icons.Outlined.DateRange,
+            label = if (endCache != null) {
+                "${startCache.format(dateFormatter)} — ${endCache?.format(dateFormatter)}"
+            } else {
+                stringResource(R.string.budget_no_date_defined)
+            },
+            onClick = { showDateSelector = true },
+        )
 
-		Spacer(modifier = Modifier.height(8.dp))
+        if (previousPeriodDays > 0 && endCache == null) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                AssistChip(
+                    onClick = {
+                        startCache = LocalDate.now()
+                        endCache = LocalDate.now().plusDays(previousPeriodDays.toLong() - 1)
+                    },
+                    label = {
+                        Text(
+                            stringResource(
+                                R.string.use_previous_period_days,
+                                previousPeriodDays
+                            )
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Rounded.Sync,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+                )
+            }
+        }
 
-		SettingsRow(
-			modifier = Modifier.testTag(BUDGET_PERIOD_STRATEGY_ROW_TAG),
-			icon = Icons.Default.Repartition,
-			label = stringResource(R.string.remaining_budget_label),
-			trailingText = when (strategyCache) {
-				RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always)
-				RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally)
-				RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(R.string.strategy_add_to_first_day)
-			},
-			onClick = { showStrategyPicker = true },
-		)
+        Spacer(modifier = Modifier.height(8.dp))
 
-		Spacer(modifier = Modifier.height(8.dp))
+        SettingsRow(
+            modifier = Modifier.testTag(BUDGET_PERIOD_STRATEGY_ROW_TAG),
+            icon = Icons.Default.Repartition,
+            label = stringResource(R.string.remaining_budget_label),
+            trailingText = when (strategyCache) {
+                RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always)
+                RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally)
+                RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(R.string.strategy_add_to_first_day)
+            },
+            onClick = { showStrategyPicker = true },
+        )
 
-		val currencyDisplay = SupportedCurrency.findByCode(currencyCache)
-		SettingsRow(
-			modifier = Modifier.testTag(BUDGET_PERIOD_CURRENCY_ROW_TAG),
-			icon = Icons.Default.Edit,
-			label = stringResource(R.string.currency_label),
-			trailingText = if (currencyDisplay != null) {
-				"${currencyDisplay.symbol} ${currencyDisplay.code}"
-			} else {
-				currencyCache
-			},
-			onClick = { showCurrencyPicker = true },
-		)
+        Spacer(modifier = Modifier.height(8.dp))
 
-		if (pendingExpensesCount > 0) {
-			Spacer(modifier = Modifier.height(8.dp))
-			Row(
-				modifier = Modifier.fillMaxWidth(),
-				verticalAlignment = Alignment.CenterVertically,
-			) {
-				Icon(
-					imageVector = Icons.Outlined.Info,
-					contentDescription = null,
-					tint = MaterialTheme.colorScheme.outline,
-					modifier = Modifier.size(24.dp),
-				)
-				Spacer(modifier = Modifier.width(8.dp))
-				Text(
-					text = pendingNotificationText,
-					style = MaterialTheme.typography.bodyMediumCondensed,
-					fontWeight = FontWeight.Medium,
-					color = MaterialTheme.colorScheme.outline,
-				)
-			}
-		}
+        val currencyDisplay = SupportedCurrency.findByCode(currencyCache)
+        SettingsRow(
+            modifier = Modifier.testTag(BUDGET_PERIOD_CURRENCY_ROW_TAG),
+            icon = Icons.Default.Edit,
+            label = stringResource(R.string.currency_label),
+            trailingText = if (currencyDisplay != null) {
+                "${currencyDisplay.symbol} ${currencyDisplay.code}"
+            } else {
+                currencyCache
+            },
+            onClick = { showCurrencyPicker = true },
+        )
 
-		if (validationMessage != null) {
-			Spacer(modifier = Modifier.height(16.dp))
-			Row(
-				modifier = Modifier.fillMaxWidth(),
-				verticalAlignment = Alignment.CenterVertically,
-			) {
-				Icon(
-					imageVector = Icons.Outlined.Info,
-					contentDescription = null,
-					tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-					modifier = Modifier.size(20.dp),
-				)
-				Spacer(modifier = Modifier.width(8.dp))
-				Text(
-					text = validationMessage,
-					style = MaterialTheme.typography.bodySmall,
-					color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-				)
-			}
-		}
+        if (pendingExpensesCount > 0) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = pendingNotificationText,
+                    style = MaterialTheme.typography.bodyMediumCondensed,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
 
-		Spacer(modifier = Modifier.height(24.dp))
+        if (validationMessage != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = validationMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                )
+            }
+        }
 
-		Button(
-			onClick = {
-				haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-				val periodDays =
-					endCache?.let { ChronoUnit.DAYS.between(startCache, it).toInt() + 1 } ?: 1
-				val period = when {
-					periodDays >= 30 -> BudgetPeriod.MONTHLY
-					periodDays >= 14 -> BudgetPeriod.BIWEEKLY
-					periodDays >= 7 -> BudgetPeriod.WEEKLY
-					else -> BudgetPeriod.DAILY
-				}
-				val newSettings = (budgetSettings ?: BudgetSettings.DEFAULT).copy(
-					totalBudget = parsedBudget,
-					startDate = startCache,
-					endDate = endCache,
-					daysInPeriod = periodDays,
-					currencyCode = currencyCache,
-					remainingBudgetStrategy = strategyCache,
-					period = period,
-				)
-				logcat {
-					"Apply tapped: budget=$parsedBudget, start=$startCache, end=$endCache, periodDays=$periodDays, resolvedPeriod=$period, strategy=$strategyCache, currency=$currencyCache"
-				}
-				onApply(newSettings)
-			},
-			modifier = Modifier
-				.fillMaxWidth()
-				.heightIn(min = 56.dp)
-				.testTag(BUDGET_PERIOD_APPLY_BUTTON_TAG),
-			enabled = canApply,
-		) {
-			Text(buttonLabel, style = MaterialTheme.typography.labelMediumEmphasized)
-		}
-	}
+        Spacer(modifier = Modifier.height(24.dp))
 
-	AnimatedVisibility(
-		visible = showDateSelector,
-		enter = fadeIn(animationSpec = tween(220)) + slideInHorizontally(
-			animationSpec = tween(300),
-			initialOffsetX = { fullWidth -> fullWidth },
-		),
-		exit = fadeOut(animationSpec = tween(160)) + slideOutHorizontally(
-			animationSpec = tween(240),
-			targetOffsetX = { fullWidth -> fullWidth },
-		),
-	) {
-		FinishDateSelector(
-			totalBudget = parsedBudget,
-			currencyCode = currencyCache,
-			onBackPressed = { showDateSelector = false },
-			onApply = { newStart, newEnd, selectedPeriod ->
-				startCache = newStart
-				endCache = newEnd
-				showDateSelector = false
-			},
-		)
-	}
+        Button(
+            onClick = {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                val periodDays =
+                    endCache?.let { ChronoUnit.DAYS.between(startCache, it).toInt() + 1 } ?: 1
+                val period = when {
+                    periodDays >= 30 -> BudgetPeriod.MONTHLY
+                    periodDays >= 14 -> BudgetPeriod.BIWEEKLY
+                    periodDays >= 7 -> BudgetPeriod.WEEKLY
+                    else -> BudgetPeriod.DAILY
+                }
+                val newSettings = (budgetSettings ?: BudgetSettings.DEFAULT).copy(
+                    totalBudget = parsedBudget,
+                    startDate = startCache,
+                    endDate = endCache,
+                    daysInPeriod = periodDays,
+                    currencyCode = currencyCache,
+                    remainingBudgetStrategy = strategyCache,
+                    period = period,
+                )
+                logcat {
+                    "Apply tapped: budget=$parsedBudget, start=$startCache, end=$endCache, periodDays=$periodDays, resolvedPeriod=$period, strategy=$strategyCache, currency=$currencyCache"
+                }
+                onApply(newSettings)
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 56.dp)
+                .testTag(BUDGET_PERIOD_APPLY_BUTTON_TAG),
+            enabled = canApply,
+        ) {
+            Text(buttonLabel, style = MaterialTheme.typography.labelMediumEmphasized)
+        }
+    }
 
-	if (showCurrencyPicker) {
-		CurrencyPickerDialog(
-			currentCode = currencyCache,
-			onDismiss = { showCurrencyPicker = false },
-			onSelect = { code ->
-				currencyCache = code
-				showCurrencyPicker = false
-			})
-	}
+    AnimatedVisibility(
+        visible = showDateSelector,
+        enter = fadeIn(animationSpec = tween(220)) + slideInHorizontally(
+            animationSpec = tween(300),
+            initialOffsetX = { fullWidth -> fullWidth },
+        ),
+        exit = fadeOut(animationSpec = tween(160)) + slideOutHorizontally(
+            animationSpec = tween(240),
+            targetOffsetX = { fullWidth -> fullWidth },
+        ),
+    ) {
+        FinishDateSelector(
+            totalBudget = parsedBudget,
+            currencyCode = currencyCache,
+            onBackPressed = { showDateSelector = false },
+            onApply = { newStart, newEnd, selectedPeriod ->
+                startCache = newStart
+                endCache = newEnd
+                showDateSelector = false
+            },
+        )
+    }
 
-	if (showStrategyPicker) {
-		StrategyPickerDialog(
-			currentStrategy = strategyCache,
-			onDismiss = { showStrategyPicker = false },
-			onSelect = { strategy ->
-				strategyCache = strategy
-				showStrategyPicker = false
-			})
-	}
+    if (showCurrencyPicker) {
+        CurrencyPickerDialog(
+            currentCode = currencyCache,
+            onDismiss = { showCurrencyPicker = false },
+            onSelect = { code ->
+                currencyCache = code
+                showCurrencyPicker = false
+            }
+        )
+    }
+
+    if (showStrategyPicker) {
+        StrategyPickerDialog(
+            currentStrategy = strategyCache,
+            onDismiss = { showStrategyPicker = false },
+            onSelect = { strategy ->
+                strategyCache = strategy
+                showStrategyPicker = false
+            }
+        )
+    }
 }
 
 @Composable
 private fun SettingsRow(
-	icon: ImageVector,
-	label: String,
-	trailingText: String? = null,
-	onClick: () -> Unit,
-	modifier: Modifier = Modifier,
+    icon: ImageVector,
+    label: String,
+    trailingText: String? = null,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-	Row(
-		modifier = modifier
-			.fillMaxWidth()
-			.clip(RoundedCornerShape(12.dp))
-			.clickable(onClick = onClick)
-			.padding(vertical = 14.dp),
-		verticalAlignment = Alignment.CenterVertically,
-	) {
-		Icon(
-			imageVector = icon,
-			contentDescription = null,
-			tint = MaterialTheme.colorScheme.onSurfaceVariant,
-			modifier = Modifier.size(24.dp),
-		)
-		Spacer(modifier = Modifier.width(16.dp))
-		Text(
-			text = label,
-			style = MaterialTheme.typography.bodyLarge,
-			fontWeight = FontWeight.Medium,
-			modifier = Modifier.weight(1f),
-		)
-		if (trailingText != null) {
-			Text(
-				text = trailingText,
-				style = MaterialTheme.typography.bodyMedium,
-				color = MaterialTheme.colorScheme.onSurfaceVariant,
-			)
-		}
-	}
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f),
+        )
+        if (trailingText != null) {
+            Text(
+                text = trailingText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }
 
 @Composable
 private fun CurrencyPickerDialog(
-	currentCode: String,
-	onDismiss: () -> Unit,
-	onSelect: (String) -> Unit,
+    currentCode: String,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit,
 ) {
-	AlertDialog(
-		onDismissRequest = onDismiss,
-		title = {
-			Text(
-				stringResource(R.string.select_currency),
-				style = MaterialTheme.typography.titleLargeEmphasized
-			)
-		},
-		text = {
-			Column(
-				modifier = Modifier
-					.heightIn(max = 400.dp)
-					.verticalScroll(rememberScrollState()),
-				verticalArrangement = Arrangement.spacedBy(2.dp),
-			) {
-				SupportedCurrency.ALL.forEach { currency ->
-					val isSelected = currency.code == currentCode
-					Row(
-						modifier = Modifier
-							.fillMaxWidth()
-							.clip(RoundedCornerShape(8.dp))
-							.clickable { onSelect(currency.code) }
-							.padding(vertical = 12.dp, horizontal = 8.dp),
-						verticalAlignment = Alignment.CenterVertically,
-					) {
-						Text(
-							text = currency.symbol,
-							style = MaterialTheme.typography.titleMediumEmphasized,
-							fontWeight = FontWeight.Bold,
-							modifier = Modifier.width(40.dp),
-						)
-						Column(modifier = Modifier.weight(1f)) {
-							Text(
-								text = currency.code,
-								style = MaterialTheme.typography.bodyMediumEmphasized,
-								fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-								color = if (isSelected) MaterialTheme.colorScheme.primary
-								else MaterialTheme.colorScheme.onSurface,
-							)
-							Text(
-								text = currency.name,
-								style = MaterialTheme.typography.bodySmallCondensed,
-								color = MaterialTheme.colorScheme.onSurfaceVariant,
-							)
-						}
-						if (isSelected) {
-							Icon(
-								imageVector = Icons.Default.Check,
-								contentDescription = stringResource(R.string.currency_selected),
-								tint = MaterialTheme.colorScheme.primary,
-								modifier = Modifier.size(20.dp),
-							)
-						}
-					}
-				}
-			}
-		},
-		confirmButton = {
-			TextButton(onClick = onDismiss) {
-				Text(
-					stringResource(R.string.close),
-					style = MaterialTheme.typography.labelMediumEmphasized
-				)
-			}
-		},
-	)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(R.string.select_currency),
+                style = MaterialTheme.typography.titleLargeEmphasized
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                SupportedCurrency.ALL.forEach { currency ->
+                    val isSelected = currency.code == currentCode
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable { onSelect(currency.code) }
+                            .padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = currency.symbol,
+                            style = MaterialTheme.typography.titleMediumEmphasized,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.width(40.dp),
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = currency.code,
+                                style = MaterialTheme.typography.bodyMediumEmphasized,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                color = if (isSelected) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                            )
+                            Text(
+                                text = currency.name,
+                                style = MaterialTheme.typography.bodySmallCondensed,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (isSelected) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = stringResource(R.string.currency_selected),
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    stringResource(R.string.close),
+                    style = MaterialTheme.typography.labelMediumEmphasized
+                )
+            }
+        },
+    )
 }
 
 @Composable
 private fun StrategyPickerDialog(
-	currentStrategy: RemainingBudgetStrategy,
-	onDismiss: () -> Unit,
-	onSelect: (RemainingBudgetStrategy) -> Unit,
+    currentStrategy: RemainingBudgetStrategy,
+    onDismiss: () -> Unit,
+    onSelect: (RemainingBudgetStrategy) -> Unit,
 ) {
-	val strategies = listOf(
-		RemainingBudgetStrategy.ASK_ALWAYS,
-		RemainingBudgetStrategy.SPLIT_EQUALLY,
-		RemainingBudgetStrategy.ADD_TO_FIRST_DAY,
-	)
+    val strategies = listOf(
+        RemainingBudgetStrategy.ASK_ALWAYS,
+        RemainingBudgetStrategy.SPLIT_EQUALLY,
+        RemainingBudgetStrategy.ADD_TO_FIRST_DAY,
+    )
 
-	AlertDialog(
-		onDismissRequest = onDismiss,
-		title = {
-			Text(
-				stringResource(R.string.strategy_dialog_title),
-				style = MaterialTheme.typography.titleLargeEmphasized
-			)
-		},
-		text = {
-			Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-				Text(
-					text = stringResource(R.string.strategy_dialog_description),
-					style = MaterialTheme.typography.bodySmallCondensed,
-					color = MaterialTheme.colorScheme.onSurfaceVariant,
-				)
-				Spacer(modifier = Modifier.height(4.dp))
-				strategies.forEach { strategy ->
-					val isSelected = strategy == currentStrategy
-					val title = when (strategy) {
-						RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always)
-						RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally)
-						RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(R.string.strategy_add_to_first_day)
-					}
-					val description = when (strategy) {
-						RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always_desc)
-						RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally_desc)
-						RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(R.string.strategy_add_to_first_day_desc)
-					}
-					OutlinedCard(
-						onClick = { onSelect(strategy) },
-						modifier = Modifier.fillMaxWidth(),
-						border = BorderStroke(
-							width = if (isSelected) 2.dp else 1.dp,
-							color = if (isSelected) MaterialTheme.colorScheme.primary
-							else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-						),
-						colors = CardDefaults.outlinedCardColors(
-							containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(
-								alpha = 0.3f
-							)
-							else MaterialTheme.colorScheme.surface,
-						),
-					) {
-						Column(modifier = Modifier.padding(12.dp)) {
-							Row(verticalAlignment = Alignment.CenterVertically) {
-								Text(
-									text = title,
-									style = MaterialTheme.typography.bodyMediumEmphasized,
-									fontWeight = FontWeight.Medium,
-									modifier = Modifier.weight(1f),
-								)
-								if (isSelected) {
-									Icon(
-										imageVector = Icons.Default.Check,
-										contentDescription = null,
-										tint = MaterialTheme.colorScheme.primary,
-										modifier = Modifier.size(18.dp),
-									)
-								}
-							}
-							Text(
-								text = description,
-								style = MaterialTheme.typography.bodySmall,
-								color = MaterialTheme.colorScheme.onSurfaceVariant,
-							)
-						}
-					}
-				}
-			}
-		},
-		confirmButton = {
-			TextButton(onClick = onDismiss) {
-				Text(
-					stringResource(R.string.close),
-					style = MaterialTheme.typography.labelMediumEmphasized
-				)
-			}
-		},
-	)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(R.string.strategy_dialog_title),
+                style = MaterialTheme.typography.titleLargeEmphasized
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.strategy_dialog_description),
+                    style = MaterialTheme.typography.bodySmallCondensed,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                strategies.forEach { strategy ->
+                    val isSelected = strategy == currentStrategy
+                    val title = when (strategy) {
+                        RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always)
+                        RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally)
+                        RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(R.string.strategy_add_to_first_day)
+                    }
+                    val description = when (strategy) {
+                        RemainingBudgetStrategy.ASK_ALWAYS -> stringResource(R.string.strategy_ask_always_desc)
+                        RemainingBudgetStrategy.SPLIT_EQUALLY -> stringResource(R.string.strategy_split_equally_desc)
+                        RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> stringResource(
+                            R.string.strategy_add_to_first_day_desc
+                        )
+                    }
+                    OutlinedCard(
+                        onClick = { onSelect(strategy) },
+                        modifier = Modifier.fillMaxWidth(),
+                        border = BorderStroke(
+                            width = if (isSelected) 2.dp else 1.dp,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                            },
+                        ),
+                        colors = CardDefaults.outlinedCardColors(
+                            containerColor = if (isSelected) {
+                                MaterialTheme.colorScheme.primaryContainer.copy(
+                                    alpha = 0.3f
+                                )
+                            } else {
+                                MaterialTheme.colorScheme.surface
+                            },
+                        ),
+                    ) {
+                        Column(modifier = Modifier.padding(12.dp)) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = title,
+                                    style = MaterialTheme.typography.bodyMediumEmphasized,
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (isSelected) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            }
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    stringResource(R.string.close),
+                    style = MaterialTheme.typography.labelMediumEmphasized
+                )
+            }
+        },
+    )
 }
 
 @Composable
 private fun CompactPeriodCard(
-	period: BudgetPeriod,
-	budgetAmount: BigDecimal,
-	currencyFormat: NumberFormat,
-	isSelected: Boolean,
-	onClick: () -> Unit,
-	modifier: Modifier = Modifier,
+    period: BudgetPeriod,
+    budgetAmount: BigDecimal,
+    currencyFormat: NumberFormat,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-	val backgroundColor = if (isSelected) {
-		MaterialTheme.colorScheme.primaryContainer
-	} else {
-		MaterialTheme.colorScheme.surface
-	}
-	val borderColor = if (isSelected) {
-		MaterialTheme.colorScheme.primary
-	} else {
-		MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
-	}
-	val textColor = if (isSelected) {
-		MaterialTheme.colorScheme.onPrimaryContainer
-	} else {
-		MaterialTheme.colorScheme.onSurface
-	}
+    val backgroundColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val borderColor = if (isSelected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+    }
+    val textColor = if (isSelected) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
 
-	OutlinedCard(
-		modifier = modifier.clickable(onClick = onClick),
-		onClick = onClick,
-		border = BorderStroke(
-			width = if (isSelected) 2.dp else 1.dp, color = borderColor
-		),
-		colors = CardDefaults.outlinedCardColors(containerColor = backgroundColor),
-	) {
-		Column(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(12.dp),
-			verticalArrangement = Arrangement.Center
-		) {
-			Text(
-				text = when (period) {
-					BudgetPeriod.DAILY -> stringResource(R.string.budget_period_daily)
-					BudgetPeriod.WEEKLY -> stringResource(R.string.budget_period_weekly)
-					BudgetPeriod.BIWEEKLY -> stringResource(R.string.budget_period_biweekly)
-					BudgetPeriod.MONTHLY -> stringResource(R.string.budget_period_monthly)
-				},
-				style = if (isSelected) MaterialTheme.typography.bodySmallEmphasized else MaterialTheme.typography.bodySmallCondensed,
-				fontWeight = FontWeight.Medium,
-				color = textColor
-			)
+    OutlinedCard(
+        modifier = modifier.clickable(onClick = onClick),
+        onClick = onClick,
+        border = BorderStroke(
+            width = if (isSelected) 2.dp else 1.dp,
+            color = borderColor
+        ),
+        colors = CardDefaults.outlinedCardColors(containerColor = backgroundColor),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = when (period) {
+                    BudgetPeriod.DAILY -> stringResource(R.string.budget_period_daily)
+                    BudgetPeriod.WEEKLY -> stringResource(R.string.budget_period_weekly)
+                    BudgetPeriod.BIWEEKLY -> stringResource(R.string.budget_period_biweekly)
+                    BudgetPeriod.MONTHLY -> stringResource(R.string.budget_period_monthly)
+                },
+                style = if (isSelected) {
+                    MaterialTheme.typography.bodySmallEmphasized
+                } else {
+                    MaterialTheme.typography.bodySmallCondensed
+                },
+                fontWeight = FontWeight.Medium,
+                color = textColor
+            )
 
-			Text(
-				text = currencyFormat.format(budgetAmount),
-				style = MaterialTheme.typography.bodySmallCondensed,
-				fontWeight = FontWeight.Bold,
-				color = if (isSelected) MaterialTheme.colorScheme.primary else textColor.copy(alpha = 0.7f),
-				modifier = Modifier.censor()
-			)
-		}
-	}
+            Text(
+                text = currencyFormat.format(budgetAmount),
+                style = MaterialTheme.typography.bodySmallCondensed,
+                fontWeight = FontWeight.Bold,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else textColor.copy(alpha = 0.7f),
+                modifier = Modifier.censor()
+            )
+        }
+    }
 }
 
 @Preview(
-	showBackground = true,
-	uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
 )
 @Composable
 private fun BudgetPeriodSheetPreview() {
-	MinusTheme {
-		Surface {
-			BudgetPeriodSheet(
-				budgetSettings = BudgetSettings(
-					totalBudget = BigDecimal("17725"),
-					period = BudgetPeriod.DAILY,
-					startDate = LocalDate.now().minusDays(29),
-					endDate = LocalDate.now(),
-					currencyCode = "MXN",
-					daysInPeriod = 30,
-					rollOverEnabled = false,
-					rollOverLimit = null,
-					rollOverCarryForward = false
-				),
-				budgetState = BudgetState(
-					remainingToday = BigDecimal("17675"),
-					totalSpentToday = BigDecimal("5072"),
-					dailyBudget = BigDecimal("5900"),
-					daysRemaining = 1,
-					progress = 0.03f,
-					isOverBudget = false,
-					totalBudget = BigDecimal("17725"),
-					totalSpentInPeriod = BigDecimal("5072"),
-				),
-				selectedPeriod = BudgetPeriod.DAILY,
-				currencyCode = "MXN",
-				onPeriodSelected = { },
-				onSaveBudget = { },
-				onFinishEarly = { })
-		}
-	}
+    MinusTheme {
+        Surface {
+            BudgetPeriodSheet(
+                budgetSettings = BudgetSettings(
+                    totalBudget = BigDecimal("17725"),
+                    period = BudgetPeriod.DAILY,
+                    startDate = LocalDate.now().minusDays(29),
+                    endDate = LocalDate.now(),
+                    currencyCode = "MXN",
+                    daysInPeriod = 30,
+                    rollOverEnabled = false,
+                    rollOverLimit = null,
+                    rollOverCarryForward = false
+                ),
+                budgetState = BudgetState(
+                    remainingToday = BigDecimal("17675"),
+                    totalSpentToday = BigDecimal("5072"),
+                    dailyBudget = BigDecimal("5900"),
+                    daysRemaining = 1,
+                    progress = 0.03f,
+                    isOverBudget = false,
+                    totalBudget = BigDecimal("17725"),
+                    totalSpentInPeriod = BigDecimal("5072"),
+                ),
+                selectedPeriod = BudgetPeriod.DAILY,
+                currencyCode = "MXN",
+                onPeriodSelected = { },
+                onSaveBudget = { },
+                onFinishEarly = { }
+            )
+        }
+    }
 }
 
 @Preview(
-	showBackground = true, device = "spec:width=1080px,height=2340px,dpi=440"
+    showBackground = true,
+    device = "spec:width=1080px,height=2340px,dpi=440"
 )
 @Composable
 private fun EditModePreview() {
-	MinusTheme {
-		Surface {
-			EditBudgetContent(
-				budgetSettings = BudgetSettings(
-					totalBudget = BigDecimal("17725"),
-					period = BudgetPeriod.DAILY,
-					startDate = LocalDate.now().minusDays(29),
-					endDate = LocalDate.now(),
-					currencyCode = "MXN",
-					daysInPeriod = 30,
-				),
-				onBack = { },
-				onApply = { },
-				pendingExpensesCount = 3,
-			)
-		}
-	}
+    MinusTheme {
+        Surface {
+            EditBudgetContent(
+                budgetSettings = BudgetSettings(
+                    totalBudget = BigDecimal("17725"),
+                    period = BudgetPeriod.DAILY,
+                    startDate = LocalDate.now().minusDays(29),
+                    endDate = LocalDate.now(),
+                    currencyCode = "MXN",
+                    daysInPeriod = 30,
+                ),
+                onBack = { },
+                onApply = { },
+                pendingExpensesCount = 3,
+            )
+        }
+    }
 }
 
-
 @Preview(
-	showSystemUi = false,
-	showBackground = true,
-	device = "spec:width=1080px,height=2340px,dpi=440,cutout=double"
+    showSystemUi = false,
+    showBackground = true,
+    device = "spec:width=1080px,height=2340px,dpi=440,cutout=double"
 )
 @Composable
 private fun EditEmptyModePreview() {
-	MinusTheme {
-		EditBudgetContent(
-			budgetSettings = BudgetSettings(
-				totalBudget = BigDecimal("0"),
-				period = BudgetPeriod.DAILY,
-				startDate = LocalDate.now().minusDays(29),
-				endDate = LocalDate.now(),
-				currencyCode = "MXN",
-				daysInPeriod = 30,
-			),
-			onBack = { },
-			onApply = { },
-		)
-	}
+    MinusTheme {
+        EditBudgetContent(
+            budgetSettings = BudgetSettings(
+                totalBudget = BigDecimal("0"),
+                period = BudgetPeriod.DAILY,
+                startDate = LocalDate.now().minusDays(29),
+                endDate = LocalDate.now(),
+                currencyCode = "MXN",
+                daysInPeriod = 30,
+            ),
+            onBack = { },
+            onApply = { },
+        )
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingScreen.kt
@@ -13,12 +13,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.LocalWindowInsets
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
@@ -28,80 +32,103 @@ import com.serranoie.app.minus.presentation.ui.theme.component.NumberedRow
 
 @Composable
 fun OnboardingScreen(
-	onSetBudget: () -> Unit = {}, onClose: () -> Unit = {}, onOnboardingComplete: () -> Unit = {}
+    viewModel: OnboardingViewModel? = null,
+    onOnboardingCompleted: () -> Unit = {},
 ) {
-	WelcomeStep(
-		onSetBudget = onSetBudget,
-	)
+    val resolvedViewModel = viewModel ?: hiltViewModel()
+    val state by resolvedViewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(resolvedViewModel) {
+        resolvedViewModel.effects.collect { effect ->
+            when (effect) {
+                OnboardingUiEffect.OnboardingCompleted -> onOnboardingCompleted()
+                is OnboardingUiEffect.OnboardingFailed -> {
+                    // Failures are also reflected in [OnboardingUiState.error];
+                    // the parent screen (or activity) may surface them.
+                }
+            }
+        }
+    }
+
+    WelcomeStep(
+        onSetBudget = { resolvedViewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding) },
+    )
 }
 
 @Composable
 private fun WelcomeStep(
-	onSetBudget: () -> Unit = {},
+    onSetBudget: () -> Unit = {},
 ) {
-	val localBottomSheetScrollState = LocalBottomSheetScrollState.current
-	val statusBarHeight = LocalWindowInsets.current.calculateTopPadding()
-	val navigationBarHeight =
-		LocalWindowInsets.current.calculateBottomPadding().coerceAtLeast(16.dp)
-	Surface(
-		modifier = Modifier
-			.fillMaxSize()
-			.padding(top = if (localBottomSheetScrollState.topPadding > 0.dp) localBottomSheetScrollState.topPadding else statusBarHeight)
-	) {
-		Column(
-			modifier = Modifier
-				.fillMaxSize()
-				.verticalScroll(rememberScrollState())
-				.padding(start = 24.dp, end = 24.dp, bottom = navigationBarHeight),
-			horizontalAlignment = Alignment.CenterHorizontally,
-		) {
-			Text(
-				text = stringResource(R.string.onboarding_welcome_title),
-				style = MaterialTheme.typography.headlineMediumEmphasized,
-				modifier = Modifier.padding(top = 16.dp),
-			)
-			Spacer(Modifier.height(4.dp))
-			Text(
-				text = stringResource(R.string.onboarding_welcome_subtitle),
-				style = MaterialTheme.typography.titleMediumEmphasized,
-				textAlign = TextAlign.Center,
-			)
-			Spacer(Modifier.height(16.dp))
-			Column(
-				modifier = Modifier.fillMaxWidth(),
-				horizontalAlignment = Alignment.Start,
-			) {
-				NumberedRow(
-					number = 1,
-					title = stringResource(R.string.onboarding_step_1_title),
-					subtitle = stringResource(R.string.onboarding_step_1_subtitle),
-				)
-				NumberedRow(
-					number = 2,
-					title = stringResource(R.string.onboarding_step_2_title),
-					subtitle = stringResource(R.string.onboarding_step_2_subtitle),
-				)
-				NumberedRow(
-					number = 3,
-					title = stringResource(R.string.onboarding_step_3_title),
-					subtitle = stringResource(R.string.onboarding_step_3_subtitle),
-				)
-			}
-			Spacer(Modifier.height(48.dp))
-			DescriptionButton(
-				title = { Text(stringResource(R.string.onboarding_set_budget_button)) },
-				contentPadding = PaddingValues(horizontal = 24.dp, vertical = 32.dp),
-				onClick = {
-					onSetBudget()
-				})
-		}
-	}
+    val localBottomSheetScrollState = LocalBottomSheetScrollState.current
+    val statusBarHeight = LocalWindowInsets.current.calculateTopPadding()
+    val navigationBarHeight =
+        LocalWindowInsets.current.calculateBottomPadding().coerceAtLeast(16.dp)
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                top = if (localBottomSheetScrollState.topPadding > 0.dp) {
+                    localBottomSheetScrollState.topPadding
+                } else {
+                    statusBarHeight
+                }
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(start = 24.dp, end = 24.dp, bottom = navigationBarHeight),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_welcome_title),
+                style = MaterialTheme.typography.headlineMediumEmphasized,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.onboarding_welcome_subtitle),
+                style = MaterialTheme.typography.titleMediumEmphasized,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(16.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.Start,
+            ) {
+                NumberedRow(
+                    number = 1,
+                    title = stringResource(R.string.onboarding_step_1_title),
+                    subtitle = stringResource(R.string.onboarding_step_1_subtitle),
+                )
+                NumberedRow(
+                    number = 2,
+                    title = stringResource(R.string.onboarding_step_2_title),
+                    subtitle = stringResource(R.string.onboarding_step_2_subtitle),
+                )
+                NumberedRow(
+                    number = 3,
+                    title = stringResource(R.string.onboarding_step_3_title),
+                    subtitle = stringResource(R.string.onboarding_step_3_subtitle),
+                )
+            }
+            Spacer(Modifier.height(48.dp))
+            DescriptionButton(
+                title = { Text(stringResource(R.string.onboarding_set_budget_button)) },
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 32.dp),
+                onClick = {
+                    onSetBudget()
+                }
+            )
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun OnboardingScreenPreview() {
-	MinusTheme {
-		OnboardingScreen()
-	}
+    MinusTheme {
+        OnboardingScreen()
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingScreen.kt
@@ -1,45 +1,69 @@
 package com.serranoie.app.minus.presentation.ui.onboarding
 
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.LocalWindowInsets
+import com.serranoie.app.minus.presentation.ui.analytics.Size
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.presentation.ui.theme.bodyMediumCondensed
 import com.serranoie.app.minus.presentation.ui.theme.component.DescriptionButton
 import com.serranoie.app.minus.presentation.ui.theme.component.LocalBottomSheetScrollState
-import com.serranoie.app.minus.presentation.ui.theme.component.NumberedRow
+import com.serranoie.app.minus.presentation.util.combineColors
 
 @Composable
 fun OnboardingScreen(
-    viewModel: OnboardingViewModel? = null,
+    viewModel: OnboardingViewModel = hiltViewModel(),
     onOnboardingCompleted: () -> Unit = {},
 ) {
-    val resolvedViewModel = viewModel ?: hiltViewModel()
-    val state by resolvedViewModel.uiState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(resolvedViewModel) {
-        resolvedViewModel.effects.collect { effect ->
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
             when (effect) {
                 OnboardingUiEffect.OnboardingCompleted -> onOnboardingCompleted()
                 is OnboardingUiEffect.OnboardingFailed -> {
@@ -50,19 +74,48 @@ fun OnboardingScreen(
         }
     }
 
-    WelcomeStep(
-        onSetBudget = { resolvedViewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding) },
+    OnboardingScreenContent(
+        onContinue = { viewModel.processIntent(OnboardingUiIntent.OnWelcomeDismissed) },
     )
 }
 
 @Composable
+internal fun OnboardingScreenContent(
+    onContinue: () -> Unit = {},
+) {
+    WelcomeStep(
+        onContinue = onContinue,
+    )
+}
+
+private data class StepItem(
+    val number: Int,
+    val titleRes: Int,
+    val subtitleRes: Int,
+)
+
+private val onboardingSteps = listOf(
+    StepItem(1, R.string.onboarding_step_1_title, R.string.onboarding_step_1_subtitle),
+    StepItem(2, R.string.onboarding_step_2_title, R.string.onboarding_step_2_subtitle),
+    StepItem(3, R.string.onboarding_step_3_title, R.string.onboarding_step_3_subtitle),
+    StepItem(4, R.string.onboarding_step_4_title, R.string.onboarding_step_4_subtitle),
+    StepItem(5, R.string.onboarding_step_5_title, R.string.onboarding_step_5_subtitle),
+    StepItem(6, R.string.onboarding_step_6_title, R.string.onboarding_step_6_subtitle),
+)
+
+@Composable
 private fun WelcomeStep(
-    onSetBudget: () -> Unit = {},
+    onContinue: () -> Unit = {},
 ) {
     val localBottomSheetScrollState = LocalBottomSheetScrollState.current
     val statusBarHeight = LocalWindowInsets.current.calculateTopPadding()
     val navigationBarHeight =
         LocalWindowInsets.current.calculateBottomPadding().coerceAtLeast(16.dp)
+
+    val scrollState = rememberScrollState()
+    val localDensity = LocalDensity.current
+    var pageSize by remember { mutableStateOf(Size(0.dp, 0.dp)) }
+
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -74,61 +127,236 @@ private fun WelcomeStep(
                 }
             )
     ) {
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(start = 24.dp, end = 24.dp, bottom = navigationBarHeight),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .onGloballyPositioned {
+                    pageSize = Size(
+                        width = with(localDensity) { it.size.width.toDp() },
+                        height = with(localDensity) { it.size.height.toDp() }
+                    )
+                }
         ) {
-            Text(
-                text = stringResource(R.string.onboarding_welcome_title),
-                style = MaterialTheme.typography.headlineMediumEmphasized,
-                modifier = Modifier.padding(top = 16.dp),
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.onboarding_welcome_subtitle),
-                style = MaterialTheme.typography.titleMediumEmphasized,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(Modifier.height(16.dp))
-            Column(
+            WelcomeBackground(scrollState = scrollState, pageSize = pageSize)
+
+            Column(modifier = Modifier.fillMaxSize()) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .verticalScroll(scrollState)
+                        .padding(horizontal = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(Modifier.height(20.dp))
+                    Text(
+                        text = stringResource(R.string.onboarding_welcome_title),
+                        style = MaterialTheme.typography.headlineLargeEmphasized,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.onboarding_welcome_intro),
+                        style = MaterialTheme.typography.bodyMediumCondensed,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+                    StepGrid(steps = onboardingSteps)
+
+                    Spacer(Modifier.height(24.dp))
+                }
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = navigationBarHeight),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    DescriptionButton(
+                        title = { Text(stringResource(R.string.onboarding_set_budget_button)) },
+                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+                        onClick = { onContinue() },
+                    )
+                    Spacer(Modifier.height(12.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WelcomeBackground(
+    scrollState: ScrollState,
+    pageSize: Size,
+) {
+    val halfWidth = pageSize.width / 2
+    val halfHeight = pageSize.height / 2
+    val scroll = with(LocalDensity.current) { scrollState.value.toDp() }
+
+    val starColor = combineColors(
+        MaterialTheme.colorScheme.secondaryContainer,
+        MaterialTheme.colorScheme.surface,
+        0.5f,
+    )
+
+    val infiniteTransition = rememberInfiniteTransition(label = "backgroundTransitions")
+
+    val angle1 by infiniteTransition.animateFloat(
+        initialValue = -20f,
+        targetValue = 20f,
+        animationSpec = infiniteRepeatable(tween(10000), RepeatMode.Reverse),
+        label = "angle1"
+    )
+
+    val angle2 by infiniteTransition.animateFloat(
+        initialValue = -50f,
+        targetValue = 50f,
+        animationSpec = infiniteRepeatable(tween(18000), RepeatMode.Reverse),
+        label = "angle2"
+    )
+
+    val angle3 by infiniteTransition.animateFloat(
+        initialValue = 30f,
+        targetValue = -30f,
+        animationSpec = infiniteRepeatable(tween(14000), RepeatMode.Reverse),
+        label = "angle3"
+    )
+
+    val angle4 by infiniteTransition.animateFloat(
+        initialValue = 10f,
+        targetValue = 170f,
+        animationSpec = infiniteRepeatable(tween(25000), RepeatMode.Reverse),
+        label = "angle4"
+    )
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Shape 1: Top Right
+        Icon(
+            modifier = Modifier
+                .requiredSize(256.dp)
+                .absoluteOffset(x = halfWidth * 0.8f, y = -halfHeight * 0.7f + scroll * 0.35f)
+                .rotate(angle1)
+                .zIndex(-1f),
+            painter = painterResource(R.drawable.shape_soft_star_1),
+            tint = starColor,
+            contentDescription = null,
+        )
+
+        // Shape 2: Bottom Left
+        Icon(
+            modifier = Modifier
+                .requiredSize(256.dp)
+                .absoluteOffset(x = -halfWidth * 0.8f, y = halfHeight * 0.6f + scroll * 0.6f)
+                .rotate(angle2)
+                .zIndex(-1f),
+            painter = painterResource(R.drawable.shape_soft_star_2),
+            tint = starColor,
+            contentDescription = null,
+        )
+
+        // Shape 3: Center Left
+        Icon(
+            modifier = Modifier
+                .requiredSize(180.dp)
+                .absoluteOffset(x = -halfWidth * 0.9f, y = -halfHeight * 0.2f + scroll * 0.45f)
+                .rotate(angle3)
+                .zIndex(-1f),
+            painter = painterResource(R.drawable.shape_soft_star_1),
+            tint = starColor,
+            contentDescription = null,
+        )
+
+        // Shape 4: Bottom Right
+        Icon(
+            modifier = Modifier
+                .requiredSize(220.dp)
+                .absoluteOffset(x = halfWidth * 0.6f, y = halfHeight * 0.2f + scroll * 0.25f)
+                .rotate(angle4)
+                .zIndex(-1f),
+            painter = painterResource(R.drawable.shape_soft_star_2),
+            tint = starColor,
+            contentDescription = null,
+        )
+    }
+}
+
+@Composable
+private fun StepGrid(steps: List<StepItem>) {
+    val rows = steps.chunked(2)
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        rows.forEach { rowSteps ->
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.Start,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                NumberedRow(
-                    number = 1,
-                    title = stringResource(R.string.onboarding_step_1_title),
-                    subtitle = stringResource(R.string.onboarding_step_1_subtitle),
-                )
-                NumberedRow(
-                    number = 2,
-                    title = stringResource(R.string.onboarding_step_2_title),
-                    subtitle = stringResource(R.string.onboarding_step_2_subtitle),
-                )
-                NumberedRow(
-                    number = 3,
-                    title = stringResource(R.string.onboarding_step_3_title),
-                    subtitle = stringResource(R.string.onboarding_step_3_subtitle),
+                rowSteps.forEach { step ->
+                    StepCard(
+                        modifier = Modifier.weight(1f),
+                        number = step.number,
+                        title = stringResource(step.titleRes),
+                        description = stringResource(step.subtitleRes),
+                    )
+                }
+                if (rowSteps.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepCard(
+    modifier: Modifier = Modifier,
+    number: Int,
+    title: String,
+    description: String,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(26.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = number.toString(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    fontWeight = FontWeight.Bold,
                 )
             }
-            Spacer(Modifier.height(48.dp))
-            DescriptionButton(
-                title = { Text(stringResource(R.string.onboarding_set_budget_button)) },
-                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 32.dp),
-                onClick = {
-                    onSetBudget()
-                }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
 }
 
-@Preview(showBackground = true)
+@PreviewLightDark
 @Composable
 private fun OnboardingScreenPreview() {
     MinusTheme {
-        OnboardingScreen()
+        OnboardingScreenContent()
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingUiContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingUiContract.kt
@@ -1,0 +1,83 @@
+package com.serranoie.app.minus.presentation.ui.onboarding
+
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import java.time.LocalDate
+
+/**
+ * MVI contract for the Onboarding screen.
+ *
+ * Follows the same pattern as [com.serranoie.app.minus.presentation.ui.budget.mvi.BudgetMviContract]
+ * and [com.serranoie.app.minus.presentation.ui.home.MainScreenMviContract]:
+ *
+ *  - [OnboardingUiState]   — the single source of truth for the screen, exposed
+ *                           as `StateFlow` by the ViewModel
+ *  - [OnboardingUiIntent]  — the set of user actions the screen can dispatch
+ *  - [OnboardingUiEffect]  — one-shot events the screen should react to
+ *                           (navigation, snackbar, …). Emitted via
+ *                           `SharedFlow` by the ViewModel.
+ *
+ * The ViewModel is responsible for translating intents into state changes
+ * and effect emissions; the UI is responsible for collecting state and
+ * effects and rendering the corresponding UI.
+ */
+data class OnboardingUiState(
+    val currentStep: Int = 0,
+    val budgetInput: String = "",
+    val selectedDays: Int = 1,
+    val daysInPeriod: Int = 1,
+    val selectedPeriod: BudgetPeriod = BudgetPeriod.DAILY,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+    val isLoading: Boolean = false,
+    val isCompleted: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * The set of user actions the Onboarding screen can dispatch.
+ *
+ * Naming aligns with the rest of the project ([BudgetUiIntent],
+ * [MainScreenUiIntent]) — these are no longer called "events" to make
+ * the MVI intent / state / effect split explicit.
+ */
+sealed interface OnboardingUiIntent {
+    data class OnBudgetAmountChanged(val amount: String) : OnboardingUiIntent
+    data class OnDaysSelected(val days: Int) : OnboardingUiIntent
+    data class OnDateRangeSelected(
+        val startDate: LocalDate,
+        val endDate: LocalDate,
+        val budgetDisplayDays: Int,
+    ) : OnboardingUiIntent
+    data object OnNextStep : OnboardingUiIntent
+    data object OnPreviousStep : OnboardingUiIntent
+    data object OnCompleteOnboarding : OnboardingUiIntent
+}
+
+/**
+ * One-shot events the screen should react to. Emitted via
+ * `SharedFlow<OnboardingUiEffect>` by the ViewModel.
+ */
+sealed interface OnboardingUiEffect {
+    /**
+     * Emitted after the user has successfully completed onboarding
+     * (budget saved, notifications scheduled, onboarding flag persisted).
+     * The screen should navigate away to the main flow.
+     */
+    data object OnboardingCompleted : OnboardingUiEffect
+
+    /**
+     * Emitted when onboarding fails for a reason the user should see
+     * (e.g. the budget repository throws). The screen should surface
+     * this as a snackbar / error state.
+     */
+    data class OnboardingFailed(val message: String) : OnboardingUiEffect
+}
+
+/**
+ * The three steps of the onboarding flow. Used by [OnboardingUiState.currentStep].
+ */
+enum class OnboardingStep {
+    WELCOME,
+    BUDGET_AMOUNT,
+    BUDGET_PERIOD,
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingUiContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingUiContract.kt
@@ -51,6 +51,17 @@ sealed interface OnboardingUiIntent {
     data object OnNextStep : OnboardingUiIntent
     data object OnPreviousStep : OnboardingUiIntent
     data object OnCompleteOnboarding : OnboardingUiIntent
+
+    /**
+     * Dispatched from the welcome step when the user taps the
+     * "Set a budget" CTA. The welcome step is informational only —
+     * it doesn't collect a budget, period, or date range. The actual
+     * budget setup happens in the wallet screen that the nav graph
+     * opens next. This intent just marks onboarding as complete and
+     * emits [OnboardingUiEffect.OnboardingCompleted] so the screen
+     * can navigate away.
+     */
+    data object OnWelcomeDismissed : OnboardingUiIntent
 }
 
 /**

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -41,6 +41,7 @@ class OnboardingViewModel @Inject constructor(
             is OnboardingUiIntent.OnNextStep -> handleNextStep()
             is OnboardingUiIntent.OnPreviousStep -> handlePreviousStep()
             is OnboardingUiIntent.OnCompleteOnboarding -> handleCompleteOnboarding()
+            is OnboardingUiIntent.OnWelcomeDismissed -> handleWelcomeDismissed()
             is OnboardingUiIntent.OnDateRangeSelected -> handleDateRangeSelected(
                 intent.startDate,
                 intent.endDate,
@@ -130,6 +131,25 @@ class OnboardingViewModel @Inject constructor(
 
                 settingsRepository.setOnboardingCompleted(true)
 
+                _uiState.update { it.copy(isCompleted = true) }
+                _effects.emit(OnboardingUiEffect.OnboardingCompleted)
+            } catch (e: Exception) {
+                _effects.emit(OnboardingUiEffect.OnboardingFailed(e.message ?: "Unknown error"))
+            }
+        }
+    }
+
+    /**
+     * Mark onboarding as completed from the welcome step. The welcome
+     * step is informational only — the user has not entered a budget
+     * yet, so we skip the budget save and notification scheduling.
+     * The actual budget setup happens in the wallet screen that the
+     * nav graph opens next.
+     */
+    private fun handleWelcomeDismissed() {
+        viewModelScope.launch {
+            try {
+                settingsRepository.setOnboardingCompleted(true)
                 _uiState.update { it.copy(isCompleted = true) }
                 _effects.emit(OnboardingUiEffect.OnboardingCompleted)
             } catch (e: Exception) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -3,12 +3,16 @@ package com.serranoie.app.minus.presentation.ui.onboarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.serranoie.app.minus.data.repository.BudgetRepository
+import com.serranoie.app.minus.data.repository.SettingsRepository
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.presentation.notification.NotificationScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -17,77 +21,64 @@ import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
-/**
- * ViewModel for the onboarding flow.
- */
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     private val budgetRepository: BudgetRepository,
-    private val notificationScheduler: NotificationScheduler
+    private val notificationScheduler: NotificationScheduler,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnboardingUiState())
     val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
 
-    /**
-     * Handle onboarding events.
-     */
-    fun onEvent(event: OnboardingEvent) {
-        when (event) {
-            is OnboardingEvent.OnBudgetAmountChanged -> handleBudgetAmountChanged(event.amount)
-            is OnboardingEvent.OnDaysSelected -> handleDaysSelected(event.days)
-            is OnboardingEvent.OnNextStep -> handleNextStep()
-            is OnboardingEvent.OnPreviousStep -> handlePreviousStep()
-            is OnboardingEvent.OnCompleteOnboarding -> handleCompleteOnboarding()
-            is OnboardingEvent.OnDateRangeSelected -> handleDateRangeSelected(
-                event.startDate, 
-                event.endDate, 
-                event.budgetDisplayDays
+    private val _effects = MutableSharedFlow<OnboardingUiEffect>()
+    val effects: SharedFlow<OnboardingUiEffect> = _effects.asSharedFlow()
+
+    fun processIntent(intent: OnboardingUiIntent) {
+        when (intent) {
+            is OnboardingUiIntent.OnBudgetAmountChanged -> handleBudgetAmountChanged(intent.amount)
+            is OnboardingUiIntent.OnDaysSelected -> handleDaysSelected(intent.days)
+            is OnboardingUiIntent.OnNextStep -> handleNextStep()
+            is OnboardingUiIntent.OnPreviousStep -> handlePreviousStep()
+            is OnboardingUiIntent.OnCompleteOnboarding -> handleCompleteOnboarding()
+            is OnboardingUiIntent.OnDateRangeSelected -> handleDateRangeSelected(
+                intent.startDate,
+                intent.endDate,
+                intent.budgetDisplayDays,
             )
         }
     }
 
     private fun handleBudgetAmountChanged(amount: String) {
-        // Prevent multiple decimals
         if (amount.contains(".") && amount.count { it == '.' } > 1) return
-        // Prevent input longer than 10 characters
         if (amount.length > 10) return
 
         _uiState.update { it.copy(budgetInput = amount) }
     }
 
     private fun handleDaysSelected(days: Int) {
-        val period = when (days) {
-            1 -> BudgetPeriod.DAILY
-            7 -> BudgetPeriod.WEEKLY
-            15 -> BudgetPeriod.BIWEEKLY
-            else -> BudgetPeriod.MONTHLY
-        }
+        val period = daysToBudgetPeriod(days)
         _uiState.update { it.copy(selectedDays = days, selectedPeriod = period) }
     }
 
-    private fun handleDateRangeSelected(startDate: LocalDate, endDate: LocalDate, budgetDisplayDays: Int) {
+    private fun handleDateRangeSelected(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        budgetDisplayDays: Int,
+    ) {
         val days = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
-        
-        // Determine the period based on the user's preference for budget display
-        val period = when (budgetDisplayDays) {
-            1 -> BudgetPeriod.DAILY
-            7 -> BudgetPeriod.WEEKLY
-            14 -> BudgetPeriod.BIWEEKLY
-            else -> BudgetPeriod.MONTHLY
-        }
-        
-        _uiState.update { 
+        val period = budgetDisplayDaysToBudgetPeriod(budgetDisplayDays)
+
+        _uiState.update {
             it.copy(
                 startDate = startDate,
                 endDate = endDate,
                 selectedDays = days,
                 daysInPeriod = budgetDisplayDays,
-                selectedPeriod = period
-            ) 
+                selectedPeriod = period,
+            )
         }
-        
-        // Auto-complete onboarding after selecting dates and budget display
+
         handleCompleteOnboarding()
     }
 
@@ -108,7 +99,6 @@ class OnboardingViewModel @Inject constructor(
     private fun handleCompleteOnboarding() {
         val state = _uiState.value
 
-        // Validate budget amount
         val budgetAmount = try {
             BigDecimal(state.budgetInput)
         } catch (e: NumberFormatException) {
@@ -118,67 +108,47 @@ class OnboardingViewModel @Inject constructor(
         if (budgetAmount <= BigDecimal.ZERO) return
 
         viewModelScope.launch {
-            // Use the selected dates or default to today
-            val startDate = state.startDate ?: LocalDate.now()
-            val endDate = state.endDate ?: startDate.plusDays(state.selectedDays.toLong() - 1)
+            try {
+                val startDate = state.startDate ?: LocalDate.now()
+                val endDate = state.endDate ?: startDate.plusDays(state.selectedDays.toLong() - 1)
 
-            // Save the budget settings with the custom days in period
-            budgetRepository.saveBudgetSettings(
-                BudgetSettings(
-                    totalBudget = budgetAmount,
-                    period = state.selectedPeriod,
-                    startDate = startDate,
-                    endDate = endDate,
-                    currencyCode = "USD",
-                    daysInPeriod = state.selectedDays,
-                    rollOverEnabled = true,
-                    rollOverCarryForward = false
+                budgetRepository.saveBudgetSettings(
+                    BudgetSettings(
+                        totalBudget = budgetAmount,
+                        period = state.selectedPeriod,
+                        startDate = startDate,
+                        endDate = endDate,
+                        currencyCode = "USD",
+                        daysInPeriod = state.selectedDays,
+                        rollOverEnabled = true,
+                        rollOverCarryForward = false,
+                    )
                 )
-            )
 
-            // Schedule notifications for period end and recurrent expenses
-            notificationScheduler.schedulePeriodEndNotification(endDate)
-            notificationScheduler.initializeNotifications()
+                notificationScheduler.schedulePeriodEndNotification(endDate)
+                notificationScheduler.initializeNotifications()
 
-            // Mark onboarding as completed
-            _uiState.update { it.copy(isCompleted = true) }
+                settingsRepository.setOnboardingCompleted(true)
+
+                _uiState.update { it.copy(isCompleted = true) }
+                _effects.emit(OnboardingUiEffect.OnboardingCompleted)
+            } catch (e: Exception) {
+                _effects.emit(OnboardingUiEffect.OnboardingFailed(e.message ?: "Unknown error"))
+            }
         }
     }
-}
 
-/**
- * Onboarding UI State.
- */
-data class OnboardingUiState(
-    val currentStep: Int = 0,
-    val budgetInput: String = "",
-    val selectedDays: Int = 1,
-    val daysInPeriod: Int = 1,
-    val selectedPeriod: BudgetPeriod = BudgetPeriod.DAILY,
-    val startDate: LocalDate? = null,
-    val endDate: LocalDate? = null,
-    val isLoading: Boolean = false,
-    val isCompleted: Boolean = false,
-    val error: String? = null
-)
+    private fun daysToBudgetPeriod(days: Int): BudgetPeriod = when (days) {
+        1 -> BudgetPeriod.DAILY
+        7 -> BudgetPeriod.WEEKLY
+        15 -> BudgetPeriod.BIWEEKLY
+        else -> BudgetPeriod.MONTHLY
+    }
 
-/**
- * Onboarding steps.
- */
-enum class OnboardingStep {
-    WELCOME,       // Welcome message
-    BUDGET_AMOUNT, // Enter budget amount
-    BUDGET_PERIOD  // Select period (days)
-}
-
-/**
- * Onboarding events.
- */
-sealed class OnboardingEvent {
-    data class OnBudgetAmountChanged(val amount: String) : OnboardingEvent()
-    data class OnDaysSelected(val days: Int) : OnboardingEvent()
-    data class OnDateRangeSelected(val startDate: LocalDate, val endDate: LocalDate, val budgetDisplayDays: Int) : OnboardingEvent()
-    data object OnNextStep : OnboardingEvent()
-    data object OnPreviousStep : OnboardingEvent()
-    data object OnCompleteOnboarding : OnboardingEvent()
+    private fun budgetDisplayDaysToBudgetPeriod(days: Int): BudgetPeriod = when (days) {
+        1 -> BudgetPeriod.DAILY
+        7 -> BudgetPeriod.WEEKLY
+        14 -> BudgetPeriod.BIWEEKLY
+        else -> BudgetPeriod.MONTHLY
+    }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -152,13 +152,20 @@
 
     <string name="onboarding_welcome_title">¡Bienvenidos a Menos!</string>
     <string name="onboarding_welcome_subtitle">Hola y bienvenido, comencemos a ahorrar juntos.</string>
+    <string name="onboarding_welcome_intro">Un sencillo rastreador de presupuestos que te ayuda a decidir cuánto puedes gastar cada día, semana, quincena o mes.</string>
     <string name="onboarding_step_1_title">Establecer un presupuesto</string>
-    <string name="onboarding_step_1_subtitle">Calcula cuánto dinero necesitas para un período y mantente informado sobre cuánto puedes ahorrar.</string>
-    <string name="onboarding_step_2_title">Seguimiento de cada gasto</string>
-    <string name="onboarding_step_2_subtitle">Esta aplicación te ayuda a calcular cuánto puedes gastar por día, semana, período quincenal o mes para mantener el rumbo y saber lo que queda.</string>
-    <string name="onboarding_step_3_title">Gasta sabiamente</string>
-    <string name="onboarding_step_3_subtitle">Con el tiempo, aprenderá cuánto puede ahorrar y cuánto puede gastar.</string>
-    <string name="onboarding_set_budget_button">Establecer un presupuesto</string>
+    <string name="onboarding_step_1_subtitle">Define tu límite de gasto para cualquier periodo.</string>
+    <string name="onboarding_step_2_title">Seguimiento de gastos</string>
+    <string name="onboarding_step_2_subtitle">Registra lo que gastas y mira lo que queda cada día.</string>
+    <string name="onboarding_step_3_title">Gastos recurrentes</string>
+    <string name="onboarding_step_3_subtitle">Añade suscripciones y Minus las seguirá por ti automáticamente.</string>
+    <string name="onboarding_step_4_title">Calcula al instante</string>
+    <string name="onboarding_step_4_subtitle">Tu presupuesto restante se actualiza en tiempo real mientras gastas.</string>
+    <string name="onboarding_step_5_title">Consulta tus analíticas</string>
+    <string name="onboarding_step_5_subtitle">Gráficas, mapas de calor y desglose por categorías de cualquier periodo.</string>
+    <string name="onboarding_step_6_title">Gasta con cabeza</string>
+    <string name="onboarding_step_6_subtitle">Con el tiempo, aprende cuánto puedes ahorrar y cuánto puedes gastar.</string>
+    <string name="onboarding_set_budget_button">Continuar</string>
 
     <string name="onboarding_finish_date_selector_title">Selecciona el periodo</string>
     <string name="onboarding_finish_date_selector_days_range">%1$d días · %2$s - %3$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -153,15 +153,22 @@
 
     <string name="day_total_format">Total : %1$s</string>
 
-    <string name="onboarding_welcome_title">Bienvenue sur Minus !</string>
+    <string name="onboarding_welcome_title">Bienvenue sur Minus</string>
     <string name="onboarding_welcome_subtitle">Bonjour et bienvenue, commençons à épargner ensemble.</string>
+    <string name="onboarding_welcome_intro">Un suivi de budget simple qui vous aide à décider combien vous pouvez dépenser chaque jour, semaine, quinzaine ou mois.</string>
     <string name="onboarding_step_1_title">Définir un budget</string>
-    <string name="onboarding_step_1_subtitle">Estimez l\'argent dont vous avez besoin pour une période et restez informé de ce que vous pouvez économiser.</string>
-    <string name="onboarding_step_2_title">Suivre chaque dépense</string>
-    <string name="onboarding_step_2_subtitle">Cette application vous aide à calculer ce que vous pouvez dépenser par jour, semaine, quinzaine ou mois pour garder le cap.</string>
-    <string name="onboarding_step_3_title">Dépenser intelligemment</string>
-    <string name="onboarding_step_3_subtitle">Au fil du temps, vous apprendrez combien vous pouvez économiser et combien vous pouvez dépenser.</string>
-    <string name="onboarding_set_budget_button">Définir un budget</string>
+    <string name="onboarding_step_1_subtitle">Définissez votre limite de dépenses pour n\'importe quelle période.</string>
+    <string name="onboarding_step_2_title">Suivre les dépenses</string>
+    <string name="onboarding_step_2_subtitle">Notez ce que vous dépensez et voyez ce qu\'il reste chaque jour.</string>
+    <string name="onboarding_step_3_title">Dépenses récurrentes</string>
+    <string name="onboarding_step_3_subtitle">Ajoutez vos abonnements et Minus les suivra automatiquement pour vous.</string>
+    <string name="onboarding_step_4_title">Calcul en temps réel</string>
+    <string name="onboarding_step_4_subtitle">Votre budget restant se met à jour en direct à chaque dépense.</string>
+    <string name="onboarding_step_5_title">Consultez vos analyses</string>
+    <string name="onboarding_step_5_subtitle">Graphiques, cartes de chaleur et répartition par catégories pour chaque période.</string>
+    <string name="onboarding_step_6_title">Dépensez malin</string>
+    <string name="onboarding_step_6_subtitle">Avec le temps, apprenez combien vous pouvez économiser et dépenser.</string>
+    <string name="onboarding_set_budget_button">Continuer</string>
 
     <!-- Finish Date Selector -->
     <string name="onboarding_finish_date_selector_title">Sélectionnez la période</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,15 +173,22 @@
 
     <string name="day_total_format">Total: %1$s</string>
 
-    <string name="onboarding_welcome_title">Welcome to Minus!</string>
+    <string name="onboarding_welcome_title">Welcome to Minus</string>
     <string name="onboarding_welcome_subtitle">Hi and welcome, lets start saving together.</string>
+    <string name="onboarding_welcome_intro">A simple budget tracker that helps you decide how much you can spend each day, week, fortnight, or month.</string>
     <string name="onboarding_step_1_title">Set a budget</string>
-    <string name="onboarding_step_1_subtitle">Estimate how much money you need for a period and stay informed about how much you can save.</string>
-    <string name="onboarding_step_2_title">Track every expense</string>
-    <string name="onboarding_step_2_subtitle">This app helps you calculate how much you can spend per day, week, biweekly period, or month so you stay on track and know what is left.</string>
-    <string name="onboarding_step_3_title">Spend wisely</string>
-    <string name="onboarding_step_3_subtitle">Over time, you will learn how much you can save and how much you can spend.</string>
-    <string name="onboarding_set_budget_button">Set a budget</string>
+    <string name="onboarding_step_1_subtitle">Define your spending limit for any period.</string>
+    <string name="onboarding_step_2_title">Track expenses</string>
+    <string name="onboarding_step_2_subtitle">Log what you spend and see what is left each day.</string>
+    <string name="onboarding_step_3_title">Recurring expenses</string>
+    <string name="onboarding_step_3_subtitle">Add subscriptions and Minus will track them for you automatically.</string>
+    <string name="onboarding_step_4_title">Calculate on the fly</string>
+    <string name="onboarding_step_4_subtitle">Your remaining budget updates in real time as you spend.</string>
+    <string name="onboarding_step_5_title">See your analytics</string>
+    <string name="onboarding_step_5_subtitle">Charts, heatmaps, and category breakdowns for any period.</string>
+    <string name="onboarding_step_6_title">Spend wisely</string>
+    <string name="onboarding_step_6_subtitle">Over time, learn how much you can save and how much you can spend.</string>
+    <string name="onboarding_set_budget_button">Continue</string>
 
     <!-- Finish Date Selector -->
     <string name="onboarding_finish_date_selector_title">Select the period</string>

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModelTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModelTest.kt
@@ -1,0 +1,611 @@
+package com.serranoie.app.minus.presentation.ui.budget
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.data.repository.BudgetRepository
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.domain.usecase.ClearEarlyFinishStateUseCase
+import com.serranoie.app.minus.domain.usecase.FinishBudgetEarlyUseCase
+import com.serranoie.app.minus.domain.usecase.GetCurrentPeriodIdUseCase
+import com.serranoie.app.minus.domain.usecase.MarkOnboardingCompletedUseCase
+import com.serranoie.app.minus.domain.usecase.ObserveCurrentPeriodBoundaryUseCase
+import com.serranoie.app.minus.domain.usecase.ObserveCurrentPeriodRolloverUseCase
+import com.serranoie.app.minus.domain.usecase.PersistBudgetSettingsUseCase
+import com.serranoie.app.minus.domain.usecase.UpdatePeriodEndNotificationTimeUseCase
+import com.serranoie.app.minus.presentation.notification.NotificationHelper
+import com.serranoie.app.minus.presentation.notification.NotificationScheduler
+import com.serranoie.app.minus.presentation.ui.budget.mvi.BudgetUiEffect
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetEditorIntent
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadIntent
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetSystemIntent
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetTransactionIntent
+import com.serranoie.app.minus.presentation.ui.editor.AnimState
+import com.serranoie.app.minus.presentation.ui.editor.EditMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BudgetViewModelTest {
+
+    private val budgetRepository: BudgetRepository = mockk(relaxed = true)
+    private val notificationHelper: NotificationHelper = mockk(relaxed = true)
+    private val notificationScheduler: NotificationScheduler = mockk(relaxed = true)
+    private val transactionHandler: BudgetTransactionHandler = mockk(relaxed = true)
+    private val budgetStateCalculator: BudgetStateCalculator = mockk(relaxed = true)
+    private val budgetWidgetUpdater: BudgetWidgetUpdater = mockk(relaxed = true)
+    private val budgetExpressionEvaluator: BudgetExpressionEvaluator = BudgetExpressionEvaluator()
+    private val observeCurrentPeriodBoundaryUseCase: ObserveCurrentPeriodBoundaryUseCase =
+        mockk(relaxed = true)
+    private val observeCurrentPeriodRolloverUseCase: ObserveCurrentPeriodRolloverUseCase =
+        mockk(relaxed = true)
+    private val getCurrentPeriodIdUseCase: GetCurrentPeriodIdUseCase = mockk(relaxed = true)
+    private val persistBudgetSettingsUseCase: PersistBudgetSettingsUseCase = mockk(relaxed = true)
+    private val updatePeriodEndNotificationTimeUseCase: UpdatePeriodEndNotificationTimeUseCase =
+        mockk(relaxed = true)
+    private val finishBudgetEarlyUseCase: FinishBudgetEarlyUseCase = mockk(relaxed = true)
+    private val clearEarlyFinishStateUseCase: ClearEarlyFinishStateUseCase = mockk(relaxed = true)
+    private val markOnboardingCompletedUseCase: MarkOnboardingCompletedUseCase =
+        mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        every { observeCurrentPeriodBoundaryUseCase() } returns kotlinx.coroutines.flow.flowOf(0L to 0L)
+        every { observeCurrentPeriodRolloverUseCase() } returns kotlinx.coroutines.flow.flowOf(
+            BigDecimal.ZERO to false
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newViewModel() = BudgetViewModel(
+        budgetRepository = budgetRepository,
+        notificationHelper = notificationHelper,
+        notificationScheduler = notificationScheduler,
+        transactionHandler = transactionHandler,
+        budgetStateCalculator = budgetStateCalculator,
+        budgetWidgetUpdater = budgetWidgetUpdater,
+        budgetExpressionEvaluator = budgetExpressionEvaluator,
+        observeCurrentPeriodBoundaryUseCase = observeCurrentPeriodBoundaryUseCase,
+        observeCurrentPeriodRolloverUseCase = observeCurrentPeriodRolloverUseCase,
+        getCurrentPeriodIdUseCase = getCurrentPeriodIdUseCase,
+        persistBudgetSettingsUseCase = persistBudgetSettingsUseCase,
+        updatePeriodEndNotificationTimeUseCase = updatePeriodEndNotificationTimeUseCase,
+        finishBudgetEarlyUseCase = finishBudgetEarlyUseCase,
+        clearEarlyFinishStateUseCase = clearEarlyFinishStateUseCase,
+        markOnboardingCompletedUseCase = markOnboardingCompletedUseCase,
+    )
+
+    private fun sampleSettings() = BudgetSettings(
+        totalBudget = BigDecimal("1000.00"),
+        period = BudgetPeriod.MONTHLY,
+        startDate = LocalDate.of(2026, 1, 1),
+        endDate = LocalDate.of(2026, 1, 30),
+        currencyCode = "USD",
+        daysInPeriod = 30,
+    )
+
+    private fun sampleTransaction() = Transaction(
+        id = 1L,
+        amount = BigDecimal("12.34"),
+        comment = "Coffee",
+        date = LocalDateTime.of(2026, 1, 1, 9, 0),
+    )
+
+    @Test
+    fun `when_viewmodel_is_created_then_ui_state_has_default_values`() = runTest {
+        val viewModel = newViewModel()
+
+        val state = viewModel.uiState.value
+        assertThat(state.numpadInput).isEqualTo("")
+        assertThat(state.isCalculation).isFalse()
+        assertThat(state.dragProgress).isEqualTo(0f)
+        assertThat(state.isFirstLaunch).isTrue()
+        assertThat(state.transactions).isEmpty()
+    }
+
+    @Test
+    fun when_save_budget_settings_is_called_then_persist_use_case_is_invoked_with_same_settings() =
+        runTest {
+            coEvery {
+                persistBudgetSettingsUseCase(any(), any())
+            } returns PeriodBoundaryResult(
+                periodStartMillis = 0L,
+                periodId = 1L,
+            )
+            val viewModel = newViewModel()
+            val settings = sampleSettings()
+
+            viewModel.saveBudgetSettings(settings, forceNewPeriodBoundary = true)
+
+            advanceUntilIdle()
+            coVerify { persistBudgetSettingsUseCase(settings, forceNewPeriodBoundary = true) }
+        }
+
+    @Test
+    fun when_update_period_end_notification_time_is_called_then_use_case_is_invoked_with_hour_and_minute() =
+        runTest {
+            coEvery { updatePeriodEndNotificationTimeUseCase(any(), any()) } returns Unit
+            val viewModel = newViewModel()
+
+            viewModel.updatePeriodEndNotificationTime(hour = 9, minute = 30)
+
+            advanceUntilIdle()
+            coVerify { updatePeriodEndNotificationTimeUseCase(9, 30) }
+        }
+
+    @Test
+    fun when_update_recurrent_notification_time_is_called_then_use_case_is_invoked_with_hour_and_minute() =
+        runTest {
+            coEvery {
+                updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(
+                    any(),
+                    any()
+                )
+            } returns Unit
+            val viewModel = newViewModel()
+
+            viewModel.updateRecurrentNotificationTime(hour = 8, minute = 0)
+
+            advanceUntilIdle()
+            coVerify {
+                updatePeriodEndNotificationTimeUseCase.updateRecurrentNotificationTime(
+                    8,
+                    0
+                )
+            }
+        }
+
+    @Test
+    fun when_finish_budget_early_is_called_then_use_case_is_invoked() = runTest {
+        coEvery { finishBudgetEarlyUseCase() } returns Unit
+        val viewModel = newViewModel()
+
+        viewModel.finishBudgetEarly()
+
+        advanceUntilIdle()
+        coVerify { finishBudgetEarlyUseCase() }
+    }
+
+    @Test
+    fun when_clear_early_finish_state_is_called_then_use_case_is_invoked() = runTest {
+        coEvery { clearEarlyFinishStateUseCase() } returns Unit
+        val viewModel = newViewModel()
+
+        viewModel.clearEarlyFinishState()
+
+        advanceUntilIdle()
+        coVerify { clearEarlyFinishStateUseCase() }
+    }
+
+    @Test
+    fun when_mark_first_launch_complete_is_called_then_is_first_launch_becomes_false_and_use_case_is_invoked() =
+        runTest {
+            coEvery { markOnboardingCompletedUseCase() } returns Unit
+            val viewModel = newViewModel()
+            assertThat(viewModel.uiState.value.isFirstLaunch).isTrue()
+
+            viewModel.markFirstLaunchComplete()
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.isFirstLaunch).isFalse()
+            coVerify { markOnboardingCompletedUseCase() }
+        }
+
+    @Test
+    fun when_number_tapped_intent_is_processed_then_numpad_input_is_updated() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("5"))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("5")
+        assertThat(viewModel.uiState.value.animState).isEqualTo(AnimState.EDITING)
+    }
+
+    @Test
+    fun when_multiple_digits_are_tapped_then_numpad_input_concatenates_them() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("3"))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("123")
+    }
+
+    @Test
+    fun when_backspace_is_tapped_then_last_digit_is_removed() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+
+        viewModel.processIntent(BudgetNumpadIntent.BackspaceTapped)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("1")
+    }
+
+    @Test
+    fun when_dot_is_tapped_then_input_gains_a_dot() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("5"))
+
+        viewModel.processIntent(BudgetNumpadIntent.DotTapped)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("5.")
+    }
+
+    @Test
+    fun when_operator_is_tapped_then_input_gains_operator_and_calculation_mode_is_set() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("5"))
+
+        viewModel.processIntent(BudgetNumpadIntent.OperatorTapped('+'))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("5+")
+        assertThat(viewModel.uiState.value.isCalculation).isTrue()
+    }
+
+    @Test
+    fun when_equals_is_tapped_on_valid_expression_then_input_becomes_evaluation_result() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+        viewModel.processIntent(BudgetNumpadIntent.OperatorTapped('+'))
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("3"))
+
+        viewModel.processIntent(BudgetNumpadIntent.EqualsTapped)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("5")
+    }
+
+    @Test
+    fun when_reset_input_is_tapped_then_input_is_cleared_and_calculation_is_reset() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+        viewModel.processIntent(BudgetNumpadIntent.OperatorTapped('+'))
+
+        viewModel.processIntent(BudgetNumpadIntent.ResetInputTapped)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("")
+        assertThat(viewModel.uiState.value.isCalculation).isFalse()
+    }
+
+    @Test
+    fun when_set_calculation_mode_is_processed_then_calculation_flag_and_drag_progress_are_set() =
+        runTest {
+            val viewModel = newViewModel()
+
+            viewModel.processIntent(BudgetNumpadIntent.SetCalculationMode(true))
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.isCalculation).isTrue()
+            assertThat(viewModel.uiState.value.dragProgress).isEqualTo(0f)
+        }
+
+    @Test
+    fun when_set_drag_progress_is_processed_then_drag_progress_is_set() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetNumpadIntent.SetDragProgress(0.5f))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.dragProgress).isEqualTo(0.5f)
+    }
+
+    @Test
+    fun when_set_edit_mode_intent_is_processed_then_edit_mode_is_updated() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetEditorIntent.SetEditMode(EditMode.EDIT))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.editMode).isEqualTo(EditMode.EDIT)
+    }
+
+    @Test
+    fun when_set_anim_state_intent_is_processed_with_non_empty_numpad_input_then_anim_state_is_updated() =
+        runTest {
+            val viewModel = newViewModel()
+            viewModel.processIntent(BudgetNumpadIntent.NumberTapped("5"))
+
+            viewModel.processIntent(BudgetEditorIntent.SetAnimState(AnimState.EDITING))
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.animState).isEqualTo(AnimState.EDITING)
+        }
+
+    @Test
+    fun when_comment_updated_intent_is_processed_then_current_comment_is_updated() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetEditorIntent.CommentUpdated("Lunch"))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentComment).isEqualTo("Lunch")
+    }
+
+    @Test
+    fun when_set_recurrent_enabled_intent_is_processed_then_flag_is_set() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetEditorIntent.SetRecurrentEnabled(true))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.isRecurrentEnabled).isTrue()
+    }
+
+    @Test
+    fun when_set_credit_enabled_with_no_cutoff_day_intent_is_processed_then_credit_flag_and_dialog_are_set() =
+        runTest {
+            val viewModel = newViewModel()
+            // budgetSettings is null in uiState, so creditCardCutoffDay is null
+
+            viewModel.processIntent(BudgetEditorIntent.SetCreditEnabled(true))
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.isCreditEnabled).isTrue()
+            assertThat(viewModel.uiState.value.showCreditCutoffDialog).isTrue()
+        }
+
+    @Test
+    fun when_date_selected_intent_is_processed_then_selected_date_is_updated() = runTest {
+        val viewModel = newViewModel()
+        val date = LocalDate.of(2026, 6, 21)
+
+        viewModel.processIntent(BudgetEditorIntent.DateSelected(date))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDate).isEqualTo(date)
+    }
+
+    @Test
+    fun when_dismiss_recurrent_dialog_intent_is_processed_then_dialog_is_hidden() = runTest {
+        val viewModel = newViewModel()
+        // Force the dialog open first
+        viewModel.processIntent(BudgetEditorIntent.SetRecurrentEnabled(true))
+
+        viewModel.processIntent(BudgetEditorIntent.DismissRecurrentDialog)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.showRecurrentDialog).isFalse()
+    }
+
+    @Test
+    fun when_dismiss_credit_cutoff_dialog_intent_is_processed_then_dialog_and_credit_are_cleared() =
+        runTest {
+            val viewModel = newViewModel()
+            viewModel.processIntent(BudgetEditorIntent.SetCreditEnabled(true))
+
+            viewModel.processIntent(BudgetEditorIntent.DismissCreditCutoffDialog)
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.showCreditCutoffDialog).isFalse()
+            assertThat(viewModel.uiState.value.isCreditEnabled).isFalse()
+        }
+
+    @Test
+    fun when_mark_first_launch_complete_system_intent_is_processed_then_is_first_launch_becomes_false() =
+        runTest {
+            coEvery { markOnboardingCompletedUseCase() } returns Unit
+            val viewModel = newViewModel()
+
+            viewModel.processIntent(BudgetSystemIntent.MarkFirstLaunchComplete)
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.isFirstLaunch).isFalse()
+        }
+
+    @Test
+    fun when_set_lock_swipeable_system_intent_is_processed_then_lock_swipeable_is_set() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetSystemIntent.SetLockSwipeable(true))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.lockSwipeable).isTrue()
+    }
+
+    @Test
+    fun when_set_lock_draggable_system_intent_is_processed_then_lock_draggable_is_set() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(BudgetSystemIntent.SetLockDraggable(true))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.lockDraggable).isTrue()
+    }
+
+    @Test
+    fun when_delete_transaction_tapped_intent_is_processed_then_handler_is_called_with_transaction() =
+        runTest {
+            coEvery { transactionHandler.deleteTransaction(any()) } returns Result.success(Unit)
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            viewModel.processIntent(BudgetTransactionIntent.DeleteTransactionTapped(transaction))
+
+            advanceUntilIdle()
+            coVerify { transactionHandler.deleteTransaction(transaction) }
+        }
+
+    @Test
+    fun when_restore_transaction_tapped_intent_is_processed_then_handler_is_called_with_transaction() =
+        runTest {
+            coEvery { transactionHandler.restoreTransaction(any()) } returns Result.success(Unit)
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            viewModel.processIntent(BudgetTransactionIntent.RestoreTransactionTapped(transaction))
+
+            advanceUntilIdle()
+            coVerify { transactionHandler.restoreTransaction(transaction) }
+        }
+
+    @Test
+    fun when_edit_transaction_tapped_intent_is_processed_then_handler_is_called_with_updated_transaction() =
+        runTest {
+            coEvery { transactionHandler.editTransaction(any()) } returns true
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            viewModel.processIntent(BudgetTransactionIntent.EditTransactionTapped(transaction))
+
+            advanceUntilIdle()
+            coVerify { transactionHandler.editTransaction(transaction) }
+        }
+
+    @Test
+    fun when_apply_intent_results_in_added_then_numpad_input_and_comment_are_cleared() = runTest {
+        coEvery {
+            transactionHandler.applyTransaction(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns
+                ApplyTransactionResult.Added(normalizedInput = "12.34")
+        val viewModel = newViewModel()
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+        viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+        viewModel.processIntent(BudgetEditorIntent.CommentUpdated("Lunch"))
+
+        viewModel.processIntent(BudgetNumpadIntent.ApplyTapped)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.numpadInput).isEqualTo("")
+        assertThat(viewModel.uiState.value.currentComment).isEqualTo("")
+    }
+
+    @Test
+    fun when_apply_intent_results_in_show_recurrent_dialog_then_dialog_and_pending_values_are_set() =
+        runTest {
+            coEvery {
+                transactionHandler.applyTransaction(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns
+                    ApplyTransactionResult.ShowRecurrentDialog(
+                        normalizedInput = "12.34",
+                        amount = BigDecimal("12.34"),
+                    )
+            val viewModel = newViewModel()
+            viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+            viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+            viewModel.processIntent(BudgetEditorIntent.SetRecurrentEnabled(true))
+
+            viewModel.processIntent(BudgetNumpadIntent.ApplyTapped)
+
+            advanceUntilIdle()
+            assertThat(viewModel.uiState.value.showRecurrentDialog).isTrue()
+            assertThat(viewModel.uiState.value.pendingRecurrentAmount).isEqualTo(BigDecimal("12.34"))
+        }
+
+    @Test
+    fun when_apply_intent_results_in_queued_for_next_period_then_show_message_effect_is_emitted() =
+        runTest {
+            coEvery {
+                transactionHandler.applyTransaction(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns
+                    ApplyTransactionResult.QueuedForNextPeriod(normalizedInput = "12.34")
+            val viewModel = newViewModel()
+            viewModel.processIntent(BudgetNumpadIntent.NumberTapped("1"))
+            viewModel.processIntent(BudgetNumpadIntent.NumberTapped("2"))
+
+            viewModel.effects.test {
+                viewModel.processIntent(BudgetNumpadIntent.ApplyTapped)
+                advanceUntilIdle()
+
+                val effect = awaitItem()
+                assertThat(effect).isInstanceOf(BudgetUiEffect.ShowMessage::class.java)
+                effect as BudgetUiEffect.ShowMessage
+                assertThat(effect.message).isEqualTo("Gasto en cola para el proximo periodo")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_delete_transaction_handler_returns_failure_then_show_message_effect_is_emitted() =
+        runTest {
+            coEvery { transactionHandler.deleteTransaction(any()) } returns Result.failure(
+                RuntimeException("boom")
+            )
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            viewModel.effects.test {
+                viewModel.processIntent(BudgetTransactionIntent.DeleteTransactionTapped(transaction))
+                advanceUntilIdle()
+
+                val effect = awaitItem()
+                assertThat(effect).isInstanceOf(BudgetUiEffect.ShowMessage::class.java)
+                effect as BudgetUiEffect.ShowMessage
+                assertThat(effect.message).isEqualTo("Could not delete transaction")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_restore_transaction_handler_returns_failure_then_show_message_effect_is_emitted() =
+        runTest {
+            coEvery { transactionHandler.restoreTransaction(any()) } returns Result.failure(
+                RuntimeException("boom")
+            )
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            viewModel.effects.test {
+                viewModel.processIntent(BudgetTransactionIntent.RestoreTransactionTapped(transaction))
+                advanceUntilIdle()
+
+                val effect = awaitItem()
+                assertThat(effect).isInstanceOf(BudgetUiEffect.ShowMessage::class.java)
+                effect as BudgetUiEffect.ShowMessage
+                assertThat(effect.message).isEqualTo("Could not restore transaction")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/EditorStateControllerTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/EditorStateControllerTest.kt
@@ -1,0 +1,295 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.presentation.ui.budget.controller.EditorStateController.EditorChange
+import com.serranoie.app.minus.presentation.ui.editor.AnimState
+import com.serranoie.app.minus.presentation.ui.editor.EditMode
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Unit tests for [EditorStateController] — a pure state machine for the
+ * editor sheet's local state. No Android, no coroutines. Backticked English
+ * test names (when_X_then_Y) following the BDD Given/When/Then convention.
+ */
+class EditorStateControllerTest {
+
+    private fun newController() = EditorStateController()
+
+    @Test
+    fun `when_controller_is_created_then_state_has_defaults`() {
+        val controller = newController()
+
+        val state = controller.state.value
+        assertThat(state.editMode).isEqualTo(EditMode.ADD)
+        assertThat(state.animState).isEqualTo(AnimState.IDLE)
+        assertThat(state.currentComment).isEqualTo("")
+        assertThat(state.lockSwipeable).isFalse()
+        assertThat(state.lockDraggable).isFalse()
+        assertThat(state.isRecurrentEnabled).isFalse()
+        assertThat(state.isCreditEnabled).isFalse()
+        assertThat(state.showRecurrentDialog).isFalse()
+        assertThat(state.showCreditCutoffDialog).isFalse()
+        assertThat(state.pendingRecurrentAmount).isNull()
+        assertThat(state.pendingRecurrentComment).isEqualTo("")
+    }
+
+    // -------------------------------------------------------------------------
+    // SetEditMode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_edit_mode_is_processed_then_edit_mode_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetEditMode(EditMode.EDIT), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.editMode).isEqualTo(EditMode.EDIT)
+        assertThat(changes).containsExactly(EditorChange.EditModeChanged(EditMode.EDIT))
+    }
+
+    // -------------------------------------------------------------------------
+    // SetAnimState
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_anim_state_is_processed_then_anim_state_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetAnimState(AnimState.EDITING), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.animState).isEqualTo(AnimState.EDITING)
+        assertThat(changes).containsExactly(EditorChange.AnimStateChanged(AnimState.EDITING))
+    }
+
+    // -------------------------------------------------------------------------
+    // CommentUpdated
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_comment_updated_is_processed_then_comment_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.CommentUpdated("Lunch"), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.currentComment).isEqualTo("Lunch")
+        assertThat(changes).containsExactly(EditorChange.CommentChanged("Lunch"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Lock toggles
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_lock_swipeable_is_processed_then_lock_swipeable_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetLockSwipeable(true), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.lockSwipeable).isTrue()
+        assertThat(changes).containsExactly(EditorChange.LockSwipeableChanged(true))
+    }
+
+    @Test
+    fun `when_set_lock_draggable_is_processed_then_lock_draggable_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetLockDraggable(true), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.lockDraggable).isTrue()
+        assertThat(changes).containsExactly(EditorChange.LockDraggableChanged(true))
+    }
+
+    // -------------------------------------------------------------------------
+    // Recurrent toggle
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_recurrent_enabled_true_is_processed_then_flag_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetRecurrentEnabled(true), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.isRecurrentEnabled).isTrue()
+        assertThat(changes).containsExactly(EditorChange.RecurrentEnabledChanged(true))
+    }
+
+    @Test
+    fun `when_set_recurrent_enabled_false_is_processed_then_flag_is_cleared`() {
+        val controller = newController()
+        controller.process(EditorIntent.SetRecurrentEnabled(true), hasCreditCardCutoffDay = false)
+
+        val changes = controller.process(EditorIntent.SetRecurrentEnabled(false), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.isRecurrentEnabled).isFalse()
+        assertThat(changes).containsExactly(EditorChange.RecurrentEnabledChanged(false))
+    }
+
+    // -------------------------------------------------------------------------
+    // Credit toggle
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_credit_enabled_true_with_no_cutoff_day_then_credit_flag_and_dialog_are_both_set`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = false)
+
+        val state = controller.state.value
+        assertThat(state.isCreditEnabled).isTrue()
+        assertThat(state.showCreditCutoffDialog).isTrue()
+        assertThat(changes).containsExactly(
+            EditorChange.CreditEnabledChanged(true),
+            EditorChange.CreditCutoffDialogVisibilityChanged(true),
+        )
+    }
+
+    @Test
+    fun `when_set_credit_enabled_true_with_cutoff_day_then_credit_flag_is_set_but_dialog_is_not_shown`() {
+        val controller = newController()
+
+        val changes = controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = true)
+
+        val state = controller.state.value
+        assertThat(state.isCreditEnabled).isTrue()
+        assertThat(state.showCreditCutoffDialog).isFalse()
+        assertThat(changes).containsExactly(
+            EditorChange.CreditEnabledChanged(true),
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+        )
+    }
+
+    @Test
+    fun `when_set_credit_enabled_false_is_processed_then_credit_flag_and_dialog_are_both_cleared`() {
+        val controller = newController()
+        controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = false)
+
+        val changes = controller.process(EditorIntent.SetCreditEnabled(false), hasCreditCardCutoffDay = true)
+
+        val state = controller.state.value
+        assertThat(state.isCreditEnabled).isFalse()
+        assertThat(state.showCreditCutoffDialog).isFalse()
+        assertThat(changes).containsExactly(
+            EditorChange.CreditEnabledChanged(false),
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Recurrent dialog
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_show_recurrent_dialog_is_called_then_dialog_amount_and_comment_are_set`() {
+        val controller = newController()
+
+        val changes = controller.showRecurrentDialog(
+            amount = BigDecimal("12.34"),
+            comment = "Coffee",
+        )
+
+        val state = controller.state.value
+        assertThat(state.showRecurrentDialog).isTrue()
+        assertThat(state.pendingRecurrentAmount).isEqualTo(BigDecimal("12.34"))
+        assertThat(state.pendingRecurrentComment).isEqualTo("Coffee")
+        assertThat(changes).containsExactly(
+            EditorChange.RecurrentDialogVisibilityChanged(true),
+            EditorChange.PendingRecurrentAmountChanged(BigDecimal("12.34")),
+            EditorChange.PendingRecurrentCommentChanged("Coffee"),
+        )
+    }
+
+    @Test
+    fun `when_dismiss_recurrent_dialog_is_processed_then_dialog_and_pending_values_are_cleared`() {
+        val controller = newController()
+        controller.showRecurrentDialog(BigDecimal("12.34"), "Coffee")
+
+        val changes = controller.process(EditorIntent.DismissRecurrentDialog, hasCreditCardCutoffDay = false)
+
+        val state = controller.state.value
+        assertThat(state.showRecurrentDialog).isFalse()
+        assertThat(state.pendingRecurrentAmount).isNull()
+        assertThat(state.pendingRecurrentComment).isEqualTo("")
+        assertThat(changes).containsExactly(
+            EditorChange.RecurrentDialogVisibilityChanged(false),
+            EditorChange.PendingRecurrentAmountChanged(null),
+            EditorChange.PendingRecurrentCommentChanged(""),
+        )
+    }
+
+    @Test
+    fun `when_apply_recurrent_dialog_is_called_then_dialog_amount_comment_and_toggles_are_cleared`() {
+        val controller = newController()
+        controller.showRecurrentDialog(BigDecimal("12.34"), "Coffee")
+        controller.process(EditorIntent.SetRecurrentEnabled(true), hasCreditCardCutoffDay = false)
+        controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = true)
+
+        val changes = controller.applyRecurrentDialog()
+
+        val state = controller.state.value
+        assertThat(state.showRecurrentDialog).isFalse()
+        assertThat(state.pendingRecurrentAmount).isNull()
+        assertThat(state.pendingRecurrentComment).isEqualTo("")
+        assertThat(state.isRecurrentEnabled).isFalse()
+        assertThat(state.isCreditEnabled).isFalse()
+        assertThat(changes).containsExactly(
+            EditorChange.RecurrentDialogVisibilityChanged(false),
+            EditorChange.PendingRecurrentAmountChanged(null),
+            EditorChange.PendingRecurrentCommentChanged(""),
+            EditorChange.RecurrentEnabledChanged(false),
+            EditorChange.CreditEnabledChanged(false),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Credit cutoff dialog
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_dismiss_credit_cutoff_dialog_is_processed_then_dialog_and_credit_flag_are_cleared`() {
+        val controller = newController()
+        controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = false)
+
+        val changes = controller.process(EditorIntent.DismissCreditCutoffDialog, hasCreditCardCutoffDay = true)
+
+        val state = controller.state.value
+        assertThat(state.showCreditCutoffDialog).isFalse()
+        assertThat(state.isCreditEnabled).isFalse()
+        assertThat(changes).containsExactly(
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+            EditorChange.CreditEnabledChanged(false),
+        )
+    }
+
+    @Test
+    fun `when_apply_credit_cutoff_day_is_called_then_dialog_is_hidden_and_credit_is_enabled`() {
+        val controller = newController()
+        controller.process(EditorIntent.SetCreditEnabled(true), hasCreditCardCutoffDay = false)
+
+        val changes = controller.applyCreditCutoffDay()
+
+        val state = controller.state.value
+        assertThat(state.showCreditCutoffDialog).isFalse()
+        assertThat(state.isCreditEnabled).isTrue()
+        assertThat(changes).containsExactly(
+            EditorChange.CreditCutoffDialogVisibilityChanged(false),
+            EditorChange.CreditEnabledChanged(true),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // DateSelected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_date_selected_is_processed_then_selected_date_and_change_are_updated`() {
+        val controller = newController()
+        val date = LocalDate.of(2026, 6, 21)
+
+        val changes = controller.process(EditorIntent.DateSelected(date), hasCreditCardCutoffDay = false)
+
+        assertThat(controller.state.value.selectedDate).isEqualTo(date)
+        assertThat(changes).containsExactly(EditorChange.SelectedDateChanged(date))
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/NumpadControllerTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/NumpadControllerTest.kt
@@ -1,0 +1,358 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.presentation.ui.budget.controller.NumpadController.NumpadChange
+import org.junit.Test
+
+/**
+ * Unit tests for [NumpadController] — a pure state machine, no Android,
+ * no coroutines. Each test follows the Given / When / Then BDD convention
+ * with a backticked English name (when_X_then_Y; underscores only because
+ * the Android DEX bytecode format rejects spaces in method names).
+ */
+class NumpadControllerTest {
+
+    private fun newController() = NumpadController()
+
+    // -------------------------------------------------------------------------
+    // Initial state
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_controller_is_created_then_input_is_empty_and_calculation_is_false`() {
+        val controller = newController()
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(controller.isCalculation.value).isFalse()
+        assertThat(controller.dragProgress.value).isEqualTo(0f)
+    }
+
+    // -------------------------------------------------------------------------
+    // NumberTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_number_tapped_then_input_appends_digit_and_change_is_emitted`() {
+        val controller = newController()
+
+        val changes = controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("1")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("1"))
+    }
+
+    @Test
+    fun `when_number_tapped_twice_then_input_is_two_chars_and_two_changes_are_emitted`() {
+        val controller = newController()
+
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+        val changes = controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("12")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("12"))
+    }
+
+    // -------------------------------------------------------------------------
+    // DotTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_dot_tapped_on_empty_input_then_input_becomes_zero_dot`() {
+        val controller = newController()
+
+        val changes = controller.process(NumpadIntent.DotTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("0.")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("0."))
+    }
+
+    @Test
+    fun `when_dot_tapped_after_digit_then_input_gains_a_dot`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.DotTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("5.")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("5."))
+    }
+
+    @Test
+    fun `when_dot_tapped_twice_in_same_segment_then_second_dot_is_ignored`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+        controller.process(NumpadIntent.DotTapped, currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.DotTapped, currentIsCalculation = false)
+
+        // Second dot in the same segment is a no-op
+        assertThat(controller.input.value).isEqualTo("5.")
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `when_dot_tapped_after_operator_then_input_becomes_operator_zero_dot`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.DotTapped, currentIsCalculation = true)
+
+        // After an operator, tapping dot should yield "5+0."
+        assertThat(controller.input.value).isEqualTo("5+0.")
+    }
+
+    // -------------------------------------------------------------------------
+    // BackspaceTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_backspace_tapped_then_last_char_is_removed_and_change_is_emitted`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+        controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.BackspaceTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("1")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("1"))
+    }
+
+    @Test
+    fun `when_backspace_clears_input_and_is_calculation_then_calculation_flag_is_cleared`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+        // Simulate that we entered calculation mode
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+        controller.process(NumpadIntent.BackspaceTapped, currentIsCalculation = true)
+
+        val changes = controller.process(NumpadIntent.BackspaceTapped, currentIsCalculation = true)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).containsExactly(
+            NumpadChange.InputChanged(""),
+            NumpadChange.CalculationModeChanged(false),
+        )
+    }
+
+    @Test
+    fun `when_backspace_clears_input_but_not_in_calculation_mode_then_calculation_flag_is_not_changed`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.BackspaceTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged(""))
+    }
+
+    // -------------------------------------------------------------------------
+    // OperatorTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_operator_tapped_on_non_empty_input_then_operator_is_appended_and_calculation_mode_is_set`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("5+")
+        assertThat(changes).containsExactly(
+            NumpadChange.InputChanged("5+"),
+            NumpadChange.CalculationModeChanged(true),
+        )
+    }
+
+    @Test
+    fun `when_operator_tapped_on_empty_input_then_input_is_unchanged`() {
+        val controller = newController()
+
+        val changes = controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `when_operator_tapped_after_another_operator_then_second_operator_is_ignored`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.OperatorTapped('-'), currentIsCalculation = true)
+
+        // Should NOT replace the existing operator — the production code
+        // ignores the second operator entirely.
+        assertThat(controller.input.value).isEqualTo("5+")
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `when_operator_tapped_after_dot_then_operator_is_ignored`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+        controller.process(NumpadIntent.DotTapped, currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("5.")
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `when_operator_tapped_while_already_in_calculation_mode_then_calculation_flag_is_not_re_emitted`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("5"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+        // Now in calculation mode
+        controller.process(NumpadIntent.NumberTapped("3"), currentIsCalculation = true)
+
+        val changes = controller.process(NumpadIntent.OperatorTapped('-'), currentIsCalculation = true)
+
+        // No CalculationModeChanged in the change list — already true
+        assertThat(controller.input.value).isEqualTo("5+3-")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged("5+3-"))
+    }
+
+    // -------------------------------------------------------------------------
+    // EqualsTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_equals_tapped_on_valid_expression_then_input_becomes_evaluation_result`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+        controller.process(NumpadIntent.NumberTapped("3"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.EqualsTapped, currentIsCalculation = false)
+
+        // BudgetExpressionEvaluator evaluates "2+3" -> "5"
+        assertThat(controller.input.value).isEqualTo("5")
+        assertThat(changes).containsExactly(
+            NumpadChange.InputChanged("5"),
+            NumpadChange.CalculationModeChanged(true),
+        )
+    }
+
+    @Test
+    fun `when_equals_tapped_on_empty_input_then_input_is_unchanged`() {
+        val controller = newController()
+
+        val changes = controller.process(NumpadIntent.EqualsTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).isEmpty()
+    }
+
+    @Test
+    fun `when_equals_tapped_on_invalid_expression_then_input_is_unchanged`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+        // "2+" is invalid (trailing operator) so evaluator returns null
+
+        val changes = controller.process(NumpadIntent.EqualsTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("2+")
+        assertThat(changes).isEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // ResetInputTapped
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_reset_tapped_then_input_is_cleared_and_calculation_is_cleared_when_in_calculation_mode`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+        controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+        controller.process(NumpadIntent.OperatorTapped('+'), currentIsCalculation = false)
+        // Now in calculation mode
+
+        val changes = controller.process(NumpadIntent.ResetInputTapped, currentIsCalculation = true)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).containsExactly(
+            NumpadChange.InputChanged(""),
+            NumpadChange.CalculationModeChanged(false),
+        )
+    }
+
+    @Test
+    fun `when_reset_tapped_not_in_calculation_mode_then_only_input_change_is_emitted`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.ResetInputTapped, currentIsCalculation = false)
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(changes).containsExactly(NumpadChange.InputChanged(""))
+    }
+
+    // -------------------------------------------------------------------------
+    // SetCalculationMode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_calculation_mode_enabled_then_calculation_flag_and_drag_progress_are_updated`() {
+        val controller = newController()
+        controller.process(NumpadIntent.SetDragProgress(0.5f), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.SetCalculationMode(true), currentIsCalculation = false)
+
+        assertThat(controller.isCalculation.value).isTrue()
+        assertThat(controller.dragProgress.value).isEqualTo(0f)
+        assertThat(changes).containsExactly(
+            NumpadChange.CalculationModeChanged(true),
+            NumpadChange.DragProgressChanged(0f),
+        )
+    }
+
+    @Test
+    fun `when_set_calculation_mode_disabled_then_calculation_flag_is_false_and_drag_progress_is_reset`() {
+        val controller = newController()
+        controller.process(NumpadIntent.SetCalculationMode(true), currentIsCalculation = false)
+        controller.process(NumpadIntent.SetDragProgress(0.8f), currentIsCalculation = false)
+
+        val changes = controller.process(NumpadIntent.SetCalculationMode(false), currentIsCalculation = true)
+
+        assertThat(controller.isCalculation.value).isFalse()
+        assertThat(controller.dragProgress.value).isEqualTo(0f)
+        assertThat(changes).containsExactly(
+            NumpadChange.CalculationModeChanged(false),
+            NumpadChange.DragProgressChanged(0f),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // SetDragProgress
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_set_drag_progress_is_processed_then_value_and_change_are_updated`() {
+        val controller = newController()
+
+        val changes = controller.process(NumpadIntent.SetDragProgress(0.42f), currentIsCalculation = false)
+
+        assertThat(controller.dragProgress.value).isEqualTo(0.42f)
+        assertThat(changes).containsExactly(NumpadChange.DragProgressChanged(0.42f))
+    }
+
+    // -------------------------------------------------------------------------
+    // clearInput
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_clear_input_is_called_then_input_becomes_empty_and_change_is_returned`() {
+        val controller = newController()
+        controller.process(NumpadIntent.NumberTapped("1"), currentIsCalculation = false)
+        controller.process(NumpadIntent.NumberTapped("2"), currentIsCalculation = false)
+
+        val change = controller.clearInput()
+
+        assertThat(controller.input.value).isEqualTo("")
+        assertThat(change).isEqualTo(NumpadChange.InputChanged(""))
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/PeriodActionsControllerTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/PeriodActionsControllerTest.kt
@@ -1,0 +1,167 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.presentation.ui.budget.controller.PeriodActionsController.PeriodAction
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Unit tests for [PeriodActionsController]. The controller owns the
+ * in-memory [isFirstLaunch] flag and emits [PeriodAction]s that the
+ * parent ViewModel applies to its own UI state and routes to the
+ * appropriate use case. Backticked English test names (when_X_then_Y)
+ * following the BDD Given/When/Then convention.
+ */
+class PeriodActionsControllerTest {
+
+    private fun newController() = PeriodActionsController(object : PeriodActions {
+        override suspend fun noop() = Unit
+    })
+
+    private fun sampleSettings() = BudgetSettings(
+        totalBudget = BigDecimal("1000.00"),
+        period = BudgetPeriod.MONTHLY,
+        startDate = LocalDate.of(2026, 1, 1),
+        endDate = LocalDate.of(2026, 1, 30),
+        currencyCode = "USD",
+        daysInPeriod = 30,
+    )
+
+    // -------------------------------------------------------------------------
+    // Initial state
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_controller_is_created_then_is_first_launch_is_true`() {
+        val controller = newController()
+
+        assertThat(controller.isFirstLaunch.value).isTrue()
+    }
+
+    // -------------------------------------------------------------------------
+    // markFirstLaunchComplete
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_mark_first_launch_complete_is_called_then_is_first_launch_becomes_false_and_action_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.markFirstLaunchComplete()
+
+        assertThat(controller.isFirstLaunch.value).isFalse()
+        assertThat(actions).containsExactly(PeriodAction.MarkOnboardingCompleted)
+    }
+
+    @Test
+    fun `when_mark_first_launch_complete_is_called_twice_then_action_is_emitted_twice_but_flag_stays_false`() {
+        val controller = newController()
+
+        controller.markFirstLaunchComplete()
+        val actions = controller.markFirstLaunchComplete()
+
+        assertThat(controller.isFirstLaunch.value).isFalse()
+        assertThat(actions).containsExactly(PeriodAction.MarkOnboardingCompleted)
+    }
+
+    // -------------------------------------------------------------------------
+    // saveBudgetSettings
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_save_budget_settings_is_called_then_persist_action_is_emitted_and_is_first_launch_becomes_false`() {
+        val controller = newController()
+        val settings = sampleSettings()
+
+        val actions = controller.saveBudgetSettings(settings)
+
+        assertThat(controller.isFirstLaunch.value).isFalse()
+        assertThat(actions).containsExactly(PeriodAction.PersistBudgetSettings(settings))
+    }
+
+    @Test
+    fun `when_save_budget_settings_is_called_twice_then_persist_action_is_emitted_twice_with_each_settings`() {
+        val controller = newController()
+        val settings1 = sampleSettings()
+        val settings2 = sampleSettings().copy(totalBudget = BigDecimal("2000.00"))
+
+        val firstActions = controller.saveBudgetSettings(settings1)
+        val secondActions = controller.saveBudgetSettings(settings2)
+
+        assertThat(firstActions).containsExactly(PeriodAction.PersistBudgetSettings(settings1))
+        assertThat(secondActions).containsExactly(PeriodAction.PersistBudgetSettings(settings2))
+    }
+
+    // -------------------------------------------------------------------------
+    // updatePeriodEndNotificationTime
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_update_period_end_notification_time_is_called_then_action_with_hour_and_minute_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.updatePeriodEndNotificationTime(hour = 9, minute = 30)
+
+        assertThat(actions).containsExactly(PeriodAction.UpdatePeriodEndNotification(9, 30))
+    }
+
+    // -------------------------------------------------------------------------
+    // updateRecurrentNotificationTime
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_update_recurrent_notification_time_is_called_then_action_with_hour_and_minute_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.updateRecurrentNotificationTime(hour = 8, minute = 0)
+
+        assertThat(actions).containsExactly(PeriodAction.UpdateRecurrentNotification(8, 0))
+    }
+
+    // -------------------------------------------------------------------------
+    // finishBudgetEarly / clearEarlyFinishState
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_finish_budget_early_is_called_then_finish_action_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.finishBudgetEarly()
+
+        assertThat(actions).containsExactly(PeriodAction.FinishBudgetEarly)
+    }
+
+    @Test
+    fun `when_clear_early_finish_state_is_called_then_clear_action_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.clearEarlyFinishState()
+
+        assertThat(actions).containsExactly(PeriodAction.ClearEarlyFinish)
+    }
+
+    // -------------------------------------------------------------------------
+    // triggerTestNotifications
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_trigger_test_notifications_is_called_then_action_is_emitted`() {
+        val controller = newController()
+
+        val actions = controller.triggerTestNotifications()
+
+        assertThat(actions).containsExactly(PeriodAction.TriggerTestNotifications)
+    }
+
+    @Test
+    fun `when_trigger_test_notifications_is_called_twice_then_two_actions_are_emitted`() {
+        val controller = newController()
+
+        controller.triggerTestNotifications()
+        val second = controller.triggerTestNotifications()
+
+        assertThat(second).containsExactly(PeriodAction.TriggerTestNotifications)
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/TransactionActionsControllerTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/controller/TransactionActionsControllerTest.kt
@@ -1,0 +1,292 @@
+package com.serranoie.app.minus.presentation.ui.budget.controller
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.presentation.ui.budget.ApplyTransactionResult
+import com.serranoie.app.minus.presentation.ui.budget.controller.TransactionActionsController.TransactionAction
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * Unit tests for [TransactionActionsController]. The controller delegates
+ * the heavy lifting to a [TransactionHandler] strategy; tests provide a
+ * fake that returns pre-canned [ApplyTransactionResult]s and Result-wrapped
+ * operations. Backticked English test names (when_X_then_Y) following
+ * the BDD Given/When/Then convention.
+ */
+class TransactionActionsControllerTest {
+
+    /**
+     * A configurable fake handler so each test can pin the exact result it
+     * wants to assert against.
+     */
+    private class FakeHandler : TransactionHandler {
+        var applyResult: ApplyTransactionResult = ApplyTransactionResult.InvalidInput
+        var applyRecurrentResult: Boolean = false
+        var deleteResult: kotlin.Result<Unit> = kotlin.Result.success(Unit)
+        var restoreResult: kotlin.Result<Unit> = kotlin.Result.success(Unit)
+        var editCalls: MutableList<Transaction> = mutableListOf()
+
+        override suspend fun apply(
+            input: String,
+            isCalculation: Boolean,
+            isRecurrentEnabled: Boolean,
+            isCreditEnabled: Boolean,
+            comment: String,
+            budgetSettings: BudgetSettings?,
+            resolveActivePeriodId: suspend () -> Long,
+        ): ApplyTransactionResult = applyResult
+
+        override suspend fun applyRecurrent(
+            pendingAmount: BigDecimal?,
+            pendingComment: String,
+            frequency: RecurrentFrequency,
+            endDate: LocalDate,
+            subscriptionDay: Int?,
+            resolveActivePeriodId: suspend () -> Long,
+            isCredit: Boolean,
+        ): Boolean = applyRecurrentResult
+
+        override suspend fun delete(transaction: Transaction): kotlin.Result<Unit> = deleteResult
+        override suspend fun restore(transaction: Transaction): kotlin.Result<Unit> = restoreResult
+        override suspend fun edit(transaction: Transaction) {
+            editCalls.add(transaction)
+        }
+    }
+
+    private fun newController(handler: FakeHandler = FakeHandler()) =
+        TransactionActionsController(handler)
+
+    private fun sampleTransaction() = Transaction(
+        id = 1L,
+        amount = BigDecimal("12.34"),
+        comment = "Coffee",
+        date = LocalDateTime.of(2026, 1, 1, 9, 0),
+    )
+
+    private fun sampleSettings() = BudgetSettings(
+        totalBudget = BigDecimal("1000.00"),
+        period = BudgetPeriod.MONTHLY,
+        startDate = LocalDate.of(2026, 1, 1),
+        endDate = LocalDate.of(2026, 1, 30),
+        currencyCode = "USD",
+        daysInPeriod = 30,
+    )
+
+    // -------------------------------------------------------------------------
+    // apply
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_handler_returns_invalid_input_then_no_actions_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { applyResult = ApplyTransactionResult.InvalidInput }
+        )
+
+        val actions = controller.apply(
+            input = "abc",
+            isCalculation = false,
+            isRecurrentEnabled = false,
+            isCreditEnabled = false,
+            comment = "",
+            budgetSettings = sampleSettings(),
+            resolveActivePeriodId = { 1L },
+        )
+
+        assertThat(actions).isEmpty()
+    }
+
+    @Test
+    fun `when_handler_returns_added_then_clear_input_clear_editor_flags_and_added_action_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { applyResult = ApplyTransactionResult.Added(normalizedInput = "12.34") }
+        )
+
+        val actions = controller.apply(
+            input = "12.34",
+            isCalculation = false,
+            isRecurrentEnabled = false,
+            isCreditEnabled = false,
+            comment = "Lunch",
+            budgetSettings = sampleSettings(),
+            resolveActivePeriodId = { 1L },
+        )
+
+        assertThat(actions).containsExactly(
+            TransactionAction.ClearInput,
+            TransactionAction.ClearEditorFlags,
+            TransactionAction.TransactionAdded,
+        )
+    }
+
+    @Test
+    fun `when_handler_returns_queued_for_next_period_then_clear_input_clear_flags_queued_and_show_message_actions_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { applyResult = ApplyTransactionResult.QueuedForNextPeriod(normalizedInput = "12.34") }
+        )
+
+        val actions = controller.apply(
+            input = "12.34",
+            isCalculation = false,
+            isRecurrentEnabled = false,
+            isCreditEnabled = false,
+            comment = "Lunch",
+            budgetSettings = sampleSettings(),
+            resolveActivePeriodId = { 1L },
+        )
+
+        assertThat(actions).containsExactly(
+            TransactionAction.ClearInput,
+            TransactionAction.ClearEditorFlags,
+            TransactionAction.TransactionQueuedForNextPeriod,
+            TransactionAction.ShowMessage("Gasto en cola para el proximo periodo"),
+        )
+    }
+
+    @Test
+    fun `when_handler_returns_show_recurrent_dialog_then_open_dialog_action_is_emitted_with_amount_and_comment`() = runTest {
+        val amount = BigDecimal("12.34")
+        val normalized = "12.34"
+        val controller = newController(
+            FakeHandler().apply {
+                applyResult = ApplyTransactionResult.ShowRecurrentDialog(
+                    normalizedInput = normalized,
+                    amount = amount,
+                )
+            }
+        )
+
+        val actions = controller.apply(
+            input = "12.34",
+            isCalculation = false,
+            isRecurrentEnabled = true,
+            isCreditEnabled = false,
+            comment = "Subscription",
+            budgetSettings = sampleSettings(),
+            resolveActivePeriodId = { 1L },
+        )
+
+        assertThat(actions).containsExactly(
+            TransactionAction.OpenRecurrentDialog(
+                normalizedInput = normalized,
+                amount = amount,
+                comment = "Subscription",
+            ),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // applyRecurrent
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_handler_reports_applied_recurrent_successfully_then_clear_input_action_is_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { applyRecurrentResult = true }
+        )
+
+        val actions = controller.applyRecurrent(
+            frequency = RecurrentFrequency.MONTHLY,
+            endDate = LocalDate.of(2027, 1, 1),
+            subscriptionDay = 15,
+            pendingAmount = BigDecimal("9.99"),
+            pendingComment = "Subscription",
+            resolveActivePeriodId = { 1L },
+            isCredit = false,
+        )
+
+        assertThat(actions).containsExactly(TransactionAction.ClearInput)
+    }
+
+    @Test
+    fun `when_handler_reports_recurrent_failure_then_no_actions_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { applyRecurrentResult = false }
+        )
+
+        val actions = controller.applyRecurrent(
+            frequency = RecurrentFrequency.MONTHLY,
+            endDate = LocalDate.of(2027, 1, 1),
+            subscriptionDay = null,
+            pendingAmount = BigDecimal("9.99"),
+            pendingComment = "Subscription",
+            resolveActivePeriodId = { 1L },
+            isCredit = false,
+        )
+
+        assertThat(actions).isEmpty()
+    }
+
+    // -------------------------------------------------------------------------
+    // delete
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_handler_reports_delete_success_then_no_actions_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { deleteResult = kotlin.Result.success(Unit) }
+        )
+
+        val actions = controller.delete(sampleTransaction())
+
+        assertThat(actions).isEmpty()
+    }
+
+    @Test
+    fun `when_handler_reports_delete_failure_then_delete_failed_action_is_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { deleteResult = kotlin.Result.failure(RuntimeException("boom")) }
+        )
+
+        val actions = controller.delete(sampleTransaction())
+
+        assertThat(actions).containsExactly(TransactionAction.DeleteFailed)
+    }
+
+    // -------------------------------------------------------------------------
+    // restore
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_handler_reports_restore_success_then_no_actions_are_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { restoreResult = kotlin.Result.success(Unit) }
+        )
+
+        val actions = controller.restore(sampleTransaction())
+
+        assertThat(actions).isEmpty()
+    }
+
+    @Test
+    fun `when_handler_reports_restore_failure_then_restore_failed_action_is_emitted`() = runTest {
+        val controller = newController(
+            FakeHandler().apply { restoreResult = kotlin.Result.failure(RuntimeException("boom")) }
+        )
+
+        val actions = controller.restore(sampleTransaction())
+
+        assertThat(actions).containsExactly(TransactionAction.RestoreFailed)
+    }
+
+    // -------------------------------------------------------------------------
+    // edit
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_edit_is_called_then_handler_receives_the_transaction`() = runTest {
+        val handler = FakeHandler()
+        val controller = newController(handler)
+        val transaction = sampleTransaction()
+
+        controller.edit(transaction)
+
+        assertThat(handler.editCalls).containsExactly(transaction)
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/home/MainScreenViewModelTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/home/MainScreenViewModelTest.kt
@@ -1,0 +1,468 @@
+package com.serranoie.app.minus.presentation.ui.home
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetEditorIntent
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadIntent
+import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetTransactionIntent
+import com.serranoie.app.minus.presentation.ui.editor.AnimState
+import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainScreenViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newViewModel() = MainScreenViewModel()
+
+    private fun sampleTransaction(
+        id: Long = 1L,
+        amount: BigDecimal = BigDecimal("12.34"),
+    ) = Transaction(
+        id = id,
+        amount = amount,
+        comment = "Coffee",
+        date = LocalDateTime.of(2026, 1, 1, 9, 0),
+    )
+
+    @Test
+    fun when_viewmodel_is_created_then_initial_state_is_default() = runTest {
+        // Given / When
+        val viewModel = newViewModel()
+
+        // Then
+        val state = viewModel.uiState.value
+        assertThat(state.pendingDeleteTransaction).isNull()
+        assertThat(state.isSnackbarVisible).isFalse()
+        assertThat(state.snackbarMessage).isEqualTo("")
+        assertThat(state.snackbarActionLabel).isEqualTo("")
+        assertThat(state.snackbarHasUndo).isFalse()
+        assertThat(state.shownStage).isNull()
+        assertThat(state.showBudgetPeriodSheet).isFalse()
+        assertThat(state.forceBudgetPeriodSheetSetup).isFalse()
+        assertThat(state.selectedViewPeriod).isEqualTo(BudgetPeriod.DAILY)
+        assertThat(state.walletSheetOpened).isFalse()
+    }
+
+    @Test
+    fun when_queue_delete_with_undo_is_processed_then_snackbar_state_and_effect_are_set() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+            val transaction = sampleTransaction()
+
+            // When
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.QueueDeleteWithUndo(transaction, "Deleted"),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+
+                // Then
+                val state = viewModel.uiState.value
+                assertThat(state.pendingDeleteTransaction).isEqualTo(transaction)
+                assertThat(state.isSnackbarVisible).isTrue()
+                assertThat(state.snackbarMessage).isEqualTo("Deleted")
+                assertThat(state.snackbarActionLabel).isEqualTo("Undo")
+                assertThat(state.snackbarHasUndo).isTrue()
+
+                val effect = awaitItem()
+                assertThat(effect).isInstanceOf(MainScreenUiEffect.ShowUndoSnackbar::class.java)
+                effect as MainScreenUiEffect.ShowUndoSnackbar
+                assertThat(effect.message).isEqualTo("Deleted")
+                assertThat(effect.actionLabel).isEqualTo("Undo")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_cancel_pending_delete_is_processed_then_snackbar_state_is_cleared_and_request_undo_is_emitted() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.QueueDeleteWithUndo(sampleTransaction(), "Deleted"),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                runCurrent()
+                awaitItem()
+
+                // When
+                viewModel.processIntent(
+                    MainScreenUiIntent.CancelPendingDelete,
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                runCurrent()
+
+                // Then
+                val state = viewModel.uiState.value
+                assertThat(state.pendingDeleteTransaction).isNull()
+                assertThat(state.isSnackbarVisible).isFalse()
+                assertThat(state.snackbarMessage).isEqualTo("")
+                assertThat(state.snackbarActionLabel).isEqualTo("")
+                assertThat(state.snackbarHasUndo).isFalse()
+
+                val effect = awaitItem()
+                assertThat(effect).isEqualTo(MainScreenUiEffect.RequestUndo)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_dismiss_snackbar_is_processed_then_snackbar_state_is_cleared_and_no_effect_is_emitted() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.QueueDeleteWithUndo(sampleTransaction(), "Deleted"),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                runCurrent()
+                awaitItem()
+
+                // When
+                viewModel.processIntent(
+                    MainScreenUiIntent.DismissSnackbar,
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                runCurrent()
+
+                // Then
+                val state = viewModel.uiState.value
+                assertThat(state.pendingDeleteTransaction).isNull()
+                assertThat(state.isSnackbarVisible).isFalse()
+                assertThat(state.snackbarMessage).isEqualTo("")
+                assertThat(state.snackbarActionLabel).isEqualTo("")
+                assertThat(state.snackbarHasUndo).isFalse()
+
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_show_budget_period_sheet_with_force_setup_is_processed_then_sheet_and_force_setup_flags_are_true() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+
+            // When
+            viewModel.processIntent(
+                MainScreenUiIntent.ShowBudgetPeriodSheet(forceSetup = true),
+                currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+            )
+
+            // Then
+            val state = viewModel.uiState.value
+            assertThat(state.showBudgetPeriodSheet).isTrue()
+            assertThat(state.forceBudgetPeriodSheetSetup).isTrue()
+        }
+
+    @Test
+    fun when_show_budget_period_sheet_without_force_setup_is_processed_then_sheet_is_visible_but_force_setup_is_false() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+
+            // When
+            viewModel.processIntent(
+                MainScreenUiIntent.ShowBudgetPeriodSheet(forceSetup = false),
+                currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+            )
+
+            // Then
+            val state = viewModel.uiState.value
+            assertThat(state.showBudgetPeriodSheet).isTrue()
+            assertThat(state.forceBudgetPeriodSheetSetup).isFalse()
+        }
+
+    @Test
+    fun when_hide_budget_period_sheet_is_processed_then_both_sheet_flags_are_false() = runTest {
+        // Given
+        val viewModel = newViewModel()
+        viewModel.processIntent(
+            MainScreenUiIntent.ShowBudgetPeriodSheet(forceSetup = true),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.HideBudgetPeriodSheet,
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        val state = viewModel.uiState.value
+        assertThat(state.showBudgetPeriodSheet).isFalse()
+        assertThat(state.forceBudgetPeriodSheetSetup).isFalse()
+    }
+
+    @Test
+    fun when_set_selected_period_is_processed_then_selected_view_period_is_updated() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.SetSelectedPeriod(BudgetPeriod.WEEKLY),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.selectedViewPeriod).isEqualTo(BudgetPeriod.WEEKLY)
+    }
+
+    @Test
+    fun when_set_selected_period_is_processed_twice_then_last_value_wins() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.SetSelectedPeriod(BudgetPeriod.WEEKLY),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+        viewModel.processIntent(
+            MainScreenUiIntent.SetSelectedPeriod(BudgetPeriod.MONTHLY),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.selectedViewPeriod).isEqualTo(BudgetPeriod.MONTHLY)
+    }
+
+    @Test
+    fun when_mark_wallet_sheet_opened_is_processed_then_wallet_sheet_opened_is_true() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.MarkWalletSheetOpened,
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.walletSheetOpened).isTrue()
+    }
+
+    @Test
+    fun when_mark_wallet_sheet_opened_is_processed_twice_then_flag_stays_true() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.MarkWalletSheetOpened,
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+        viewModel.processIntent(
+            MainScreenUiIntent.MarkWalletSheetOpened,
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.walletSheetOpened).isTrue()
+    }
+
+    @Test
+    fun when_set_shown_stage_is_processed_then_shown_stage_is_updated() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.SetShownStage(FirstLaunchTutorialStage.TAP_ANY_NUMBER),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.shownStage).isEqualTo(FirstLaunchTutorialStage.TAP_ANY_NUMBER)
+    }
+
+    @Test
+    fun when_set_shown_stage_with_null_is_processed_then_shown_stage_is_null() = runTest {
+        // Given
+        val viewModel = newViewModel()
+        viewModel.processIntent(
+            MainScreenUiIntent.SetShownStage(FirstLaunchTutorialStage.TAP_DONE_SAVE),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.SetShownStage(null),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value.shownStage).isNull()
+    }
+
+    @Test
+    fun when_set_drag_progress_is_processed_then_update_drag_progress_effect_is_emitted_with_value() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+
+            // When / Then
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.SetDragProgress(0.5f),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+
+                val effect = awaitItem()
+                assertThat(effect).isEqualTo(MainScreenUiEffect.UpdateDragProgress(0.5f))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_set_drag_progress_is_processed_twice_then_effects_are_emitted_in_order() = runTest {
+        // Given
+        val viewModel = newViewModel()
+
+        // When / Then
+        viewModel.effects.test {
+            viewModel.processIntent(
+                MainScreenUiIntent.SetDragProgress(0.25f),
+                currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+            )
+            assertThat(awaitItem()).isEqualTo(MainScreenUiEffect.UpdateDragProgress(0.25f))
+
+            viewModel.processIntent(
+                MainScreenUiIntent.SetDragProgress(0.75f),
+                currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+            )
+            assertThat(awaitItem()).isEqualTo(MainScreenUiEffect.UpdateDragProgress(0.75f))
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun when_advance_tutorial_expected_mismatches_current_then_state_is_unchanged() = runTest {
+        // Given
+        val viewModel = newViewModel()
+        val before = viewModel.uiState.value
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.AdvanceTutorial(FirstLaunchTutorialStage.TAP_ANY_NUMBER),
+            currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value).isEqualTo(before)
+    }
+
+    @Test
+    fun when_advance_tutorial_expected_matches_current_then_state_remains_unchanged() = runTest {
+        // Given
+        val viewModel = newViewModel()
+        val before = viewModel.uiState.value
+
+        // When
+        viewModel.processIntent(
+            MainScreenUiIntent.AdvanceTutorial(FirstLaunchTutorialStage.TAP_DONE_SAVE),
+            currentTutorialStage = FirstLaunchTutorialStage.TAP_DONE_SAVE,
+        )
+
+        // Then
+        assertThat(viewModel.uiState.value).isEqualTo(before)
+    }
+
+    @Test
+    fun when_process_budget_intents_are_processed_then_state_is_unchanged_and_no_effect_is_emitted() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+            val before = viewModel.uiState.value
+
+            // When
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.ProcessBudgetTransactionIntent(
+                        BudgetTransactionIntent.RestoreTransactionTapped(sampleTransaction())
+                    ),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                viewModel.processIntent(
+                    MainScreenUiIntent.ProcessBudgetEditorIntent(
+                        BudgetEditorIntent.SetAnimState(AnimState.IDLE)
+                    ),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                viewModel.processIntent(
+                    MainScreenUiIntent.ProcessBudgetNumpadIntent(
+                        BudgetNumpadIntent.SetDragProgress(0.1f)
+                    ),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                runCurrent()
+
+                // Then
+                assertThat(viewModel.uiState.value).isEqualTo(before)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun when_3500ms_pass_without_user_action_then_snackbar_is_auto_dismissed_and_request_undo_is_emitted() =
+        runTest {
+            // Given
+            val viewModel = newViewModel()
+            viewModel.effects.test {
+                viewModel.processIntent(
+                    MainScreenUiIntent.QueueDeleteWithUndo(sampleTransaction(), "Deleted"),
+                    currentTutorialStage = FirstLaunchTutorialStage.COMPLETED,
+                )
+                advanceUntilIdle()
+                awaitItem()
+
+                // When
+                advanceTimeBy(3_500L.milliseconds)
+                advanceUntilIdle()
+
+                // Then
+                val state = viewModel.uiState.value
+                assertThat(state.pendingDeleteTransaction).isNull()
+                assertThat(state.isSnackbarVisible).isFalse()
+                assertThat(state.snackbarMessage).isEqualTo("")
+                assertThat(state.snackbarActionLabel).isEqualTo("")
+                assertThat(state.snackbarHasUndo).isFalse()
+
+                val effect = awaitItem()
+                assertThat(effect).isEqualTo(MainScreenUiEffect.RequestUndo)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModelTest.kt
@@ -536,4 +536,62 @@ class OnboardingViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    // -------------------------------------------------------------------------
+    // OnWelcomeDismissed — fired by the welcome-step CTA
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_welcome_dismissed_is_called_then_settings_marked_completed_and_effect_emitted`() = runTest {
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+
+        viewModel.effects.test {
+            viewModel.processIntent(OnboardingUiIntent.OnWelcomeDismissed)
+            advanceUntilIdle()
+            runCurrent()
+
+            // Settings flag flipped, state updated, effect emitted.
+            coVerify { settingsRepository.setOnboardingCompleted(true) }
+            assertThat(viewModel.uiState.value.isCompleted).isTrue()
+
+            val effect = awaitItem()
+            assertThat(effect).isEqualTo(OnboardingUiEffect.OnboardingCompleted)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when_welcome_dismissed_is_called_then_no_budget_is_saved_and_no_notification_scheduled`() = runTest {
+        // No stubs needed — the welcome step never touches the budget
+        // repository or the notification scheduler. The relaxed mocks
+        // would still pass; coVerify(exactly = 0) is the actual
+        // assertion of "never called".
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnWelcomeDismissed)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { budgetRepository.saveBudgetSettings(any()) }
+        coVerify(exactly = 0) { notificationScheduler.schedulePeriodEndNotification(any()) }
+        coVerify(exactly = 0) { notificationScheduler.initializeNotifications() }
+    }
+
+    @Test
+    fun `when_welcome_dismissed_fails_with_repo_exception_then_onboarding_failed_effect_is_emitted`() = runTest {
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } throws RuntimeException("datastore locked")
+        val viewModel = newViewModel()
+
+        viewModel.effects.test {
+            viewModel.processIntent(OnboardingUiIntent.OnWelcomeDismissed)
+            advanceUntilIdle()
+            runCurrent()
+
+            val effect = awaitItem()
+            assertThat(effect).isInstanceOf(OnboardingUiEffect.OnboardingFailed::class.java)
+            effect as OnboardingUiEffect.OnboardingFailed
+            assertThat(effect.message).isEqualTo("datastore locked")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,539 @@
+package com.serranoie.app.minus.presentation.ui.onboarding
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.data.repository.BudgetRepository
+import com.serranoie.app.minus.data.repository.SettingsRepository
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.presentation.notification.NotificationScheduler
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Unit tests for [OnboardingViewModel]. Verifies the MVI flow:
+ *   - every [OnboardingUiIntent] routes through the right handler
+ *   - the resulting [OnboardingUiState] matches expectations
+ *   - the budget save + notification schedule + settings persist side
+ *     effects fire on completion
+ *   - the [OnboardingUiEffect.OnboardingCompleted] effect is emitted
+ *     after the user has successfully completed onboarding
+ *
+ * All collaborators are mocked with MockK. The VM's `viewModelScope.launch`
+ * uses [Dispatchers.Main], so we install a [StandardTestDispatcher] in
+ * `@Before` and reset it in `@After` — same recipe as the
+ * [com.serranoie.app.minus.presentation.ui.budget.BudgetViewModelTest].
+ *
+ * Backticked English test names (when_X_then_Y) following the BDD
+ * Given / When / Then convention. The Android DEX bytecode format
+ * rejects spaces in method names, so underscores are used as the word
+ * separator.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingViewModelTest {
+
+    private val budgetRepository: BudgetRepository = mockk(relaxed = true)
+    private val notificationScheduler: NotificationScheduler = mockk(relaxed = true)
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true)
+
+    /**
+     * `viewModelScope` uses `Dispatchers.Main.immediate`, which throws on
+     * a plain JVM test. Install a [StandardTestDispatcher] so the
+     * launched coroutines run on the test scheduler and can be drained
+     * by `runTest` / `advanceUntilIdle`.
+     */
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun newViewModel() = OnboardingViewModel(
+        budgetRepository = budgetRepository,
+        notificationScheduler = notificationScheduler,
+        settingsRepository = settingsRepository,
+    )
+
+    // -------------------------------------------------------------------------
+    // Initial state
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_viewmodel_is_created_then_state_has_defaults`() {
+        val viewModel = newViewModel()
+
+        val state = viewModel.uiState.value
+        assertThat(state.currentStep).isEqualTo(0)
+        assertThat(state.budgetInput).isEqualTo("")
+        assertThat(state.selectedDays).isEqualTo(1)
+        assertThat(state.daysInPeriod).isEqualTo(1)
+        assertThat(state.selectedPeriod).isEqualTo(BudgetPeriod.DAILY)
+        assertThat(state.startDate).isNull()
+        assertThat(state.endDate).isNull()
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.isCompleted).isFalse()
+        assertThat(state.error).isNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // OnBudgetAmountChanged
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_budget_amount_changed_with_valid_input_then_state_is_updated`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.budgetInput).isEqualTo("100.00")
+    }
+
+    @Test
+    fun `when_budget_amount_changed_with_multiple_dots_then_input_is_ignored`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("1.2.3"))
+
+        advanceUntilIdle()
+        // The handler rejects inputs with more than one dot.
+        assertThat(viewModel.uiState.value.budgetInput).isEqualTo("")
+    }
+
+    @Test
+    fun `when_budget_amount_changed_with_input_longer_than_10_chars_then_input_is_ignored`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("12345678901"))
+
+        advanceUntilIdle()
+        // The handler rejects inputs longer than 10 characters.
+        assertThat(viewModel.uiState.value.budgetInput).isEqualTo("")
+    }
+
+    @Test
+    fun `when_budget_amount_changed_with_exactly_10_chars_then_input_is_accepted`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("1234567890"))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.budgetInput).isEqualTo("1234567890")
+    }
+
+    // -------------------------------------------------------------------------
+    // OnDaysSelected — period mapping
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_days_selected_1_then_selected_period_is_daily`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(1))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDays).isEqualTo(1)
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.DAILY)
+    }
+
+    @Test
+    fun `when_days_selected_7_then_selected_period_is_weekly`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDays).isEqualTo(7)
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.WEEKLY)
+    }
+
+    @Test
+    fun `when_days_selected_15_then_selected_period_is_biweekly`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(15))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDays).isEqualTo(15)
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.BIWEEKLY)
+    }
+
+    @Test
+    fun `when_days_selected_30_then_selected_period_is_monthly`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(30))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDays).isEqualTo(30)
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.MONTHLY)
+    }
+
+    @Test
+    fun `when_days_selected_with_unrecognized_value_then_selected_period_falls_back_to_monthly`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(42))
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedDays).isEqualTo(42)
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.MONTHLY)
+    }
+
+    // -------------------------------------------------------------------------
+    // OnNextStep / OnPreviousStep
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_next_step_is_processed_then_current_step_is_incremented`() = runTest {
+        val viewModel = newViewModel()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(0)
+
+        viewModel.processIntent(OnboardingUiIntent.OnNextStep)
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(1)
+    }
+
+    @Test
+    fun `when_next_step_is_processed_at_max_then_current_step_stays_at_max`() = runTest {
+        val viewModel = newViewModel()
+        // OnboardingStep has 3 entries, so the max index is 2.
+        repeat(OnboardingStep.entries.size) { viewModel.processIntent(OnboardingUiIntent.OnNextStep) }
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(OnboardingStep.entries.size - 1)
+
+        viewModel.processIntent(OnboardingUiIntent.OnNextStep)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(OnboardingStep.entries.size - 1)
+    }
+
+    @Test
+    fun `when_previous_step_is_processed_then_current_step_is_decremented`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnNextStep)
+        viewModel.processIntent(OnboardingUiIntent.OnNextStep)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(2)
+
+        viewModel.processIntent(OnboardingUiIntent.OnPreviousStep)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(1)
+    }
+
+    @Test
+    fun `when_previous_step_is_processed_at_zero_then_current_step_stays_at_zero`() = runTest {
+        val viewModel = newViewModel()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(0)
+
+        viewModel.processIntent(OnboardingUiIntent.OnPreviousStep)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.currentStep).isEqualTo(0)
+    }
+
+    // -------------------------------------------------------------------------
+    // OnDateRangeSelected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_date_range_selected_with_daily_display_then_selected_period_is_daily`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        val start = LocalDate.of(2026, 1, 1)
+        val end = LocalDate.of(2026, 1, 31)
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+
+        viewModel.processIntent(OnboardingUiIntent.OnDateRangeSelected(start, end, budgetDisplayDays = 1))
+
+        advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.startDate).isEqualTo(start)
+        assertThat(state.endDate).isEqualTo(end)
+        // 31 days inclusive
+        assertThat(state.selectedDays).isEqualTo(31)
+        assertThat(state.daysInPeriod).isEqualTo(1)
+        assertThat(state.selectedPeriod).isEqualTo(BudgetPeriod.DAILY)
+    }
+
+    @Test
+    fun `when_date_range_selected_with_weekly_display_then_selected_period_is_weekly`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+
+        viewModel.processIntent(
+            OnboardingUiIntent.OnDateRangeSelected(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 7),
+                budgetDisplayDays = 7,
+            )
+        )
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.WEEKLY)
+    }
+
+    @Test
+    fun `when_date_range_selected_with_biweekly_display_then_selected_period_is_biweekly`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+
+        viewModel.processIntent(
+            OnboardingUiIntent.OnDateRangeSelected(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 14),
+                budgetDisplayDays = 14,
+            )
+        )
+
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.selectedPeriod).isEqualTo(BudgetPeriod.BIWEEKLY)
+    }
+
+    @Test
+    fun `when_date_range_selected_then_auto_completes_onboarding`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+
+        viewModel.processIntent(
+            OnboardingUiIntent.OnDateRangeSelected(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 30),
+                budgetDisplayDays = 30,
+            )
+        )
+
+        advanceUntilIdle()
+        // OnDateRangeSelected calls handleCompleteOnboarding() at the end,
+        // so the VM should be marked as completed.
+        assertThat(viewModel.uiState.value.isCompleted).isTrue()
+    }
+
+    // -------------------------------------------------------------------------
+    // OnCompleteOnboarding — success and failure paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_complete_onboarding_is_called_with_valid_budget_then_repository_saves_settings_and_notifications_scheduled_and_settings_persisted`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("1500.50"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(30))
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        coVerify {
+            budgetRepository.saveBudgetSettings(match { settings ->
+                settings.totalBudget == BigDecimal("1500.50") &&
+                    settings.period == BudgetPeriod.MONTHLY &&
+                    settings.currencyCode == "USD" &&
+                    settings.rollOverEnabled &&
+                    !settings.rollOverCarryForward
+            })
+        }
+        coVerify { notificationScheduler.schedulePeriodEndNotification(any()) }
+        coVerify { notificationScheduler.initializeNotifications() }
+        coVerify { settingsRepository.setOnboardingCompleted(true) }
+        assertThat(viewModel.uiState.value.isCompleted).isTrue()
+    }
+
+    @Test
+    fun `when_complete_onboarding_is_called_with_invalid_budget_string_then_state_does_not_advance`() = runTest {
+        val viewModel = newViewModel()
+        // Set an unparseable string
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("not a number"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        // BigDecimal("not a number") throws NumberFormatException, the
+        // handler returns early — isCompleted stays false.
+        assertThat(viewModel.uiState.value.isCompleted).isFalse()
+        coVerify(exactly = 0) { budgetRepository.saveBudgetSettings(any()) }
+        coVerify(exactly = 0) { settingsRepository.setOnboardingCompleted(any()) }
+    }
+
+    @Test
+    fun `when_complete_onboarding_is_called_with_zero_budget_then_state_does_not_advance`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("0"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        // BigDecimal("0") <= BigDecimal.ZERO — handler returns early.
+        assertThat(viewModel.uiState.value.isCompleted).isFalse()
+        coVerify(exactly = 0) { budgetRepository.saveBudgetSettings(any()) }
+    }
+
+    @Test
+    fun `when_complete_onboarding_is_called_with_negative_budget_then_state_does_not_advance`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("-10.00"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        // BigDecimal("-10.00") <= BigDecimal.ZERO — handler returns early.
+        assertThat(viewModel.uiState.value.isCompleted).isFalse()
+        coVerify(exactly = 0) { budgetRepository.saveBudgetSettings(any()) }
+    }
+
+    @Test
+    fun `when_complete_onboarding_is_called_with_no_budget_set_then_state_does_not_advance`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+        // No OnBudgetAmountChanged event — budgetInput stays ""
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        // BigDecimal("") throws NumberFormatException — handler returns early.
+        assertThat(viewModel.uiState.value.isCompleted).isFalse()
+        coVerify(exactly = 0) { budgetRepository.saveBudgetSettings(any()) }
+    }
+
+    @Test
+    fun `when_complete_onboarding_falls_back_to_today_when_start_date_is_null`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+        // startDate is null at this point
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        coVerify {
+            budgetRepository.saveBudgetSettings(match { settings ->
+                settings.startDate == LocalDate.now() &&
+                    settings.endDate == LocalDate.now().plusDays(6)
+            })
+        }
+    }
+
+    @Test
+    fun `when_complete_onboarding_calls_schedule_period_end_notification_with_end_date`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+
+        advanceUntilIdle()
+        coVerify {
+            notificationScheduler.schedulePeriodEndNotification(
+                match { date -> date == LocalDate.now().plusDays(6) }
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Effect channel — OnboardingCompleted
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `when_complete_onboarding_succeeds_then_onboarding_completed_effect_is_emitted()`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } returns Unit
+        coEvery { notificationScheduler.schedulePeriodEndNotification(any()) } returns Unit
+        coEvery { notificationScheduler.initializeNotifications() } returns Unit
+        coEvery { settingsRepository.setOnboardingCompleted(any()) } returns Unit
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.effects.test {
+            viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+            advanceUntilIdle()
+            // Use runCurrent to drain the shared flow emit
+            runCurrent()
+
+            val effect = awaitItem()
+            assertThat(effect).isEqualTo(OnboardingUiEffect.OnboardingCompleted)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when_complete_onboarding_fails_with_invalid_input_then_no_effect_is_emitted`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("invalid"))
+
+        viewModel.effects.test {
+            viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+            advanceUntilIdle()
+            runCurrent()
+
+            // No effect should be emitted because the handler returned
+            // early (NumberFormatException was caught).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when_complete_onboarding_fails_with_repo_exception_then_onboarding_failed_effect_is_emitted`() = runTest {
+        coEvery { budgetRepository.saveBudgetSettings(any()) } throws RuntimeException("disk full")
+        val viewModel = newViewModel()
+        viewModel.processIntent(OnboardingUiIntent.OnBudgetAmountChanged("100.00"))
+        viewModel.processIntent(OnboardingUiIntent.OnDaysSelected(7))
+
+        viewModel.effects.test {
+            viewModel.processIntent(OnboardingUiIntent.OnCompleteOnboarding)
+            advanceUntilIdle()
+            runCurrent()
+
+            val effect = awaitItem()
+            assertThat(effect).isInstanceOf(OnboardingUiEffect.OnboardingFailed::class.java)
+            effect as OnboardingUiEffect.OnboardingFailed
+            assertThat(effect.message).isEqualTo("disk full")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/screenshot/MainScreenScreenshotTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/screenshot/MainScreenScreenshotTest.kt
@@ -65,38 +65,6 @@ class MainScreenScreenshotTest {
     }
 }
 
-class MainScreenTabletScreenshotTest {
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.PIXEL_C,
-        renderingMode = SessionParams.RenderingMode.NORMAL,
-        maxPercentDifference = 10.0,
-    )
-
-    @Test
-    @org.junit.Ignore(
-        "Tablet two-pane layout instantiates HistoryViewModel via hiltViewModel(), " +
-            "which requires an activity context. Paparazzi does not provide one, so " +
-            "the layout cannot be rendered. See MainScreenScreenshotTest#mainScreenPhone* " +
-            "for the phone layout which renders without ViewModels."
-    )
-    fun mainScreenTabletTwoPane() {
-        Locale.setDefault(Locale.US)
-
-        paparazzi.snapshot {
-            MainScreenPreviewContent(
-                budgetUiState = sampleMainBudgetUiState().copy(
-                    numpadInput = "17.25+8.75",
-                    isNumpadValid = true,
-                    isCalculation = true,
-                    animState = AnimState.EDITING,
-                ),
-                windowSizeClass = WindowWidthSizeClass.Expanded,
-            )
-        }
-    }
-}
-
 @Composable
 private fun MainScreenPreviewContent(
     budgetUiState: BudgetUiState,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,9 @@ logcat = "0.4"
 uiTestManifest = "1.8.3"
 paparazzi = "2.0.0-alpha05"
 touchRobot = "0.1.0"
+truth = "1.4.4"
+kotlinxCoroutinesTest = "1.10.2"
+turbine = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -113,6 +116,9 @@ androidx-compose-ui-tooling-v106 = { group = "androidx.compose.ui", name = "ui-t
 androidx-compose-ui-testmanifest-v183 = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "uiTestManifest" }
 touchrobot-core = { group = "me.saket.touchrobot", name = "touchrobot-core", version.ref = "touchRobot" }
 touchrobot-paparazzi = { group = "me.saket.touchrobot", name = "touchrobot-paparazzi", version.ref = "touchRobot" }
+google-truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ touchRobot = "0.1.0"
 truth = "1.4.4"
 kotlinxCoroutinesTest = "1.10.2"
 turbine = "1.2.0"
+mockk = "1.13.13"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -119,6 +120,7 @@ touchrobot-paparazzi = { group = "me.saket.touchrobot", name = "touchrobot-papar
 google-truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,7 @@ google-truth = { group = "com.google.truth", name = "truth", version.ref = "trut
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Description
Decoupled BudgetViewModel into 4 focused controllers with full unit test coverage, refactored the Onboarding flow onto a proper MVI architecture (state / intent / effect) with VM tests and Compose E2E tests, and redesigned the Onboarding screen into a 6-step 2-column grid that better explains Minus's features.

This branch fixes both problems:

- BudgetViewModel is now a thin orchestrator that delegates to 4 pure state-machine controllers - each one independently testable.
- OnboardingViewModel exposes a typed MVI contract (processIntent -> state + effects), ships with 28 unit tests, and the welcome step's "Continue" button now actually navigates to the main app.
- A new Compose E2E suite (23 tests) covers the redesigned Onboarding screen end-to-end on the emulator, including intent dispatch, effect collection, and click handling.

## Change strategy

1. For the BudgetViewModel split: extract a pure state machine (no Android, no Hilt, no coroutines) 
2. OnboardingUiState (data class) + sealed OnboardingUiIntent + sealed OnboardingUiEffect + enum OnboardingStep, following the same pattern as the existing BudgetMviContract and MainScreenMviContract. 
3. Each E2E test instantiates OnboardingViewModel with mockk(relaxed = true) repositories and passes it to the screen. This sidesteps the @AndroidEntryPoint requirement on the test's ComponentActivity and keeps tests focused on wiring (intent -> effect -> callback) rather than on full integration.

## Implemented

 - BudgetViewModel Decouple:
    - NumpadController — numpad input state (24 unit tests)
    - EditorStateController — input validation + editor state (17 unit tests)
    - TransactionActionsController — transaction lifecycle via a TransactionHandler strategy interface (11 unit tests)
    - PeriodActionsController — period actions + isFirstLaunc

## Working demo


## Testing
- [x] Ran `./gradlew :app:testFossDebugUnitTest :app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug -P android.testInstrumentationRunnerArguments.class=`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

<img width="584" height="185" alt="image" src="https://github.com/user-attachments/assets/ced94673-2e0b-4bfc-8d2b-29a14c8e72ab" />

