### PR TITLE
feat: add more currencies and fix currency code on components

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
@@ -1,7 +1,12 @@
 package com.serranoie.app.minus.domain.model
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalConfiguration
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.Currency
+import java.util.Locale
 
 enum class BudgetPeriod {
     DAILY, WEEKLY, BIWEEKLY, MONTHLY
@@ -14,39 +19,58 @@ enum class RemainingBudgetStrategy {
 data class SupportedCurrency(
     val code: String,
     val symbol: String,
-    val name: String,
 ) {
+    fun displayName(locale: Locale = Locale.getDefault()): String =
+        runCatching { Currency.getInstance(code).getDisplayName(locale) }
+            .getOrDefault(code)
+
+    @Composable
+    @ReadOnlyComposable
+    fun displayName(): String {
+        val locale = LocalConfiguration.current.locales[0]
+        return displayName(locale)
+    }
+
     companion object {
         val ALL = listOf(
-            SupportedCurrency("USD", "$", "Dólar estadounidense"),
-            SupportedCurrency("MXN", "$", "Peso mexicano"),
-            SupportedCurrency("EUR", "€", "Euro"),
-            SupportedCurrency("GBP", "£", "Libra esterlina"),
-            SupportedCurrency("JPY", "¥", "Yen japonés"),
-            SupportedCurrency("CNY", "¥", "Yuan chino"),
-            SupportedCurrency("KRW", "₩", "Won surcoreano"),
-            SupportedCurrency("INR", "₹", "Rupia india"),
-            SupportedCurrency("BRL", "R$", "Real brasileño"),
-            SupportedCurrency("ARS", "$", "Peso argentino"),
-            SupportedCurrency("COP", "$", "Peso colombiano"),
-            SupportedCurrency("CLP", "$", "Peso chileno"),
-            SupportedCurrency("PEN", "S/", "Sol peruano"),
-            SupportedCurrency("CAD", "CA$", "Dólar canadiense"),
-            SupportedCurrency("AUD", "A$", "Dólar australiano"),
-            SupportedCurrency("CHF", "CHF", "Franco suizo"),
-            SupportedCurrency("SEK", "kr", "Corona sueca"),
-            SupportedCurrency("NOK", "kr", "Corona noruega"),
-            SupportedCurrency("DKK", "kr", "Corona danesa"),
-            SupportedCurrency("PLN", "zł", "Zloty polaco"),
-            SupportedCurrency("TRY", "₺", "Lira turca"),
-            SupportedCurrency("RUB", "₽", "Rublo ruso"),
-            SupportedCurrency("THB", "฿", "Baht tailandés"),
-            SupportedCurrency("PHP", "₱", "Peso filipino"),
-            SupportedCurrency("TWD", "NT$", "Dólar taiwanés"),
-            SupportedCurrency("ILS", "₪", "Shekel israelí"),
-            SupportedCurrency("ZAR", "R", "Rand sudafricano"),
-            SupportedCurrency("NGN", "₦", "Naira nigeriana"),
-            SupportedCurrency("EGP", "E£", "Libra egipcia"),
+            SupportedCurrency("USD", "$"),
+            SupportedCurrency("MXN", "$"),
+            SupportedCurrency("EUR", "€"),
+            SupportedCurrency("GBP", "£"),
+            SupportedCurrency("HKD", "HK$"),
+            SupportedCurrency("SGD", "S$"),
+            SupportedCurrency("JPY", "¥"),
+            SupportedCurrency("CNY", "¥"),
+            SupportedCurrency("KRW", "₩"),
+            SupportedCurrency("INR", "₹"),
+            SupportedCurrency("PKR", "₨"),
+            SupportedCurrency("BDT", "৳"),
+            SupportedCurrency("MYR", "RM"),
+            SupportedCurrency("IDR", "Rp"),
+            SupportedCurrency("VND", "₫"),
+            SupportedCurrency("BRL", "R$"),
+            SupportedCurrency("ARS", "$"),
+            SupportedCurrency("COP", "$"),
+            SupportedCurrency("CLP", "$"),
+            SupportedCurrency("PEN", "S/"),
+            SupportedCurrency("CAD", "CA$"),
+            SupportedCurrency("AUD", "A$"),
+            SupportedCurrency("NZD", "NZ$"),
+            SupportedCurrency("CHF", "CHF"),
+            SupportedCurrency("SEK", "kr"),
+            SupportedCurrency("NOK", "kr"),
+            SupportedCurrency("DKK", "kr"),
+            SupportedCurrency("PLN", "zł"),
+            SupportedCurrency("TRY", "₺"),
+            SupportedCurrency("RUB", "₽"),
+            SupportedCurrency("THB", "฿"),
+            SupportedCurrency("PHP", "₱"),
+            SupportedCurrency("TWD", "NT$"),
+            SupportedCurrency("ILS", "₪"),
+            SupportedCurrency("AED", "د.إ"),
+            SupportedCurrency("ZAR", "R"),
+            SupportedCurrency("NGN", "₦"),
+            SupportedCurrency("EGP", "E£"),
         )
 
         fun findByCode(code: String): SupportedCurrency? =

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -293,7 +293,7 @@ private fun AnalyticsCompactLayout(
             MinMaxSpentCard(
                 isMin = true,
                 spends = state.spends,
-                currency = "MXN",
+                currency = state.currencyCode,
                 modifier = Modifier
 					.weight(1f)
 					.fillMaxHeight(),
@@ -302,7 +302,7 @@ private fun AnalyticsCompactLayout(
             MinMaxSpentCard(
                 isMin = false,
                 spends = state.spends,
-                currency = "MXN",
+                currency = state.currencyCode,
                 modifier = Modifier
 					.weight(1f)
 					.fillMaxHeight(),
@@ -326,7 +326,7 @@ private fun AnalyticsCompactLayout(
                 spends = state.spends,
                 startDate = state.startPeriodDate,
                 finishDate = state.finishPeriodDate,
-                currency = "MXN",
+                currency = state.currencyCode,
                 modifier = Modifier
 					.weight(1f)
 					.fillMaxHeight(),
@@ -336,6 +336,7 @@ private fun AnalyticsCompactLayout(
         SpendBudgetCard(
             budget = state.wholeBudget,
             spend = state.spends.sumOf { it.amount },
+            currency = state.currencyCode,
             modifier = Modifier
 				.fillMaxWidth()
 				.padding(horizontal = 16.dp),
@@ -343,7 +344,7 @@ private fun AnalyticsCompactLayout(
         Spacer(modifier = Modifier.height(16.dp))
         CategoriesChartCard(
             spends = state.spends,
-            currency = "MXN",
+            currency = state.currencyCode,
             modifier = Modifier
 				.padding(horizontal = 16.dp)
 				.fillMaxWidth(),
@@ -395,7 +396,7 @@ private fun AnalyticsTabletLayout(
                 MinMaxSpentCard(
                     isMin = true,
                     spends = state.spends,
-                    currency = "MXN",
+                    currency = state.currencyCode,
                     modifier = Modifier
 						.weight(1f)
 						.fillMaxHeight(),
@@ -404,7 +405,7 @@ private fun AnalyticsTabletLayout(
                 MinMaxSpentCard(
                     isMin = false,
                     spends = state.spends,
-                    currency = "MXN",
+                    currency = state.currencyCode,
                     modifier = Modifier
 						.weight(1f)
 						.fillMaxHeight(),
@@ -420,6 +421,7 @@ private fun AnalyticsTabletLayout(
             SpendBudgetCard(
                 budget = state.wholeBudget,
                 spend = state.spends.sumOf { it.amount },
+                currency = state.currencyCode,
                 modifier = Modifier.weight(1f),
             )
             Spacer(modifier = Modifier.width(16.dp))
@@ -440,7 +442,7 @@ private fun AnalyticsTabletLayout(
                     spends = state.spends,
                     startDate = state.startPeriodDate,
                     finishDate = state.finishPeriodDate,
-                    currency = "MXN",
+                    currency = state.currencyCode,
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -448,7 +450,7 @@ private fun AnalyticsTabletLayout(
         Spacer(modifier = Modifier.height(8.dp))
         CategoriesChartCard(
             spends = state.spends,
-            currency = "MXN",
+            currency = state.currencyCode,
             modifier = Modifier.fillMaxWidth(),
             onCategoryClick = onCategoryClick
         )
@@ -468,7 +470,8 @@ private fun AnalyticsState.toCategoryAnalyticsState(
     finishPeriodDate = finishPeriodDate,
     isLoading = isLoading,
     categoryName = categoryName,
-    categorySpends = categorySpends
+    categorySpends = categorySpends,
+    currencyCode = currencyCode,
 )
 
 private val previewStartDate: Date

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
@@ -53,7 +53,8 @@ data class CategoryAnalyticsState(
     val finishPeriodDate: Date? = null,
     val isLoading: Boolean = false,
     val categoryName: String = "",
-    val categorySpends: List<Transaction> = emptyList()
+    val categorySpends: List<Transaction> = emptyList(),
+    val currencyCode: String = "USD"
 )
 
 @Composable
@@ -98,6 +99,7 @@ fun CategoryAnalytics(
             ) {
                 DetailedChart(
                     spends = state.categorySpends,
+                    currencyCode = state.currencyCode,
                     modifier = Modifier.fillMaxSize(),
                     chartPadding = PaddingValues(
                         horizontal = 16.dp,
@@ -111,7 +113,7 @@ fun CategoryAnalytics(
         } else if (state.categorySpends.size == 1) {
             val transaction = state.categorySpends.first()
             val currencyFormat =
-                symbolOnlyCurrencyFormat("USD")
+                symbolOnlyCurrencyFormat(state.currencyCode)
 
             Card(
                 modifier = Modifier
@@ -151,7 +153,7 @@ fun CategoryAnalytics(
                 spends = state.categorySpends,
                 startDate = state.startPeriodDate,
                 finishDate = state.finishPeriodDate,
-                currency = "USD",
+                currency = state.currencyCode,
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
             )
 
@@ -160,7 +162,7 @@ fun CategoryAnalytics(
 
         if (state.categorySpends.isNotEmpty()) {
             val currencyFormat =
-                symbolOnlyCurrencyFormat("USD")
+                symbolOnlyCurrencyFormat(state.currencyCode)
 
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -346,6 +346,7 @@ private fun ViewBudgetContent(
                 .padding(bottom = 8.dp),
             budget = totalBudget,
             spend = totalSpent,
+            currency = currencyCode,
         )
 
         Row(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -903,7 +903,7 @@ fun EditBudgetContent(
     }
 
     if (showCurrencyPicker) {
-        CurrencyPickerDialog(
+        CurrencySelectorDialog(
             currentCode = currencyCache,
             onDismiss = { showCurrencyPicker = false },
             onSelect = { code ->
@@ -962,83 +962,6 @@ private fun SettingsRow(
             )
         }
     }
-}
-
-@Composable
-private fun CurrencyPickerDialog(
-    currentCode: String,
-    onDismiss: () -> Unit,
-    onSelect: (String) -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(
-                stringResource(R.string.select_currency),
-                style = MaterialTheme.typography.titleLargeEmphasized
-            )
-        },
-        text = {
-            Column(
-                modifier = Modifier
-                    .heightIn(max = 400.dp)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                SupportedCurrency.ALL.forEach { currency ->
-                    val isSelected = currency.code == currentCode
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .clickable { onSelect(currency.code) }
-                            .padding(vertical = 12.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = currency.symbol,
-                            style = MaterialTheme.typography.titleMediumEmphasized,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.width(40.dp),
-                        )
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = currency.code,
-                                style = MaterialTheme.typography.bodyMediumEmphasized,
-                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                color = if (isSelected) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    MaterialTheme.colorScheme.onSurface
-                                },
-                            )
-                            Text(
-                                text = currency.name,
-                                style = MaterialTheme.typography.bodySmallCondensed,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        if (isSelected) {
-                            Icon(
-                                imageVector = Icons.Default.Check,
-                                contentDescription = stringResource(R.string.currency_selected),
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(20.dp),
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(
-                    stringResource(R.string.close),
-                    style = MaterialTheme.typography.labelMediumEmphasized
-                )
-            }
-        },
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/CurrencySelectorDialog.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/CurrencySelectorDialog.kt
@@ -1,0 +1,122 @@
+package com.serranoie.app.minus.presentation.ui.editor.sheets
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.serranoie.app.minus.R
+import com.serranoie.app.minus.domain.model.SupportedCurrency
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.presentation.ui.theme.bodySmallCondensed
+
+@Composable
+fun CurrencySelectorDialog(
+    currentCode: String,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                stringResource(R.string.select_currency),
+                style = MaterialTheme.typography.titleLargeEmphasized
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                SupportedCurrency.ALL.forEach { currency ->
+                    val isSelected = currency.code == currentCode
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable { onSelect(currency.code) }
+                            .padding(vertical = 12.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = currency.symbol,
+                            style = MaterialTheme.typography.titleMediumEmphasized,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.width(50.dp),
+                        )
+                        Column(modifier = Modifier.weight(1f).padding(start = 4.dp)) {
+                            Text(
+                                text = currency.code,
+                                style = MaterialTheme.typography.bodyMediumEmphasized,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                color = if (isSelected) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                            )
+                            Text(
+                                text = currency.displayName(),
+                                style = MaterialTheme.typography.bodySmallCondensed,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (isSelected) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = stringResource(R.string.currency_selected),
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    stringResource(R.string.close),
+                    style = MaterialTheme.typography.labelMediumEmphasized
+                )
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CurrencySelectorDialogPreview() {
+    MinusTheme {
+        CurrencySelectorDialog(
+            currentCode = "USD",
+            onDismiss = {},
+            onSelect = {}
+        )
+    }
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/BudgetDisplay.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/BudgetDisplay.kt
@@ -341,15 +341,11 @@ fun Arrow(
     }
 }
 
-@Preview
+@Preview(device = "id:pixel_tablet", showBackground = true)
 @Composable
-private fun PreviewChart() {
+private fun PreviewArrow() {
     MinusTheme {
         Box {
-            Icon(
-                imageVector = Icons.Default.ArrowForward,
-                contentDescription = null,
-            )
             Arrow(
                 modifier = Modifier
                     .height(24.dp)
@@ -359,12 +355,12 @@ private fun PreviewChart() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun PreviewCross() {
     MinusTheme {
         Cross {
-            Text(text = "Days count")
+            Text(text = "Just a normal date here")
         }
     }
 }
@@ -441,7 +437,7 @@ private fun BudgetDisplayPreview_OverBudget() {
     }
 }
 
-@Preview(device = "spec:width=800px,height=500px")
+@Preview(device = "spec:width=1800px,height=900px,dpi=320")
 @Composable
 private fun BudgetDisplayPreview_RolloverSplit() {
     MinusTheme {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/SpendBudgetCard.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/SpendBudgetCard.kt
@@ -120,6 +120,7 @@ fun SpendBudgetCard(
     modifier: Modifier = Modifier,
     budget: BigDecimal,
     spend: BigDecimal,
+    currency: String = "USD",
 ) {
     val context: Context = LocalContext.current
 
@@ -193,7 +194,7 @@ fun SpendBudgetCard(
                     .padding(vertical = 16.dp, horizontal = 24.dp),
             ) {
                 Text(
-                    text = numberFormat(context, spend, "MXN"),
+                    text = numberFormat(context, spend, currency),
                     style = MaterialTheme.typography.displaySmallEmphasized.copy(fontWeight = FontWeight.Light),
                     fontSize = MaterialTheme.typography.titleLargeEmphasized.fontSize,
                     overflow = TextOverflow.Ellipsis,
@@ -246,6 +247,7 @@ private fun PreviewSpendBudgetCard() {
                 modifier = Modifier.height(IntrinsicSize.Min),
                 spend = BigDecimal(3740),
                 budget = BigDecimal(60000),
+                currency = "INR"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -254,6 +256,7 @@ private fun PreviewSpendBudgetCard() {
                 modifier = Modifier.height(IntrinsicSize.Min),
                 spend = BigDecimal(30740),
                 budget = BigDecimal(60000),
+                currency = "EUR"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -262,6 +265,16 @@ private fun PreviewSpendBudgetCard() {
                 modifier = Modifier.height(IntrinsicSize.Min),
                 spend = BigDecimal(45740),
                 budget = BigDecimal(60000),
+                currency = "BKT"
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SpendBudgetCard(
+                modifier = Modifier.height(IntrinsicSize.Min),
+                spend = BigDecimal(58000),
+                budget = BigDecimal(60000),
+                currency = "MXN"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -270,6 +283,7 @@ private fun PreviewSpendBudgetCard() {
                 modifier = Modifier.height(IntrinsicSize.Min),
                 spend = BigDecimal.ZERO,
                 budget = BigDecimal(60000),
+                currency = "VND"
             )
         }
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/CategoriesChartCard.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/CategoriesChartCard.kt
@@ -315,33 +315,7 @@ private fun PreviewCategoriesChart() {
                     comment = "Food",
                     date = LocalDateTime.now(),
                     isDeleted = false
-                ),
-                Transaction(
-                    amount = BigDecimal(50),
-                    comment = "Streaming",
-                    date = LocalDateTime.now(),
-                    isDeleted = false
-                ),
-                Transaction(
-                    amount = BigDecimal(20),
-                    comment = "Gas",
-                    date = LocalDateTime.now(),
-                    isDeleted = false
-                ),
-
-                Transaction(
-                    amount = BigDecimal(200),
-                    comment = "Gym",
-                    date = LocalDateTime.now(),
-                    isDeleted = false
-                ),
-
-                Transaction(
-                    amount = BigDecimal(15),
-                    comment = "Internet",
-                    date = LocalDateTime.now(),
-                    isDeleted = false
-                ),
+                )
             )
         )
     }


### PR DESCRIPTION
## Description
Increment the coverage for the available currencies on the `CurrencySelectorDialog`

## Change strategy
Refactored the `BudgetPeriod` model in only accept the Currency text value and it's symbol, on app using `LocalConfiguration.current.locales` automatically gets the correct locale depending on the user phone.

## Implemented
- Added 10+ more currencies
- Refactor currency name value
- Use budget period data state to fetch for the correct `currencyCode` for missing components

## Working demo
https://github.com/user-attachments/assets/1fad25c6-0fa8-40cc-b98a-a65f8a251b1d


## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This PR will close #54 & #50 since it fixes the hardcoded `currencyCode` and implement new currencies into the list.
