### PR TITLE
fix: show donut chart when only 1 category and enhance card

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -46,6 +46,7 @@ import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.LocalWindowInsets
 import com.serranoie.app.minus.presentation.ui.analytics.dialogs.CategoryAnalytics
 import com.serranoie.app.minus.presentation.ui.analytics.dialogs.CategoryAnalyticsState
+import com.serranoie.app.minus.presentation.ui.analytics.util.previewAnalyticsState
 import com.serranoie.app.minus.presentation.ui.history.HistoryScreen
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.FinishedPeriodHeader
@@ -472,67 +473,6 @@ private fun AnalyticsState.toCategoryAnalyticsState(
     categoryName = categoryName,
     categorySpends = categorySpends,
     currencyCode = currencyCode,
-)
-
-private val previewStartDate: Date
-    get() = Calendar.getInstance().apply {
-        add(Calendar.DAY_OF_MONTH, -34)
-    }.time
-
-private val previewFinishDate: Date
-    get() = Calendar.getInstance().apply {
-        add(Calendar.DAY_OF_MONTH, 7)
-    }.time
-
-private fun previewAnalyticsTransactions(): List<Transaction> {
-    val categories = listOf(
-        "Comida",
-        "Transporte",
-        "Entretenimiento",
-        "Salud",
-        "Servicios",
-        "Compras",
-        "Café",
-        "Mascotas",
-        "Gimnasio",
-        "Regalos",
-    )
-
-    return categories.flatMapIndexed { index, category ->
-        listOf(
-            Transaction(
-                amount = BigDecimal(45 + index * 18),
-                date = LocalDateTime.now().minusDays((index * 3L) + 1),
-                comment = category,
-            ),
-            Transaction(
-                amount = BigDecimal(30 + index * 11),
-                date = LocalDateTime.now().minusDays((index * 3L) + 2),
-                comment = category,
-            ),
-        )
-    } + listOf(
-        Transaction(
-            amount = BigDecimal(180),
-            date = LocalDateTime.now().minusDays(31),
-            comment = "",
-        ),
-        Transaction(
-            amount = BigDecimal(96),
-            date = LocalDateTime.now().minusDays(27),
-            comment = "Comida",
-        ),
-    )
-}
-
-private fun previewAnalyticsState(periodFinished: Boolean): AnalyticsState = AnalyticsState(
-    periodFinished = periodFinished,
-    transactions = previewAnalyticsTransactions(),
-    spends = previewAnalyticsTransactions(),
-    wholeBudget = BigDecimal(2400),
-    startPeriodDate = previewStartDate,
-    finishPeriodDate = if (periodFinished) Date() else previewFinishDate,
-    finishPeriodActualDate = if (periodFinished) Date() else null,
 )
 
 @PreviewScreenSizes

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/util/AnalyticsPreviewHelpers.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/util/AnalyticsPreviewHelpers.kt
@@ -1,0 +1,52 @@
+package com.serranoie.app.minus.presentation.ui.analytics.util
+
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.presentation.ui.analytics.AnalyticsState
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Calendar
+import java.util.Date
+
+val previewStartDate: Date
+    get() =
+        Calendar
+            .getInstance()
+            .apply {
+                add(Calendar.DAY_OF_MONTH, -34)
+            }.time
+
+val previewFinishDate: Date
+    get() =
+        Calendar
+            .getInstance()
+            .apply {
+                add(Calendar.DAY_OF_MONTH, 7)
+            }.time
+
+fun previewAnalyticsTransactions(): List<Transaction> {
+    val categories =
+        listOf(
+            "Comida",
+        )
+
+    return categories.flatMapIndexed { index, category ->
+        listOf(
+            Transaction(
+                amount = BigDecimal(45 + index * 18),
+                date = LocalDateTime.now().minusDays((index * 3L) + 1),
+                comment = category,
+            ),
+        )
+    }
+}
+
+fun previewAnalyticsState(periodFinished: Boolean): AnalyticsState =
+    AnalyticsState(
+        periodFinished = periodFinished,
+        transactions = previewAnalyticsTransactions(),
+        spends = previewAnalyticsTransactions(),
+        wholeBudget = BigDecimal(2400),
+        startPeriodDate = previewStartDate,
+        finishPeriodDate = if (periodFinished) Date() else previewFinishDate,
+        finishPeriodActualDate = if (periodFinished) Date() else null,
+    )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/BudgetPill.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/BudgetPill.kt
@@ -21,12 +21,15 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -105,21 +108,15 @@ fun BudgetPill(
     val (periodBudget, periodSpent, periodRemaining) = when (period) {
         BudgetPeriod.DAILY -> Triple(dailyBudgetAmount, dailySpent, dailyRemainingAmount)
         BudgetPeriod.WEEKLY -> Triple(
-            weeklyBudgetAmount,
-            periodSpentAggregate,
-            weeklyRemainingAmount
+            weeklyBudgetAmount, periodSpentAggregate, weeklyRemainingAmount
         )
 
         BudgetPeriod.BIWEEKLY -> Triple(
-            biweeklyBudgetAmount,
-            periodSpentAggregate,
-            biweeklyRemainingAmount
+            biweeklyBudgetAmount, periodSpentAggregate, biweeklyRemainingAmount
         )
 
         BudgetPeriod.MONTHLY -> Triple(
-            monthlyBudgetAmount,
-            periodSpentAggregate,
-            monthlyRemainingAmount
+            monthlyBudgetAmount, periodSpentAggregate, monthlyRemainingAmount
         )
     }
 
@@ -149,9 +146,7 @@ fun BudgetPill(
                     0 -> null
                     1 -> stringResource(R.string.budget_pill_exhausted_single, exhausted.first())
                     2 -> stringResource(
-                        R.string.budget_pill_exhausted_double,
-                        exhausted[0],
-                        exhausted[1]
+                        R.string.budget_pill_exhausted_double, exhausted[0], exhausted[1]
                     )
 
                     else -> null
@@ -172,9 +167,7 @@ fun BudgetPill(
                     0 -> null
                     1 -> stringResource(R.string.budget_pill_exhausted_single, exhausted.first())
                     2 -> stringResource(
-                        R.string.budget_pill_exhausted_double,
-                        exhausted[0],
-                        exhausted[1]
+                        R.string.budget_pill_exhausted_double, exhausted[0], exhausted[1]
                     )
 
                     else -> stringResource(
@@ -208,8 +201,7 @@ fun BudgetPill(
     val bad = colorBad
     val harmonizedColor = remember(spendProgress, primaryColor, isDarkTheme, good, notGood, bad) {
         val combined = combineColors(
-            listOf(good, notGood, bad),
-            spendProgress.coerceIn(0f, 1f)
+            listOf(good, notGood, bad), spendProgress.coerceIn(0f, 1f)
         )
         val harmonized = harmonizeWithColor(combined, primaryColor)
         toPaletteWithTheme(harmonized, isDarkTheme)
@@ -227,8 +219,7 @@ fun BudgetPill(
     )
 
     Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Card(
             modifier = Modifier.height(if (showExhaustedMessage) 50.dp else 50.dp),
@@ -240,8 +231,7 @@ fun BudgetPill(
             onClick = onOpenBudgetSheet
         ) {
             Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
+                modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center
             ) {
                 // Background progress indicator
                 if (!bigVariant) {
@@ -252,8 +242,7 @@ fun BudgetPill(
                             .clip(CircleShape),
                         color = harmonizedColor.main,
                         trackColor = Color.Transparent,
-                        drawStopIndicator = {}
-                    )
+                        drawStopIndicator = {})
 
 // 					val density  = LocalDensity.current
 // 					val strokeWidthPx = with(density) { 28.dp.toPx() }
@@ -277,25 +266,17 @@ fun BudgetPill(
                     modifier = Modifier.fillMaxSize(),
                     transitionSpec = {
                         if (targetState) {
-                            (
-                                slideInHorizontally(animationSpec = tween(220)) { it / 5 } + fadeIn(
-                                    tween(180)
-                                )
-                                ) togetherWith (
-                                slideOutHorizontally(animationSpec = tween(180)) { -it / 5 } + fadeOut(
-                                    tween(120)
-                                )
-                                )
+                            (slideInHorizontally(animationSpec = tween(220)) { it / 5 } + fadeIn(
+                                tween(180)
+                            )) togetherWith (slideOutHorizontally(animationSpec = tween(180)) { -it / 5 } + fadeOut(
+                                tween(120)
+                            ))
                         } else {
-                            (
-                                slideInHorizontally(animationSpec = tween(220)) { -it / 5 } + fadeIn(
-                                    tween(180)
-                                )
-                                ) togetherWith (
-                                slideOutHorizontally(animationSpec = tween(180)) { it / 5 } + fadeOut(
-                                    tween(120)
-                                )
-                                )
+                            (slideInHorizontally(animationSpec = tween(220)) { -it / 5 } + fadeIn(
+                                tween(180)
+                            )) togetherWith (slideOutHorizontally(animationSpec = tween(180)) { it / 5 } + fadeOut(
+                                tween(120)
+                            ))
                         }
                     },
                     label = "budgetPillContent",
@@ -343,12 +324,13 @@ fun BudgetPill(
                                 isOverBudget = isCurrentPeriodOverBudget,
                                 exhaustedMessage = exhaustedMessage,
                                 bigVariant = bigVariant,
-                                modifier = if (isCurrentPeriodOverBudget || bigVariant) {
-                                    Modifier.padding(
+                                wrapContent = true,
+                                modifier = when {
+                                    isCurrentPeriodOverBudget || bigVariant -> Modifier.padding(
                                         horizontal = 32.dp
                                     )
-                                } else {
-                                    Modifier.weight(1f)
+
+                                    else -> Modifier.wrapContentWidth()
                                 },
                             )
 
@@ -359,9 +341,9 @@ fun BudgetPill(
                                     color = textColor,
                                     minFontSize = 16.sp,
                                     modifier = Modifier
-                                        .weight(0.45f)
+                                        .weight(1f)
                                         .censor(),
-                                    textAlign = TextAlign.End,
+                                    textAlign = TextAlign.End
                                 )
                             }
                         }
@@ -379,6 +361,7 @@ private fun StatusLabel(
     isOverBudget: Boolean,
     exhaustedMessage: String? = null,
     bigVariant: Boolean = false,
+    wrapContent: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val textColor = LocalContentColor.current
@@ -409,9 +392,8 @@ private fun StatusLabel(
     ) {
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .offset(y = labelVerticalOffset),
-            verticalAlignment = Alignment.CenterVertically
+                .then(if (wrapContent) Modifier.wrapContentWidth() else Modifier.fillMaxWidth())
+                .offset(y = labelVerticalOffset), verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(modifier = Modifier.width(textStartOffset))
             AdaptiveSingleLineText(
@@ -425,14 +407,14 @@ private fun StatusLabel(
                 },
                 color = textColor,
                 minFontSize = if (bigVariant) 14.sp else 12.sp,
-                modifier = Modifier.weight(1f),
+                modifier = if (wrapContent) Modifier.wrapContentWidth() else Modifier.weight(1f),
                 textAlign = if (bigVariant) TextAlign.Center else TextAlign.Start,
+                fillWidth = !wrapContent,
             )
         }
 
         AnimatedVisibility(
-            visible = exhaustedMessage != null && !bigVariant,
-            enter = slideInVertically(
+            visible = exhaustedMessage != null && !bigVariant, enter = slideInVertically(
                 initialOffsetY = { -it }, animationSpec = tween(300)
             ) + fadeIn(animationSpec = tween(300))
         ) {
@@ -456,6 +438,7 @@ private fun AdaptiveSingleLineText(
     minFontSize: TextUnit,
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Start,
+    fillWidth: Boolean = true,
 ) {
     BoxWithConstraints(modifier = modifier) {
         val density = LocalDensity.current
@@ -478,7 +461,9 @@ private fun AdaptiveSingleLineText(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = textAlign,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = (if (fillWidth) Modifier
+                .fillMaxWidth()
+                .wrapContentHeight() else Modifier).align(Alignment.Center),
         )
     }
 }
@@ -488,8 +473,7 @@ private fun AdaptiveSingleLineText(
 private fun PreviewBudgetPill() {
     MinusTheme {
         Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.background(
+            verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.background(
                 MaterialTheme.colorScheme.surface
             )
         ) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/CategoriesChartCard.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/CategoriesChartCard.kt
@@ -1,5 +1,11 @@
 package com.serranoie.app.minus.presentation.ui.theme.component.charts
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,10 +18,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BarChart
+import androidx.compose.material.icons.rounded.QuestionMark
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.Text
+import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,12 +36,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.Transaction
@@ -49,22 +64,23 @@ data class CategoryUsage(
     var isSpecial: Boolean = false,
 )
 
-var baseColors = listOf(
-    Color(0xFFF86BAE),
-    Color(0xFFF36FFF),
-    Color(0xFFAB96FF),
-    Color(0xFF5FC7E7),
-    Color(0xFF75E584),
-    Color(0xFFFFD386),
-    Color(0xFFEF7564),
-    Color(0xFF64B5F6),
-    Color(0xFFAED581),
-    Color(0xFFFFB74D),
-    Color(0xFFBA68C8),
-    Color(0xFF4DB6AC),
-    Color(0xFF9575CD),
-    Color(0xFFF06292),
-)
+var baseColors =
+    listOf(
+        Color(0xFFF86BAE),
+        Color(0xFFF36FFF),
+        Color(0xFFAB96FF),
+        Color(0xFF5FC7E7),
+        Color(0xFF75E584),
+        Color(0xFFFFD386),
+        Color(0xFFEF7564),
+        Color(0xFF64B5F6),
+        Color(0xFFAED581),
+        Color(0xFFFFB74D),
+        Color(0xFFBA68C8),
+        Color(0xFF4DB6AC),
+        Color(0xFF9575CD),
+        Color(0xFFF06292),
+    )
 
 @Composable
 fun CategoriesChartCard(
@@ -82,111 +98,130 @@ fun CategoriesChartCard(
 
     var selectedCategoryName by remember { mutableStateOf<String?>(null) }
 
-    val colors = remember(isNightMode, primaryColor) {
-        (0 until maxDisplay).map { i ->
-            val baseSize = baseColors.size
-            val colorIndex = i % baseSize
-            val iteration = i / baseSize
+    val colors =
+        remember(isNightMode, primaryColor) {
+            (0 until maxDisplay).map { i ->
+                val baseSize = baseColors.size
+                val colorIndex = i % baseSize
+                val iteration = i / baseSize
 
-            var baseColor = baseColors[colorIndex]
+                var baseColor = baseColors[colorIndex]
 
-            if (iteration > 0) {
-                val hsl = FloatArray(3)
-                ColorUtils.colorToHSL(baseColor.toArgb(), hsl)
-                hsl[0] = (hsl[0] + (iteration * 137.5f)) % 360f
-                baseColor = Color(ColorUtils.HSLToColor(hsl))
+                if (iteration > 0) {
+                    val hsl = FloatArray(3)
+                    ColorUtils.colorToHSL(baseColor.toArgb(), hsl)
+                    hsl[0] = (hsl[0] + (iteration * 137.5f)) % 360f
+                    baseColor = Color(ColorUtils.HSLToColor(hsl))
+                }
+
+                toPaletteWithTheme(
+                    color =
+                        harmonizeWithColor(
+                            designColor = baseColor,
+                            sourceColor = primaryColor,
+                            chromaMultiplier = if (isNightMode) 2f else 1f,
+                        ),
+                    darkTheme = isNightMode,
+                )
             }
-
+        }
+    val restColor =
+        remember(isNightMode, primaryColor) {
             toPaletteWithTheme(
-                color = harmonizeWithColor(
-                    designColor = baseColor,
-                    sourceColor = primaryColor,
-                    chromaMultiplier = if (isNightMode) 2f else 1f
-                ),
-                darkTheme = isNightMode
+                color =
+                    harmonizeWithColor(
+                        designColor = Color(0xFF222222),
+                        sourceColor = primaryColor,
+                    ),
+                darkTheme = isNightMode,
+            ).copy(
+                main = if (isNightMode) Color(0xFFF0F0F0) else Color(0xFF222222),
+                onSurface = if (isNightMode) Color(0xFF1A1A1A) else Color(0xFFF4F4F4),
             )
         }
-    }
-    val restColor = remember(isNightMode, primaryColor) {
-        toPaletteWithTheme(
-            color = harmonizeWithColor(
-                designColor = Color(0xFF222222),
-                sourceColor = primaryColor
-            ),
-            darkTheme = isNightMode
-        ).copy(
-            main = if (isNightMode) Color(0xFFF0F0F0) else Color(0xFF222222),
-            onSurface = if (isNightMode) Color(0xFF1A1A1A) else Color(0xFFF4F4F4)
-        )
-    }
-    val stubColor = remember(isNightMode, primaryColor, surfaceVariantColor) {
-        toPaletteWithTheme(
-            color = harmonizeWithColor(
-                designColor = Color(0xFFCCCCCC),
-                sourceColor = primaryColor
-            ),
-            darkTheme = isNightMode
-        ).copy(
-            main = if (isNightMode) surfaceVariantColor else Color(0xFFCCCCCC),
-        )
-    }
+    val stubColor =
+        remember(isNightMode, primaryColor, surfaceVariantColor) {
+            toPaletteWithTheme(
+                color =
+                    harmonizeWithColor(
+                        designColor = Color(0xFFCCCCCC),
+                        sourceColor = primaryColor,
+                    ),
+                darkTheme = isNightMode,
+            ).copy(
+                main = if (isNightMode) surfaceVariantColor else Color(0xFFCCCCCC),
+            )
+        }
 
     var offsetColor = 0
 
-    val tags = remember(spends, labelWithoutTag, labelRest, colors, restColor) {
-        var result = spends.map { it.copy(comment = it.comment.ifEmpty { labelWithoutTag }) }
-            .groupBy { it.comment.trim() }.map { tag ->
-                CategoryUsage(
-                    tag.key,
-                    tag.value.map { it.amount }.reduce { acc, next -> acc + next },
-                    isSpecial = tag.key == labelWithoutTag,
-                )
-            }.sortedBy { it.amount }.reversed().toList()
+    val tags =
+        remember(spends, labelWithoutTag, labelRest, colors, restColor) {
+            var result =
+                spends
+                    .map { it.copy(comment = it.comment.ifEmpty { labelWithoutTag }) }
+                    .groupBy { it.comment.trim() }
+                    .map { tag ->
+                        CategoryUsage(
+                            tag.key,
+                            tag.value.map { it.amount }.reduce { acc, next -> acc + next },
+                            isSpecial = tag.key == labelWithoutTag,
+                        )
+                    }.sortedBy { it.amount }
+                    .reversed()
+                    .toList()
 
-        if (result.size > maxDisplay) {
-            result.find { it.name == labelWithoutTag }?.let {
-                result = result.filter { tagUsage -> tagUsage.name != labelWithoutTag }
-                result = result + it
+            if (result.size > maxDisplay) {
+                result.find { it.name == labelWithoutTag }?.let {
+                    result = result.filter { tagUsage -> tagUsage.name != labelWithoutTag }
+                    result = result + it
+                }
             }
-        }
 
-        result.subList(0, result.size.coerceAtMost(maxDisplay)).forEachIndexed { index, tagUsage ->
-            tagUsage.color = if (tagUsage.name == labelWithoutTag) {
-                offsetColor++
-                restColor
-            } else {
-                val colorIndex = (index - offsetColor).coerceIn(0, colors.lastIndex)
-                colors[colorIndex]
+            result.subList(0, result.size.coerceAtMost(maxDisplay)).forEachIndexed { index, tagUsage ->
+                tagUsage.color =
+                    if (tagUsage.name == labelWithoutTag) {
+                        offsetColor++
+                        restColor
+                    } else {
+                        val colorIndex = (index - offsetColor).coerceIn(0, colors.lastIndex)
+                        colors[colorIndex]
+                    }
             }
-        }
 
-        if (result.size > maxDisplay) {
-            result = result.slice(0..<maxDisplay) + CategoryUsage(
-                name = labelRest,
-                amount = result.slice(maxDisplay until result.size).map { it.amount }
-                    .reduce { acc, next -> acc + next },
-                color = restColor,
-                isSpecial = true,
-            )
-        }
+            if (result.size > maxDisplay) {
+                result = result.slice(0..<maxDisplay) +
+                    CategoryUsage(
+                        name = labelRest,
+                        amount =
+                            result
+                                .slice(maxDisplay until result.size)
+                                .map { it.amount }
+                                .reduce { acc, next -> acc + next },
+                        color = restColor,
+                        isSpecial = true,
+                    )
+            }
 
-        result
-    }
+            result
+        }
 
     val isEmpty = tags.isEmpty() || (tags.size == 1 && tags.first().name == labelWithoutTag)
 
-    val cardBgColor = combineColors(
-        MaterialTheme.colorScheme.surface,
-        MaterialTheme.colorScheme.surfaceVariant,
-        t = 0.3f,
-    )
+    val cardBgColor =
+        combineColors(
+            MaterialTheme.colorScheme.surface,
+            MaterialTheme.colorScheme.surfaceVariant,
+            t = 0.3f,
+        )
 
     Card(
         modifier = if (isEmpty) modifier else modifier.fillMaxHeight(),
         shape = RoundedCornerShape(22.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = cardBgColor,
-        )
+        colors =
+            CardDefaults.cardColors(
+                containerColor = cardBgColor,
+            ),
     ) {
         if (isEmpty) {
             EmptyChartContent(stubColor)
@@ -198,38 +233,65 @@ fun CategoriesChartCard(
                 labelWithoutTag = labelWithoutTag,
                 currency = currency,
                 onCategoryClick = onCategoryClick,
-                onSelectionChange = { selectedCategoryName = it }
+                onSelectionChange = { selectedCategoryName = it },
             )
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun EmptyChartContent(stubColor: HarmonizedColorPalette) {
+    val infiniteTransition = rememberInfiniteTransition(label = "emptyChartRotation")
+    val rotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 12000, easing = LinearEasing),
+            repeatMode = androidx.compose.animation.core.RepeatMode.Restart,
+        ),
+        label = "emptyChartRotationAngle",
+    )
+
     Box {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                DonutChart(
+                Box(
                     modifier = Modifier
                         .padding(end = 16.dp)
-                        .size(64.dp),
-                    items = listOf(CategoryUsage("", BigDecimal(360), stubColor)),
-                )
+                        .size(72.dp)
+                        .rotate(rotation)
+                        .background(
+                            color = stubColor.main,
+                            shape = MaterialShapes.Flower.toShape()
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.QuestionMark,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.rotate(-rotation)
+                    )
+                }
                 Column {
                     Text(
                         text = stringResource(R.string.categories_chart_empty_title),
-                        style = MaterialTheme.typography.bodyLargeEmphasized.copy(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        ),
+                        style =
+                            MaterialTheme.typography.bodyLargeEmphasized.copy(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
+                        lineHeight = 18.sp,
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     Row(
@@ -237,9 +299,10 @@ private fun EmptyChartContent(stubColor: HarmonizedColorPalette) {
                     ) {
                         Text(
                             text = stringResource(R.string.categories_chart_empty_subtitle),
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.8f),
-                            ),
+                            style =
+                                MaterialTheme.typography.bodyMedium.copy(
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.8f),
+                                ),
                         )
                     }
                 }
@@ -256,37 +319,40 @@ private fun ChartContent(
     labelWithoutTag: String,
     currency: String,
     onCategoryClick: ((String, List<Transaction>) -> Unit)?,
-    onSelectionChange: (String?) -> Unit
+    onSelectionChange: (String?) -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         DonutChart(
-            modifier = Modifier
-                .padding(top = 24.dp, bottom = 16.dp)
-                .size(180.dp),
+            modifier =
+                Modifier
+                    .padding(top = 24.dp, bottom = 16.dp)
+                    .size(180.dp),
             items = tags,
             selectedIndex = tags.indexOfFirst { it.name == selectedCategoryName },
             onItemClick = { index ->
                 val tag = tags[index]
                 onSelectionChange(if (selectedCategoryName == tag.name) null else tag.name)
-            }
+            },
         )
         FlowRow(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .fillMaxWidth(),
+            modifier =
+                Modifier
+                    .padding(horizontal = 8.dp)
+                    .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(0.dp)
+            verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             tags.forEach { tag ->
-                val categoryTransactions = remember(spends, tag.name) {
-                    spends.filter {
-                        val category = it.comment.trim().ifEmpty { labelWithoutTag }
-                        category == tag.name
+                val categoryTransactions =
+                    remember(spends, tag.name) {
+                        spends.filter {
+                            val category = it.comment.trim().ifEmpty { labelWithoutTag }
+                            category == tag.name
+                        }
                     }
-                }
                 CategoryAmount(
                     value = tag.name,
                     amount = tag.amount,
@@ -304,19 +370,30 @@ private fun ChartContent(
     }
 }
 
+@Preview(name = "Empty chart", device = "spec:width=800px,height=800px")
+@Composable
+private fun PreviewEmptyState() {
+    MinusTheme {
+        CategoriesChartCard(
+            spends = emptyList(),
+        )
+    }
+}
+
 @Preview(name = "CategoriesChart", device = "spec:width=800px,height=800px")
 @Composable
 private fun PreviewCategoriesChart() {
     MinusTheme {
         CategoriesChartCard(
-            spends = listOf(
-                Transaction(
-                    amount = BigDecimal(100),
-                    comment = "Food",
-                    date = LocalDateTime.now(),
-                    isDeleted = false
-                )
-            )
+            spends =
+                listOf(
+                    Transaction(
+                        amount = BigDecimal(100),
+                        comment = "Food",
+                        date = LocalDateTime.now(),
+                        isDeleted = false,
+                    ),
+                ),
         )
     }
 }
@@ -324,22 +401,40 @@ private fun PreviewCategoriesChart() {
 @PreviewLightDark
 @Composable
 private fun PreviewCategoriesChartExtremeManyCategories() {
-    val categories = listOf(
-        "Food", "Rent", "Transport", "Entertainment", "Health",
-        "Education", "Shopping", "Gift", "Tech", "Other",
-        "Travel", "Gym", "Subscript.", "Pets", "Hobbies",
-        "Savings", "Insurance", "Taxes", "Repair", "Donate"
-    )
+    val categories =
+        listOf(
+            "Food",
+            "Rent",
+            "Transport",
+            "Entertainment",
+            "Health",
+            "Education",
+            "Shopping",
+            "Gift",
+            "Tech",
+            "Other",
+            "Travel",
+            "Gym",
+            "Subscript.",
+            "Pets",
+            "Hobbies",
+            "Savings",
+            "Insurance",
+            "Taxes",
+            "Repair",
+            "Donate",
+        )
     MinusTheme {
         CategoriesChartCard(
-            spends = categories.mapIndexed { index, name ->
-                Transaction(
-                    amount = BigDecimal(100 - index * 2),
-                    comment = name,
-                    date = LocalDateTime.now()
-                )
-            },
-            onCategoryClick = { _, _ -> }
+            spends =
+                categories.mapIndexed { index, name ->
+                    Transaction(
+                        amount = BigDecimal(100 - index * 2),
+                        comment = name,
+                        date = LocalDateTime.now(),
+                    )
+                },
+            onCategoryClick = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/DonutChart.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/charts/DonutChart.kt
@@ -1,6 +1,7 @@
 package com.serranoie.app.minus.presentation.ui.theme.component.charts
 
 import android.graphics.Paint
+import android.graphics.Typeface.DEFAULT_BOLD
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -41,75 +42,91 @@ fun DonutChart(
     val total = items.map { it.amount }.reduce { acc, next -> acc + next }
     if (total.compareTo(java.math.BigDecimal.ZERO) == 0) return
 
-    val finalAngles = remember(items, total) {
-        val initialAngles = items.map {
-            it.amount.divide(total, 5, RoundingMode.HALF_DOWN).multiply(360.toBigDecimal()).toFloat()
+    val finalAngles =
+        remember(items, total) {
+            val initialAngles =
+                items.map {
+                    it.amount
+                        .divide(total, 5, RoundingMode.HALF_DOWN)
+                        .multiply(360.toBigDecimal())
+                        .toFloat()
+                }
+
+            val maxTotalMinAngle = 250f
+            val minSweepAngle = (maxTotalMinAngle / items.size).coerceAtMost(15f)
+            val smallSlices = initialAngles.filter { it < minSweepAngle }
+            val largeSlices = initialAngles.filter { it >= minSweepAngle }
+            val extraNeeded = (smallSlices.size * minSweepAngle) - smallSlices.sum()
+
+            initialAngles.map { angle ->
+                val adjusted =
+                    if (angle < minSweepAngle) {
+                        minSweepAngle
+                    } else if (largeSlices.isNotEmpty()) {
+                        angle - (extraNeeded * (angle / largeSlices.sum()))
+                    } else {
+                        angle
+                    }
+                // For some weird reason, it can't handle 360 since it breaks the pie chart
+                if (adjusted >= 360f) 359.9f else adjusted
+            }
         }
 
-        val maxTotalMinAngle = 250f
-        val minSweepAngle = (maxTotalMinAngle / items.size).coerceAtMost(15f)
-        val smallSlices = initialAngles.filter { it < minSweepAngle }
-        val largeSlices = initialAngles.filter { it >= minSweepAngle }
-        val extraNeeded = (smallSlices.size * minSweepAngle) - smallSlices.sum()
-
-        initialAngles.map { angle ->
-            if (angle < minSweepAngle) minSweepAngle
-            else if (largeSlices.isNotEmpty()) angle - (extraNeeded * (angle / largeSlices.sum()))
-            else angle
+    val animatedOffsets =
+        items.mapIndexed { index, _ ->
+            animateFloatAsState(
+                targetValue = if (index == selectedIndex) 1f else 0f,
+                animationSpec =
+                    spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessLow,
+                    ),
+                label = "offset_$index",
+            )
         }
-    }
-
-    val animatedOffsets = items.mapIndexed { index, _ ->
-        animateFloatAsState(
-            targetValue = if (index == selectedIndex) 1f else 0f,
-            animationSpec = spring(
-                dampingRatio = Spring.DampingRatioLowBouncy,
-                stiffness = Spring.StiffnessLow
-            ),
-            label = "offset_$index"
-        )
-    }
 
     val onSurfaceColor = MaterialTheme.colorScheme.onSurface
     val surfaceColor = MaterialTheme.colorScheme.surface
-    val textPaint = remember(localDensity, onSurfaceColor, surfaceColor) {
-        Paint().apply {
-            color = onSurfaceColor.toArgb()
-            textAlign = Paint.Align.CENTER
-            textSize = with(localDensity) { 16.sp.toPx() }
-            isAntiAlias = true
-            typeface = android.graphics.Typeface.DEFAULT_BOLD
+    val textPaint =
+        remember(localDensity, onSurfaceColor, surfaceColor) {
+            Paint().apply {
+                color = onSurfaceColor.toArgb()
+                textAlign = Paint.Align.CENTER
+                textSize = with(localDensity) { 16.sp.toPx() }
+                isAntiAlias = true
+                typeface = DEFAULT_BOLD
+            }
         }
-    }
 
     Canvas(
-        modifier = modifier
-            .pointerInput(items, finalAngles) {
-                detectTapGestures { offset ->
-                    val centerX = size.width / 2f
-                    val centerY = size.height / 2f
-                    val dx = offset.x - centerX
-                    val dy = offset.y - centerY
-                    val distance = sqrt(dx * dx + dy * dy)
+        modifier =
+            modifier
+                .pointerInput(items, finalAngles) {
+                    detectTapGestures { offset ->
+                        val centerX = size.width / 2f
+                        val centerY = size.height / 2f
+                        val dx = offset.x - centerX
+                        val dy = offset.y - centerY
+                        val distance = sqrt(dx * dx + dy * dy)
 
-                    val radius = min(size.width, size.height) / 2f
-                    val innerRadius = radius * 0.45f
+                        val radius = min(size.width, size.height) / 2f
+                        val innerRadius = radius * 0.45f
 
-                    if (distance in innerRadius..radius) {
-                        var angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble())).toFloat()
-                        if (angle < -90) angle += 360
+                        if (distance in innerRadius..radius) {
+                            var angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble())).toFloat()
+                            if (angle < -90) angle += 360
 
-                        var currentAngle = -90f
-                        finalAngles.forEachIndexed { index, sweepAngle ->
-                            if (angle >= currentAngle && angle <= (currentAngle + sweepAngle)) {
-                                onItemClick(index)
-                                return@detectTapGestures
+                            var currentAngle = -90f
+                            finalAngles.forEachIndexed { index, sweepAngle ->
+                                if (angle >= currentAngle && angle <= (currentAngle + sweepAngle)) {
+                                    onItemClick(index)
+                                    return@detectTapGestures
+                                }
+                                currentAngle += sweepAngle
                             }
-                            currentAngle += sweepAngle
                         }
                     }
-                }
-            }
+                },
     ) {
         val radius = min(size.width, size.height) / 2f
         val innerRadius = radius * 0.45f
@@ -122,10 +139,10 @@ fun DonutChart(
         items.forEachIndexed { index, tag ->
             val sweepAngle = finalAngles[index]
             val offsetProgress = animatedOffsets[index].value
-            
+
             var arcCenterX = centerX
             var arcCenterY = centerY
-            
+
             val midAngle = currentStartAngle + (sweepAngle / 2f)
             if (offsetProgress > 0f) {
                 val offsetDist = 12.dp.toPx() * offsetProgress
@@ -133,47 +150,62 @@ fun DonutChart(
                 arcCenterY += sin(Math.toRadians(midAngle.toDouble())).toFloat() * offsetDist
             }
 
-            val path = Path().apply {
-                arcTo(
-                    rect = androidx.compose.ui.geometry.Rect(arcCenterX - outerRadius, arcCenterY - outerRadius, arcCenterX + outerRadius, arcCenterY + outerRadius),
-                    startAngleDegrees = currentStartAngle,
-                    sweepAngleDegrees = sweepAngle,
-                    forceMoveTo = true
-                )
-                arcTo(
-                    rect = androidx.compose.ui.geometry.Rect(arcCenterX - innerRadius, arcCenterY - innerRadius, arcCenterX + innerRadius, arcCenterY + innerRadius),
-                    startAngleDegrees = currentStartAngle + sweepAngle,
-                    sweepAngleDegrees = -sweepAngle,
-                    forceMoveTo = false
-                )
-                close()
-            }
+            val path =
+                Path().apply {
+                    arcTo(
+                        rect =
+                            androidx.compose.ui.geometry.Rect(
+                                arcCenterX - outerRadius,
+                                arcCenterY - outerRadius,
+                                arcCenterX + outerRadius,
+                                arcCenterY + outerRadius,
+                            ),
+                        startAngleDegrees = currentStartAngle,
+                        sweepAngleDegrees = sweepAngle,
+                        forceMoveTo = true,
+                    )
+                    arcTo(
+                        rect =
+                            androidx.compose.ui.geometry.Rect(
+                                arcCenterX - innerRadius,
+                                arcCenterY - innerRadius,
+                                arcCenterX + innerRadius,
+                                arcCenterY + innerRadius,
+                            ),
+                        startAngleDegrees = currentStartAngle + sweepAngle,
+                        sweepAngleDegrees = -sweepAngle,
+                        forceMoveTo = false,
+                    )
+                    close()
+                }
 
             drawPath(
                 path = path,
                 color = tag.color?.main ?: Color.Black,
-                style = Fill
+                style = Fill,
             )
 
             if (offsetProgress > 0.5f) {
-                val percentage = items[index].amount
-                    .divide(total, 4, RoundingMode.HALF_UP)
-                    .multiply(java.math.BigDecimal(100))
-                    .setScale(0, RoundingMode.HALF_UP)
-                    .toInt()
-                
+                val percentage =
+                    items[index]
+                        .amount
+                        .divide(total, 4, RoundingMode.HALF_UP)
+                        .multiply(java.math.BigDecimal(100))
+                        .setScale(0, RoundingMode.HALF_UP)
+                        .toInt()
+
                 val labelRadius = (outerRadius + innerRadius) / 2f
                 val labelX = arcCenterX + cos(Math.toRadians(midAngle.toDouble())).toFloat() * labelRadius
                 val labelY = arcCenterY + sin(Math.toRadians(midAngle.toDouble())).toFloat() * labelRadius
-                
+
                 textPaint.color = (if (items[index].isSpecial) surfaceColor else onSurfaceColor).toArgb()
                 textPaint.alpha = (255 * ((offsetProgress - 0.5f) * 2f)).toInt().coerceIn(0, 255)
-                
+
                 drawContext.canvas.nativeCanvas.drawText(
                     "$percentage%",
                     labelX,
                     labelY + (textPaint.textSize / 3),
-                    textPaint
+                    textPaint,
                 )
             }
 
@@ -187,12 +219,26 @@ fun DonutChart(
 private fun PreviewDonutChart() {
     MinusTheme {
         DonutChart(
-            items = listOf(
-                CategoryUsage("Alimentacion", 100.toBigDecimal()),
-                CategoryUsage("Transporte", 200.toBigDecimal()),
-                CategoryUsage("Salud", 300.toBigDecimal()),
-            ),
-            selectedIndex = 1
+            items =
+                listOf(
+                    CategoryUsage("Alimentacion", 100.toBigDecimal()),
+                    CategoryUsage("Transporte", 200.toBigDecimal()),
+                    CategoryUsage("Salud", 300.toBigDecimal()),
+                ),
+            selectedIndex = 1,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDonutChartSingleItem() {
+    MinusTheme {
+        DonutChart(
+            items =
+                listOf(
+                    CategoryUsage("Alimentacion", 100.toBigDecimal()),
+                ),
         )
     }
 }


### PR DESCRIPTION
## Description
Fixing an issue regarding the DonutChart not showing when 1 expense was made with only 1 category.

## Change strategy
For some reason, Canvas doesn't render properly when given a 360 value, so make a condition that render a 359.9 when there's a single category

## Implemented
- New and animated empty state for the CategoryChartCard
- Fixed and changed the DonutChart
- Fixed wrong space for the BudgetPill

## Working demo
https://github.com/user-attachments/assets/dbc42bb0-d302-4cd0-957b-693bdee3fe14

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This PR closes #53 