### PR TITLE
feat: added badge and info on settings about privacy/censor mode

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -35,6 +35,8 @@ import androidx.compose.material.icons.rounded.CreditCard
 import androidx.compose.material.icons.rounded.EventRepeat
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -84,6 +86,7 @@ import com.serranoie.app.minus.presentation.ui.theme.component.AutoResizeBasicTe
 import com.serranoie.app.minus.presentation.ui.theme.component.budget.BudgetPill
 import com.serranoie.app.minus.presentation.ui.theme.component.numpad.EditStage
 import com.serranoie.app.minus.presentation.ui.theme.displayLargeCondensed
+import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import com.serranoie.app.minus.presentation.util.Utils.weakHapticFeedback
 import com.serranoie.app.minus.presentation.util.symbolOnlyCurrencyFormat
 import kotlinx.coroutines.delay
@@ -241,6 +244,7 @@ fun Editor(
                         }
 
                         if (showSettingsButton) {
+                            val isCensored = LocalCensorMode.current
                             IconButton(
                                 onClick = {
                                     onOpenSettings()
@@ -248,12 +252,16 @@ fun Editor(
                                 },
                                 modifier = Modifier.size(48.dp)
                             ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Settings,
-                                    contentDescription = "Settings",
-                                    tint = MaterialTheme.colorScheme.onSurface,
-                                    modifier = Modifier.size(28.dp),
-                                )
+                                BadgedBox(
+                                    badge = { if (isCensored) Badge() },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Settings,
+                                        contentDescription = "Settings",
+                                        tint = MaterialTheme.colorScheme.onSurface,
+                                        modifier = Modifier.size(28.dp),
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.BarChart
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -97,6 +99,7 @@ import com.serranoie.app.minus.presentation.ui.theme.component.numpad.Numpad
 import com.serranoie.app.minus.presentation.ui.theme.isNightMode
 import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
 import com.serranoie.app.minus.presentation.ui.tutorial.FIRST_LAUNCH_TUTORIAL_STAGE_KEY
+import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import com.serranoie.app.minus.presentation.util.StatusBarPadding
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -339,7 +342,14 @@ private fun MainNavigationRail(
             modifier = itemModifier,
             selected = false,
             onClick = onNavigateToSettings,
-            icon = { Icon(Icons.Rounded.Settings, contentDescription = "Settings") },
+            icon = {
+                val isCensored = LocalCensorMode.current
+                BadgedBox(
+                    badge = { if (isCensored) Badge() },
+                ) {
+                    Icon(Icons.Rounded.Settings, contentDescription = "Settings")
+                }
+            },
             label = { Text("Settings") })
         Spacer(Modifier.weight(1f))
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
@@ -6,6 +6,7 @@ import android.app.TimePickerDialog
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -38,12 +39,15 @@ import androidx.compose.material.icons.filled.Publish
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.outlined.RemoveRedEye
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
@@ -65,6 +69,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -81,6 +86,7 @@ import com.serranoie.app.minus.domain.model.PeriodMappingMode
 import com.serranoie.app.minus.presentation.ui.history.RecurrentPaymentsViewMode
 import com.serranoie.app.minus.presentation.ui.settings.bugreport.buildAppEnvironmentMetadata
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.presentation.ui.theme.bodySmallCondensed
 import com.serranoie.app.minus.presentation.ui.theme.component.CustomPaddedExpandableItem
 import com.serranoie.app.minus.presentation.ui.theme.component.CustomPaddedListItem
 import com.serranoie.app.minus.presentation.ui.theme.component.PaddedListGroup
@@ -89,15 +95,16 @@ import com.serranoie.app.minus.presentation.ui.theme.labelLargeCondensed
 import com.serranoie.app.minus.presentation.util.Utils
 import com.serranoie.app.minus.presentation.util.Utils.toggleFeedback
 import com.serranoie.app.minus.presentation.util.Utils.weakHapticFeedback
+import kotlinx.coroutines.launch
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun Settings(
 	modifier: Modifier = Modifier,
+	isCensored: Boolean = false,
 	currentTheme: String,
 	currentTypography: String,
 	isMaterialYouEnabled: Boolean,
@@ -176,6 +183,50 @@ fun Settings(
 				.padding(paddingValues)
 				.testTag("SettingsScreen"),
 		) {
+			if (isCensored) {
+				item {
+					OutlinedCard(
+						modifier = Modifier
+							.fillMaxWidth()
+							.padding(horizontal = 16.dp, vertical = 8.dp),
+						shape = MaterialTheme.shapes.large,
+						border = BorderStroke(
+							1.dp,
+							MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+						),
+						colors = CardDefaults.outlinedCardColors(
+							containerColor = Color.Transparent
+						),
+					) {
+						Column(
+							modifier = Modifier
+								.fillMaxWidth()
+								.padding(horizontal = 12.dp, vertical = 14.dp),
+						) {
+							Row(verticalAlignment = Alignment.CenterVertically) {
+								Icon(
+									imageVector = Icons.Outlined.RemoveRedEye,
+									contentDescription = null,
+									tint = MaterialTheme.colorScheme.outline,
+									modifier = Modifier.size(20.dp)
+								)
+								Spacer(modifier = Modifier.width(8.dp))
+								Text(
+									text = stringResource(R.string.censor_mode_card_label),
+									style = MaterialTheme.typography.bodySmallCondensed,
+									color = MaterialTheme.colorScheme.outline,
+								)
+							}
+							Text(
+								text = stringResource(R.string.censor_mode_card_body),
+								modifier = Modifier.padding(top = 4.dp),
+								style = MaterialTheme.typography.bodySmallCondensed,
+								color = MaterialTheme.colorScheme.onSurface,
+							)
+						}
+					}
+				}
+			}
 			item {
 				PaddedListGroup(
 					title = stringResource(R.string.settings_section_appearance)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import dagger.hilt.android.EntryPointAccessors
 
 @Composable
@@ -18,6 +19,7 @@ fun SettingsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val isCensored = LocalCensorMode.current
 
     val importLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
@@ -50,6 +52,7 @@ fun SettingsScreen(
     }
 
     Settings(
+        isCensored = isCensored,
         currentTheme = uiState.currentTheme,
         currentTypography = uiState.currentTypography,
         isMaterialYouEnabled = uiState.isMaterialYouEnabled,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,6 +167,11 @@
     <string name="onboarding_step_6_subtitle">Con el tiempo, aprende cuánto puedes ahorrar y cuánto puedes gastar.</string>
     <string name="onboarding_set_budget_button">Continuar</string>
     <string name="recurrent_toggle_label">Recurrente</string>
+    <string name="censor_mode_alert_title">Modo de censura activo</string>
+    <string name="censor_mode_alert_message">Todos tus valores financieros están difuminados.</string>
+    <string name="censor_mode_alert_dismiss">Entendido</string>
+    <string name="censor_mode_card_label">Modo privado activado</string>
+    <string name="censor_mode_card_body">Cubre la parte superior del teléfono (donde está la cámara) con la mano durante un segundo para desactivarlo.</string>
 
     <string name="onboarding_finish_date_selector_title">Selecciona el periodo</string>
     <string name="onboarding_finish_date_selector_days_range">%1$d días · %2$s - %3$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -170,6 +170,11 @@
     <string name="onboarding_step_6_subtitle">Avec le temps, apprenez combien vous pouvez économiser et dépenser.</string>
     <string name="onboarding_set_budget_button">Continuer</string>
     <string name="recurrent_toggle_label">Récurrent</string>
+    <string name="censor_mode_alert_title">Mode censure activé</string>
+    <string name="censor_mode_alert_message">Toutes vos valeurs financières sont floutées.</string>
+    <string name="censor_mode_alert_dismiss">Compris</string>
+    <string name="censor_mode_card_label">Mode privé activé</string>
+    <string name="censor_mode_card_body">Couvrez le haut du téléphone (là où se trouve l\'appareil photo) avec votre main pendant environ une seconde pour l\'éteindre.</string>
 
     <!-- Finish Date Selector -->
     <string name="onboarding_finish_date_selector_title">Sélectionnez la période</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,11 @@
     <string name="onboarding_step_6_subtitle">Over time, learn how much you can save and how much you can spend.</string>
     <string name="onboarding_set_budget_button">Continue</string>
     <string name="recurrent_toggle_label">Recurrent</string>
+    <string name="censor_mode_alert_title">Censor mode is active</string>
+    <string name="censor_mode_alert_message">All your financial values are currently blurred.</string>
+    <string name="censor_mode_alert_dismiss">Got it</string>
+    <string name="censor_mode_card_label">Privacy mode activated</string>
+    <string name="censor_mode_card_body">Cover the top of the phone (where the camera sits) with your hand for about a second to turn it off.</string>
 
     <!-- Finish Date Selector -->
     <string name="onboarding_finish_date_selector_title">Select the period</string>


### PR DESCRIPTION
## Description
PR about feature request #33, merging this closes the issue.

## Change strategy
Added a small badge and a new card when activated on settings.

## Implemented
- Small badge at settings icon
- Outlined card with the info regarding the mode when activated

## Working demo
https://github.com/user-attachments/assets/6059ed8d-7ad3-4e0a-bbb0-0f125b2a45b7

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
N/A
