### PR TITLE
fix: send the state for the budget split on main screen

### DIFF
--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/home/MainScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/home/MainScreenE2ETest.kt
@@ -143,6 +143,7 @@ class MainScreenE2ETest {
                         showBudgetPeriodSheet = showBudgetPeriodSheet,
                         forceBudgetPeriodSheetSetup = false,
                         selectedViewPeriod = selectedViewPeriod,
+                        onPeriodSelected = {},
                         settingsDataStore = null,
                         undoSnackbarActionLabel = "Undo",
                     )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -40,7 +40,8 @@ fun MainScreen(
         .map { it[ONBOARDING_COMPLETED_KEY] ?: false }
         .collectAsStateWithLifecycle(initialValue = false)
 
-    val tutorialStage by context.firstLaunchTutorialStageFlow()
+    val tutorialStage by context
+        .firstLaunchTutorialStageFlow()
         .collectAsStateWithLifecycle(initialValue = FirstLaunchTutorialStage.COMPLETED)
 
     val showCreditQuickToggleFeature by context.settingsDataStore.data
@@ -74,32 +75,40 @@ fun MainScreen(
             when (effect) {
                 is MainScreenUiEffect.RequestUndo -> {
                     budgetViewModel.processIntent(
-                        BudgetTransactionIntent.RestoreTransactionTapped(effect.transaction)
+                        BudgetTransactionIntent.RestoreTransactionTapped(effect.transaction),
                     )
                 }
 
                 is MainScreenUiEffect.UpdateDragProgress -> {
                     budgetViewModel.processIntent(
-                        BudgetNumpadIntent.SetDragProgress(effect.progress)
+                        BudgetNumpadIntent.SetDragProgress(effect.progress),
                     )
                 }
 
-                is MainScreenUiEffect.OpenWallet -> onNavigateToWallet()
-                is MainScreenUiEffect.OpenAnalytics -> onNavigateToAnalytics()
+                is MainScreenUiEffect.OpenWallet -> {
+                    onNavigateToWallet()
+                }
+
+                is MainScreenUiEffect.OpenAnalytics -> {
+                    onNavigateToAnalytics()
+                }
+
                 is MainScreenUiEffect.ShowUndoSnackbar -> {}
             }
         }
     }
 
     ChangelogGate(
-        currentVersionCode = run {
-            val info = context.packageManager.getPackageInfo(
-                context.packageName,
-                0,
-            )
-            @Suppress("DEPRECATION")
-            info.longVersionCode.toInt()
-        },
+        currentVersionCode =
+            run {
+                val info =
+                    context.packageManager.getPackageInfo(
+                        context.packageName,
+                        0,
+                    )
+                @Suppress("DEPRECATION")
+                info.longVersionCode.toInt()
+            },
     ) {
         MainScreenContent(
             mainScreenState = mainScreenState,
@@ -109,16 +118,21 @@ fun MainScreen(
             showCreditQuickToggleFeature = showCreditQuickToggleFeature,
             onProcessIntent = { intent ->
                 when (intent) {
-                    is MainScreenUiIntent.ProcessBudgetTransactionIntent ->
+                    is MainScreenUiIntent.ProcessBudgetTransactionIntent -> {
                         budgetViewModel.processIntent(intent.intent)
+                    }
 
-                    is MainScreenUiIntent.ProcessBudgetEditorIntent ->
+                    is MainScreenUiIntent.ProcessBudgetEditorIntent -> {
                         budgetViewModel.processIntent(intent.intent)
+                    }
 
-                    is MainScreenUiIntent.ProcessBudgetNumpadIntent ->
+                    is MainScreenUiIntent.ProcessBudgetNumpadIntent -> {
                         budgetViewModel.processIntent(intent.intent)
+                    }
 
-                    else -> mainScreenViewModel.processIntent(intent, tutorialStage)
+                    else -> {
+                        mainScreenViewModel.processIntent(intent, tutorialStage)
+                    }
                 }
             },
             onNavigateToAnalytics = onNavigateToAnalytics,
@@ -128,6 +142,9 @@ fun MainScreen(
             showBudgetPeriodSheet = mainScreenState.showBudgetPeriodSheet,
             forceBudgetPeriodSheetSetup = mainScreenState.forceBudgetPeriodSheetSetup,
             selectedViewPeriod = mainScreenState.selectedViewPeriod,
+            onPeriodSelected = { period ->
+                mainScreenViewModel.processIntent(MainScreenUiIntent.SetSelectedPeriod(period), tutorialStage)
+            },
             settingsDataStore = context.settingsDataStore,
             undoSnackbarActionLabel = undoSnackbarActionLabel,
         )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
@@ -54,14 +54,12 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.Density
@@ -73,7 +71,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.SwipeableState
 import androidx.wear.compose.material.rememberSwipeableState
-import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetState
@@ -97,8 +94,8 @@ import com.serranoie.app.minus.presentation.ui.theme.component.numpad.EditStage
 import com.serranoie.app.minus.presentation.ui.theme.component.numpad.EditorState
 import com.serranoie.app.minus.presentation.ui.theme.component.numpad.Numpad
 import com.serranoie.app.minus.presentation.ui.theme.isNightMode
-import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
 import com.serranoie.app.minus.presentation.ui.tutorial.FIRST_LAUNCH_TUTORIAL_STAGE_KEY
+import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
 import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import com.serranoie.app.minus.presentation.util.StatusBarPadding
 import kotlinx.coroutines.delay
@@ -126,6 +123,7 @@ fun MainScreenContent(
     showBudgetPeriodSheet: Boolean,
     forceBudgetPeriodSheetSetup: Boolean,
     selectedViewPeriod: BudgetPeriod,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
     settingsDataStore: DataStore<Preferences>?,
     undoSnackbarActionLabel: String,
 ) {
@@ -151,11 +149,12 @@ fun MainScreenContent(
         mainScreenState.snackbarActionLabel,
     ) {
         if (mainScreenState.isSnackbarVisible) {
-            val result = snackbarHostState.showSnackbar(
-                message = mainScreenState.snackbarMessage,
-                actionLabel = mainScreenState.snackbarActionLabel,
-                duration = SnackbarDuration.Short,
-            )
+            val result =
+                snackbarHostState.showSnackbar(
+                    message = mainScreenState.snackbarMessage,
+                    actionLabel = mainScreenState.snackbarActionLabel,
+                    duration = SnackbarDuration.Short,
+                )
             when (result) {
                 SnackbarResult.ActionPerformed -> onProcessIntent(MainScreenUiIntent.CancelPendingDelete)
                 SnackbarResult.Dismissed -> onProcessIntent(MainScreenUiIntent.DismissSnackbar)
@@ -166,12 +165,15 @@ fun MainScreenContent(
     fun executeDelete(transaction: Transaction) {
         onProcessIntent(
             MainScreenUiIntent.ProcessBudgetTransactionIntent(
-                BudgetTransactionIntent.DeleteTransactionTapped(transaction)
-            )
+                BudgetTransactionIntent.DeleteTransactionTapped(transaction),
+            ),
         )
     }
 
-    fun queueDeleteWithUndo(transaction: Transaction, message: String) {
+    fun queueDeleteWithUndo(
+        transaction: Transaction,
+        message: String,
+    ) {
         onProcessIntent(MainScreenUiIntent.QueueDeleteWithUndo(transaction, message))
     }
 
@@ -197,28 +199,33 @@ fun MainScreenContent(
         }
     }
 
-    val quickLogSwipeModifier = Modifier.pointerInput(isHistoryVisible) {
-        if (!isHistoryVisible) return@pointerInput
-        var totalDrag = 0f
-        detectHorizontalDragGestures(
-            onHorizontalDrag = { _, dragAmount -> totalDrag += dragAmount },
-            onDragEnd = {
-                if (abs(totalDrag) > 120f) {
-                    onProcessIntent(
-                        MainScreenUiIntent.ProcessBudgetEditorIntent(
-                            BudgetEditorIntent.SetAnimState(AnimState.EDITING)
+    val quickLogSwipeModifier =
+        Modifier.pointerInput(isHistoryVisible) {
+            if (!isHistoryVisible) return@pointerInput
+            var totalDrag = 0f
+            detectHorizontalDragGestures(
+                onHorizontalDrag = { _, dragAmount -> totalDrag += dragAmount },
+                onDragEnd = {
+                    if (abs(totalDrag) > 120f) {
+                        onProcessIntent(
+                            MainScreenUiIntent.ProcessBudgetEditorIntent(
+                                BudgetEditorIntent.SetAnimState(AnimState.EDITING),
+                            ),
                         )
-                    )
-                    coroutineScope.launch {
-                        runCatching { topSheetState.animateTo(TopSheetValue.HalfExpanded) }
+                        coroutineScope.launch {
+                            runCatching { topSheetState.animateTo(TopSheetValue.HalfExpanded) }
+                        }
                     }
-                }
-                totalDrag = 0f
-            })
-    }
+                    totalDrag = 0f
+                },
+            )
+        }
 
     LaunchedEffect(
-        tutorialStage, onboardingCompleted, budgetUiState.numpadInput, isHistoryVisible
+        tutorialStage,
+        onboardingCompleted,
+        budgetUiState.numpadInput,
+        isHistoryVisible,
     ) {
         if (!onboardingCompleted || tutorialStage == FirstLaunchTutorialStage.COMPLETED) return@LaunchedEffect
         if (mainScreenState.shownStage == tutorialStage) return@LaunchedEffect
@@ -231,8 +238,8 @@ fun MainScreenContent(
         if (windowSizeClass != WindowWidthSizeClass.Compact && !budgetUiState.isCalculation) {
             onProcessIntent(
                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                    BudgetNumpadIntent.SetCalculationMode(true)
-                )
+                    BudgetNumpadIntent.SetCalculationMode(true),
+                ),
             )
         }
     }
@@ -247,10 +254,11 @@ fun MainScreenContent(
         }
 
         BoxWithConstraints(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight()
-                .background(MaterialTheme.colorScheme.surface),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(MaterialTheme.colorScheme.surface),
         ) {
             val contentHeight = constraints.maxHeight.toFloat()
             val contentWidth = constraints.maxWidth.toFloat()
@@ -278,6 +286,7 @@ fun MainScreenContent(
                     showBudgetPeriodSheet = showBudgetPeriodSheet,
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
+                    onPeriodSelected = onPeriodSelected,
                 )
             } else {
                 TabletLayout(
@@ -299,15 +308,17 @@ fun MainScreenContent(
                     showBudgetPeriodSheet = showBudgetPeriodSheet,
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
+                    onPeriodSelected = onPeriodSelected,
                 )
             }
 
             SnackbarHost(
                 hostState = snackbarHostState,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(horizontal = 16.dp, vertical = 20.dp)
-                    .navigationBarsPadding(),
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 16.dp, vertical = 20.dp)
+                        .navigationBarsPadding(),
             ) { snackbarData ->
                 Snackbar(
                     snackbarData = snackbarData,
@@ -337,7 +348,8 @@ private fun MainNavigationRail(
             selected = false,
             onClick = onNavigateToAnalytics,
             icon = { Icon(Icons.Rounded.BarChart, contentDescription = "Analytics") },
-            label = { Text("Analytics") })
+            label = { Text("Analytics") },
+        )
         NavigationRailItem(
             modifier = itemModifier,
             selected = false,
@@ -350,7 +362,8 @@ private fun MainNavigationRail(
                     Icon(Icons.Rounded.Settings, contentDescription = "Settings")
                 }
             },
-            label = { Text("Settings") })
+            label = { Text("Settings") },
+        )
         Spacer(Modifier.weight(1f))
     }
 }
@@ -376,17 +389,18 @@ private fun PhoneLayout(
     cancelPendingDelete: () -> Unit,
     showInfoSnackbar: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
-    // Editor bottom sheet (MVI-driven)
     showBudgetPeriodSheet: Boolean,
     forceBudgetPeriodSheetSetup: Boolean,
     selectedViewPeriod: BudgetPeriod,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val navigationBarOffset = windowInsets.calculateBottomPadding()
     val navBarHeightPx = with(localDensity) { navigationBarOffset.toPx() }
 
     val defaultInternalKeyboardHeightBase =
-        contentWidth.coerceAtMost(with(localDensity) { 500.dp.toPx() })
+        contentWidth
+            .coerceAtMost(with(localDensity) { 500.dp.toPx() })
             .coerceAtMost(contentHeight / 2)
     val rowHeightPx = defaultInternalKeyboardHeightBase / 4
     val defaultInternalKeyboardHeight = rowHeightPx * 4
@@ -414,30 +428,36 @@ private fun PhoneLayout(
 
     val internalKeyboardTarget =
         defaultInternalKeyboardHeight + (calcModeKeyboardHeight - defaultInternalKeyboardHeight) * effectiveProgress
-    val targetKeyboardHeight = if (keepImeLayout && lastImeHeightPx > 0f) {
-        lastImeHeightPx
-    } else {
-        internalKeyboardTarget
-    }
+    val targetKeyboardHeight =
+        if (keepImeLayout && lastImeHeightPx > 0f) {
+            lastImeHeightPx
+        } else {
+            internalKeyboardTarget
+        }
 
     val editorHeight by remember(
-        contentHeight, targetKeyboardHeight, navBarHeightPx,
-        budgetUiState.isCalculation, localDragProgress,
+        contentHeight,
+        targetKeyboardHeight,
+        navBarHeightPx,
+        budgetUiState.isCalculation,
+        localDragProgress,
     ) {
         derivedStateOf {
-            contentHeight.minus(
-                targetKeyboardHeight.plus(navBarHeightPx).coerceAtLeast(0f)
-            ).coerceAtMost(contentHeight - (navBarHeightPx + with(localDensity) { 96.dp.toPx() }))
+            contentHeight
+                .minus(
+                    targetKeyboardHeight.plus(navBarHeightPx).coerceAtLeast(0f),
+                ).coerceAtMost(contentHeight - (navBarHeightPx + with(localDensity) { 96.dp.toPx() }))
         }
     }
 
-    val keyboardAnimationSpec = remember<AnimationSpec<Float>>(localDragProgress) {
-        if (localDragProgress > 0f && localDragProgress < 1f) {
-            tween(durationMillis = 0)
-        } else {
-            tween(durationMillis = 200, easing = FastOutSlowInEasing)
+    val keyboardAnimationSpec =
+        remember<AnimationSpec<Float>>(localDragProgress) {
+            if (localDragProgress > 0f && localDragProgress < 1f) {
+                tween(durationMillis = 0)
+            } else {
+                tween(durationMillis = 200, easing = FastOutSlowInEasing)
+            }
         }
-    }
 
     val editorHeightAnimated by animateFloatAsState(
         label = "editorHeightAnimatedValue",
@@ -451,56 +471,65 @@ private fun PhoneLayout(
         animationSpec = keyboardAnimationSpec,
     )
 
-    val currentEditorHeight = with(localDensity) {
-        val halfExpanedOffset =
-            (-contentHeight + navBarHeightPx + with(localDensity) { 16.dp.toPx() } + editorHeightAnimated).coerceAtMost(
-                0f
-            )
+    val currentEditorHeight =
+        with(localDensity) {
+            val halfExpanedOffset =
+                (-contentHeight + navBarHeightPx + with(localDensity) { 16.dp.toPx() } + editorHeightAnimated).coerceAtMost(
+                    0f,
+                )
 
-        (topSheetState.offset.value.coerceIn(
-            halfExpanedOffset, 0f
-        ) + contentHeight - navBarHeightPx - with(localDensity) { 16.dp.toPx() }).toDp()
-    }
+            (
+                topSheetState.offset.value.coerceIn(
+                    halfExpanedOffset,
+                    0f,
+                ) + contentHeight - navBarHeightPx - with(localDensity) { 16.dp.toPx() }
+            ).toDp()
+        }
 
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.BottomCenter,
     ) {
-        val halfExpandedOffsetPx = with(localDensity) {
-            (-contentHeight + navBarHeightPx + 16.dp.toPx() + editorHeightAnimated).coerceAtMost(0f)
-        }
+        val halfExpandedOffsetPx =
+            with(localDensity) {
+                (-contentHeight + navBarHeightPx + 16.dp.toPx() + editorHeightAnimated).coerceAtMost(0f)
+            }
         val isSheetExpanding by remember(halfExpandedOffsetPx) {
             derivedStateOf { topSheetState.offset.value > halfExpandedOffsetPx + 10f }
         }
 
         Card(
             shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface,
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(with(localDensity) { (keyboardHeightAnimated + navBarHeightPx).toDp() })
-                .zIndex(if (isSheetExpanding) 0f else 1f),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                ),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(with(localDensity) { (keyboardHeightAnimated + navBarHeightPx).toDp() })
+                    .zIndex(if (isSheetExpanding) 0f else 1f),
         ) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.BottomCenter,
             ) {
-                val editorState = remember(budgetUiState) {
-                    EditorState(
-                        mode = when (budgetUiState.editMode) {
-                            EditorEditMode.ADD -> NumpadEditMode.ADD
-                            EditorEditMode.EDIT -> NumpadEditMode.EDIT
-                        },
-                        rawSpentValue = budgetUiState.numpadInput,
-                        stage = if (budgetUiState.numpadInput.isNotEmpty()) EditStage.EDIT_SPENT else EditStage.IDLE,
-                        currentSpent = budgetUiState.numpadInput,
-                        currentComment = budgetUiState.currentComment,
-                        editedTransaction = null,
-                    )
-                }
+                val editorState =
+                    remember(budgetUiState) {
+                        EditorState(
+                            mode =
+                                when (budgetUiState.editMode) {
+                                    EditorEditMode.ADD -> NumpadEditMode.ADD
+                                    EditorEditMode.EDIT -> NumpadEditMode.EDIT
+                                },
+                            rawSpentValue = budgetUiState.numpadInput,
+                            stage = if (budgetUiState.numpadInput.isNotEmpty()) EditStage.EDIT_SPENT else EditStage.IDLE,
+                            currentSpent = budgetUiState.numpadInput,
+                            currentComment = budgetUiState.currentComment,
+                            editedTransaction = null,
+                        )
+                    }
                 Numpad(
                     editorState = editorState,
                     numberHintAnchorModifier = Modifier,
@@ -508,52 +537,51 @@ private fun PhoneLayout(
                     onNumberInput = { digit ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.NumberTapped(digit.toString())
-                            )
+                                BudgetNumpadIntent.NumberTapped(digit.toString()),
+                            ),
                         )
                         onAdvanceTutorial(FirstLaunchTutorialStage.TAP_ANY_NUMBER)
                     },
                     onDotInput = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.DotTapped
-                            )
+                                BudgetNumpadIntent.DotTapped,
+                            ),
                         )
                     },
                     onBackspace = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.BackspaceTapped
-                            )
+                                BudgetNumpadIntent.BackspaceTapped,
+                            ),
                         )
                     },
                     onBackspaceLongPress = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.ResetInputTapped
-                            )
+                                BudgetNumpadIntent.ResetInputTapped,
+                            ),
                         )
                     },
                     onOperatorInput = { op ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.OperatorTapped(op)
-                            )
+                                BudgetNumpadIntent.OperatorTapped(op),
+                            ),
                         )
                     },
                     onEqualsInput = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.EqualsTapped
-                            )
+                                BudgetNumpadIntent.EqualsTapped,
+                            ),
                         )
                     },
                     onApply = {
-                        Log.d("MainScreen", "Numpad check/save button pressed")
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.ApplyTapped
-                            )
+                                BudgetNumpadIntent.ApplyTapped,
+                            ),
                         )
                         onAdvanceTutorial(FirstLaunchTutorialStage.TAP_DONE_SAVE)
                     },
@@ -563,22 +591,23 @@ private fun PhoneLayout(
                     onCalculationModeChanged = { enabled ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.SetCalculationMode(enabled)
-                            )
+                                BudgetNumpadIntent.SetCalculationMode(enabled),
+                            ),
                         )
                     },
                     onShowSnackbar = { message ->
                         coroutineScope.launch {
                             snackbarHostState.showSnackbar(
-                                message = message, duration = SnackbarDuration.Short
+                                message = message,
+                                duration = SnackbarDuration.Short,
                             )
                         }
                     },
                     onTestNotifications = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                BudgetNumpadIntent.TriggerTestNotifications
-                            )
+                                BudgetNumpadIntent.TriggerTestNotifications,
+                            ),
                         )
                     },
                     rowHeight = with(localDensity) { rowHeightPx.toDp() },
@@ -590,10 +619,12 @@ private fun PhoneLayout(
             swipeableState = topSheetState,
             customHalfHeight = editorHeightAnimated,
             isLockSwipeable = {
-                budgetUiState.lockSwipeable || localDragProgress > 0f || (budgetUiState.isCalculation && effectiveProgress < 1f) || (!budgetUiState.isCalculation && effectiveProgress > 0f)
+                budgetUiState.lockSwipeable || localDragProgress > 0f || (budgetUiState.isCalculation && effectiveProgress < 1f) ||
+                    (!budgetUiState.isCalculation && effectiveProgress > 0f)
             },
             isLockDraggable = {
-                budgetUiState.lockDraggable || localDragProgress > 0f || (budgetUiState.isCalculation && effectiveProgress < 1f) || (!budgetUiState.isCalculation && effectiveProgress > 0f)
+                budgetUiState.lockDraggable || localDragProgress > 0f || (budgetUiState.isCalculation && effectiveProgress < 1f) ||
+                    (!budgetUiState.isCalculation && effectiveProgress > 0f)
             },
             onDismiss = {},
             sheetContentHalfExpand = {
@@ -609,6 +640,7 @@ private fun PhoneLayout(
                     showBudgetPeriodSheet = showBudgetPeriodSheet,
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
+                    onPeriodSelected = onPeriodSelected,
                     onShowBudgetPeriodSheet = {
                         onProcessIntent(MainScreenUiIntent.ShowBudgetPeriodSheet())
                     },
@@ -622,8 +654,8 @@ private fun PhoneLayout(
                         if (budgetUiState.numpadInput.isNotEmpty() && budgetUiState.animState != AnimState.EDITING) {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                    BudgetEditorIntent.SetAnimState(AnimState.EDITING)
-                                )
+                                    BudgetEditorIntent.SetAnimState(AnimState.EDITING),
+                                ),
                             )
                         }
                     },
@@ -631,65 +663,65 @@ private fun PhoneLayout(
                     onCommentUpdate = { comment ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.CommentUpdated(comment)
-                            )
+                                BudgetEditorIntent.CommentUpdated(comment),
+                            ),
                         )
                     },
                     onDeleteTag = { tag ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DeleteTag(tag)
-                            )
+                                BudgetEditorIntent.DeleteTag(tag),
+                            ),
                         )
                     },
                     onRecurrentToggle = { enabled ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.SetRecurrentEnabled(enabled)
-                            )
+                                BudgetEditorIntent.SetRecurrentEnabled(enabled),
+                            ),
                         )
                     },
                     onCreditToggle = { enabled ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.SetCreditEnabled(enabled)
-                            )
+                                BudgetEditorIntent.SetCreditEnabled(enabled),
+                            ),
                         )
                     },
                     showCreditQuickToggleFeature = showCreditQuickToggleFeature,
                     onDismissRecurrentDialog = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DismissRecurrentDialog
-                            )
+                                BudgetEditorIntent.DismissRecurrentDialog,
+                            ),
                         )
                     },
                     onDismissCreditCutoffDialog = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DismissCreditCutoffDialog
-                            )
+                                BudgetEditorIntent.DismissCreditCutoffDialog,
+                            ),
                         )
                     },
                     onRecurrentExpenseConfirm = { freq, date, day ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.RecurrentExpenseApplied(freq, date, day)
-                            )
+                                BudgetEditorIntent.RecurrentExpenseApplied(freq, date, day),
+                            ),
                         )
                     },
                     onCreditCutoffConfirm = { day ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.CreditCutoffDayConfirmed(day)
-                            )
+                                BudgetEditorIntent.CreditCutoffDayConfirmed(day),
+                            ),
                         )
                     },
                     onSaveBudget = { settings ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.UpdateSettings(settings)
-                            )
+                                BudgetEditorIntent.UpdateSettings(settings),
+                            ),
                         )
                     },
                     budgetPillHintAnchorModifier = Modifier,
@@ -699,10 +731,11 @@ private fun PhoneLayout(
             sheetContentExpand = {
                 if (topSheetState.targetValue == TopSheetValue.Expanded || topSheetState.currentValue == TopSheetValue.Expanded) {
                     HistoryScreen(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(colorButton)
-                            .then(quickLogSwipeModifier),
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .background(colorButton)
+                                .then(quickLogSwipeModifier),
                         onQueueDeleteWithUndo = { tx, msg, _ -> queueDeleteWithUndo(tx, msg) },
                         onCancelPendingDelete = { cancelPendingDelete() },
                         onShowInfoSnackbar = { msg -> showInfoSnackbar(msg) },
@@ -740,13 +773,15 @@ private fun TabletLayout(
     showBudgetPeriodSheet: Boolean,
     forceBudgetPeriodSheetSetup: Boolean,
     selectedViewPeriod: BudgetPeriod,
+    onPeriodSelected: (BudgetPeriod) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val navigationBarOffset = windowInsets.calculateBottomPadding()
     val navBarHeightPx = with(localDensity) { navigationBarOffset.toPx() }
 
     val defaultInternalKeyboardHeightBase =
-        (contentWidth / 2f).coerceAtMost(with(localDensity) { 500.dp.toPx() })
+        (contentWidth / 2f)
+            .coerceAtMost(with(localDensity) { 500.dp.toPx() })
             .coerceAtMost(contentHeight / 2)
     val rowHeightPx = defaultInternalKeyboardHeightBase / 4
     val defaultInternalKeyboardHeight = rowHeightPx * 4
@@ -759,36 +794,38 @@ private fun TabletLayout(
 
     val internalKeyboardTarget =
         defaultInternalKeyboardHeight + (calcModeKeyboardHeight - defaultInternalKeyboardHeight) * effectiveProgress
-    val targetKeyboardHeight = internalKeyboardTarget
 
-    val keyboardAnimationSpec = remember<AnimationSpec<Float>>(localDragProgress) {
-        if (localDragProgress > 0f && localDragProgress < 1f) {
-            tween(durationMillis = 0)
-        } else {
-            tween(durationMillis = 200, easing = FastOutSlowInEasing)
+    val keyboardAnimationSpec =
+        remember<AnimationSpec<Float>>(localDragProgress) {
+            if (localDragProgress > 0f && localDragProgress < 1f) {
+                tween(durationMillis = 0)
+            } else {
+                tween(durationMillis = 200, easing = FastOutSlowInEasing)
+            }
         }
-    }
 
     val keyboardHeightAnimated by animateFloatAsState(
         label = "keyboardHeightAnimatedValue",
-        targetValue = targetKeyboardHeight,
+        targetValue = internalKeyboardTarget,
         animationSpec = keyboardAnimationSpec,
     )
 
     Row(modifier = Modifier.fillMaxSize()) {
         // History pane (50%)
         Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight()
-                .background(colorEditor)
-                .navigationBarsPadding(),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(colorEditor)
+                    .navigationBarsPadding(),
         ) {
             HistoryScreen(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(colorButton)
-                    .then(quickLogSwipeModifier),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(colorButton)
+                        .then(quickLogSwipeModifier),
                 onQueueDeleteWithUndo = { tx, msg, _ -> queueDeleteWithUndo(tx, msg) },
                 onCancelPendingDelete = { cancelPendingDelete() },
                 onShowInfoSnackbar = { msg -> showInfoSnackbar(msg) },
@@ -804,16 +841,18 @@ private fun TabletLayout(
 
         // Editor and Numpad pane (50%)
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
         ) {
             Card(
                 shape = RoundedCornerShape(bottomStart = 48.dp, bottomEnd = 48.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = colorEditor,
-                    contentColor = colorOnEditor,
-                ),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = colorEditor,
+                        contentColor = colorOnEditor,
+                    ),
                 modifier = Modifier.weight(1f),
             ) {
                 Editor(
@@ -828,6 +867,7 @@ private fun TabletLayout(
                     showBudgetPeriodSheet = showBudgetPeriodSheet,
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
+                    onPeriodSelected = onPeriodSelected,
                     onShowBudgetPeriodSheet = {
                         onProcessIntent(MainScreenUiIntent.ShowBudgetPeriodSheet())
                     },
@@ -841,8 +881,8 @@ private fun TabletLayout(
                         if (budgetUiState.numpadInput.isNotEmpty() && budgetUiState.animState != AnimState.EDITING) {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                    BudgetEditorIntent.SetAnimState(AnimState.EDITING)
-                                )
+                                    BudgetEditorIntent.SetAnimState(AnimState.EDITING),
+                                ),
                             )
                         }
                     },
@@ -850,65 +890,65 @@ private fun TabletLayout(
                     onCommentUpdate = { comment ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.CommentUpdated(comment)
-                            )
+                                BudgetEditorIntent.CommentUpdated(comment),
+                            ),
                         )
                     },
                     onDeleteTag = { tag ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DeleteTag(tag)
-                            )
+                                BudgetEditorIntent.DeleteTag(tag),
+                            ),
                         )
                     },
                     onRecurrentToggle = { enabled ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.SetRecurrentEnabled(enabled)
-                            )
+                                BudgetEditorIntent.SetRecurrentEnabled(enabled),
+                            ),
                         )
                     },
                     onCreditToggle = { enabled ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.SetCreditEnabled(enabled)
-                            )
+                                BudgetEditorIntent.SetCreditEnabled(enabled),
+                            ),
                         )
                     },
                     showCreditQuickToggleFeature = showCreditQuickToggleFeature,
                     onDismissRecurrentDialog = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DismissRecurrentDialog
-                            )
+                                BudgetEditorIntent.DismissRecurrentDialog,
+                            ),
                         )
                     },
                     onDismissCreditCutoffDialog = {
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.DismissCreditCutoffDialog
-                            )
+                                BudgetEditorIntent.DismissCreditCutoffDialog,
+                            ),
                         )
                     },
                     onRecurrentExpenseConfirm = { freq, date, day ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.RecurrentExpenseApplied(freq, date, day)
-                            )
+                                BudgetEditorIntent.RecurrentExpenseApplied(freq, date, day),
+                            ),
                         )
                     },
                     onCreditCutoffConfirm = { day ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.CreditCutoffDayConfirmed(day)
-                            )
+                                BudgetEditorIntent.CreditCutoffDayConfirmed(day),
+                            ),
                         )
                     },
                     onSaveBudget = { settings ->
                         onProcessIntent(
                             MainScreenUiIntent.ProcessBudgetEditorIntent(
-                                BudgetEditorIntent.UpdateSettings(settings)
-                            )
+                                BudgetEditorIntent.UpdateSettings(settings),
+                            ),
                         )
                     },
                     showAnalyticsButton = false,
@@ -920,31 +960,35 @@ private fun TabletLayout(
 
             Card(
                 shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    contentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(with(localDensity) { (keyboardHeightAnimated + navBarHeightPx).toDp() }),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(with(localDensity) { (keyboardHeightAnimated + navBarHeightPx).toDp() }),
             ) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.BottomCenter,
                 ) {
-                    val editorState = remember(budgetUiState) {
-                        EditorState(
-                            mode = when (budgetUiState.editMode) {
-                                EditorEditMode.ADD -> NumpadEditMode.ADD
-                                EditorEditMode.EDIT -> NumpadEditMode.EDIT
-                            },
-                            rawSpentValue = budgetUiState.numpadInput,
-                            stage = if (budgetUiState.numpadInput.isNotEmpty()) EditStage.EDIT_SPENT else EditStage.IDLE,
-                            currentSpent = budgetUiState.numpadInput,
-                            currentComment = budgetUiState.currentComment,
-                            editedTransaction = null,
-                        )
-                    }
+                    val editorState =
+                        remember(budgetUiState) {
+                            EditorState(
+                                mode =
+                                    when (budgetUiState.editMode) {
+                                        EditorEditMode.ADD -> NumpadEditMode.ADD
+                                        EditorEditMode.EDIT -> NumpadEditMode.EDIT
+                                    },
+                                rawSpentValue = budgetUiState.numpadInput,
+                                stage = if (budgetUiState.numpadInput.isNotEmpty()) EditStage.EDIT_SPENT else EditStage.IDLE,
+                                currentSpent = budgetUiState.numpadInput,
+                                currentComment = budgetUiState.currentComment,
+                                editedTransaction = null,
+                            )
+                        }
                     Numpad(
                         editorState = editorState,
                         numberHintAnchorModifier = Modifier,
@@ -952,52 +996,52 @@ private fun TabletLayout(
                         onNumberInput = { digit ->
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.NumberTapped(digit.toString())
-                                )
+                                    BudgetNumpadIntent.NumberTapped(digit.toString()),
+                                ),
                             )
                             onAdvanceTutorial(FirstLaunchTutorialStage.TAP_ANY_NUMBER)
                         },
                         onDotInput = {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.DotTapped
-                                )
+                                    BudgetNumpadIntent.DotTapped,
+                                ),
                             )
                         },
                         onBackspace = {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.BackspaceTapped
-                                )
+                                    BudgetNumpadIntent.BackspaceTapped,
+                                ),
                             )
                         },
                         onBackspaceLongPress = {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.ResetInputTapped
-                                )
+                                    BudgetNumpadIntent.ResetInputTapped,
+                                ),
                             )
                         },
                         onOperatorInput = { op ->
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.OperatorTapped(op)
-                                )
+                                    BudgetNumpadIntent.OperatorTapped(op),
+                                ),
                             )
                         },
                         onEqualsInput = {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.EqualsTapped
-                                )
+                                    BudgetNumpadIntent.EqualsTapped,
+                                ),
                             )
                         },
                         onApply = {
                             Log.d("MainScreen", "Numpad check/save button pressed")
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.ApplyTapped
-                                )
+                                    BudgetNumpadIntent.ApplyTapped,
+                                ),
                             )
                             onAdvanceTutorial(FirstLaunchTutorialStage.TAP_DONE_SAVE)
                         },
@@ -1007,23 +1051,24 @@ private fun TabletLayout(
                         onCalculationModeChanged = { enabled ->
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.SetCalculationMode(enabled)
-                                )
+                                    BudgetNumpadIntent.SetCalculationMode(enabled),
+                                ),
                             )
                             localDragProgress = 0f
                         },
                         onShowSnackbar = { message ->
                             coroutineScope.launch {
                                 snackbarHostState.showSnackbar(
-                                    message = message, duration = SnackbarDuration.Short
+                                    message = message,
+                                    duration = SnackbarDuration.Short,
                                 )
                             }
                         },
                         onTestNotifications = {
                             onProcessIntent(
                                 MainScreenUiIntent.ProcessBudgetNumpadIntent(
-                                    BudgetNumpadIntent.TriggerTestNotifications
-                                )
+                                    BudgetNumpadIntent.TriggerTestNotifications,
+                                ),
                             )
                         },
                         rowHeight = with(localDensity) { rowHeightPx.toDp() },
@@ -1039,37 +1084,41 @@ private fun TabletLayout(
 @Composable
 private fun MainScreenPreview() {
     val configuration = LocalConfiguration.current
-    val windowSizeClass = when {
-        configuration.screenWidthDp < 600 -> WindowWidthSizeClass.Compact
-        configuration.screenWidthDp < 840 -> WindowWidthSizeClass.Medium
-        else -> WindowWidthSizeClass.Expanded
-    }
+    val windowSizeClass =
+        when {
+            configuration.screenWidthDp < 600 -> WindowWidthSizeClass.Compact
+            configuration.screenWidthDp < 840 -> WindowWidthSizeClass.Medium
+            else -> WindowWidthSizeClass.Expanded
+        }
 
     CompositionLocalProvider(LocalWindowSize provides windowSizeClass) {
         MinusTheme {
             MainScreenContent(
                 mainScreenState = MainScreenUiState(),
-                budgetUiState = BudgetUiState(
-                    budgetSettings = BudgetSettings(
-                        totalBudget = BigDecimal("500.00"),
-                        period = BudgetPeriod.DAILY,
-                        startDate = LocalDate.now(),
-                        currencyCode = "USD",
+                budgetUiState =
+                    BudgetUiState(
+                        budgetSettings =
+                            BudgetSettings(
+                                totalBudget = BigDecimal("500.00"),
+                                period = BudgetPeriod.DAILY,
+                                startDate = LocalDate.now(),
+                                currencyCode = "USD",
+                            ),
+                        budgetState =
+                            BudgetState(
+                                remainingToday = BigDecimal("110.00"),
+                                totalSpentToday = BigDecimal("12.50"),
+                                dailyBudget = BigDecimal("122.50"),
+                                daysRemaining = 15,
+                                progress = 0.1f,
+                                isOverBudget = false,
+                                totalBudget = BigDecimal("500.00"),
+                                totalSpentInPeriod = BigDecimal("12.50"),
+                            ),
+                        transactions = emptyList(),
+                        numpadInput = "12",
+                        isNumpadValid = false,
                     ),
-                    budgetState = BudgetState(
-                        remainingToday = BigDecimal("110.00"),
-                        totalSpentToday = BigDecimal("12.50"),
-                        dailyBudget = BigDecimal("122.50"),
-                        daysRemaining = 15,
-                        progress = 0.1f,
-                        isOverBudget = false,
-                        totalBudget = BigDecimal("500.00"),
-                        totalSpentInPeriod = BigDecimal("12.50"),
-                    ),
-                    transactions = emptyList(),
-                    numpadInput = "12",
-                    isNumpadValid = false,
-                ),
                 onboardingCompleted = true,
                 tutorialStage = FirstLaunchTutorialStage.COMPLETED,
                 showCreditQuickToggleFeature = true,
@@ -1081,6 +1130,7 @@ private fun MainScreenPreview() {
                 showBudgetPeriodSheet = false,
                 forceBudgetPeriodSheetSetup = false,
                 selectedViewPeriod = BudgetPeriod.DAILY,
+                onPeriodSelected = {},
                 settingsDataStore = null,
                 undoSnackbarActionLabel = "Undo",
             )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/NumpadButton.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/NumpadButton.kt
@@ -47,7 +47,6 @@ import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.colorButton
 import com.serranoie.app.minus.presentation.ui.theme.colorOnButton
-import com.serranoie.app.minus.presentation.ui.theme.displayMediumCondensed
 import com.serranoie.app.minus.presentation.ui.theme.displaySmallCondensed
 
 enum class NumpadButtonType { DEFAULT, PRIMARY, SECONDARY, TERTIARY, DELETE, OPERATOR }
@@ -67,7 +66,7 @@ fun NumpadButton(
 	val emphasizedTextStyle = MaterialTheme.typography.displayMediumEmphasized
 
 	val radius by animateDpAsState(
-		targetValue = if (isPressed) 24.dp else 80.dp, animationSpec = if (isPressed) {
+		targetValue = if (isPressed) 18.dp else 100.dp, animationSpec = if (isPressed) {
 			tween(durationMillis = 60, easing = LinearOutSlowInEasing)
 		} else {
 			tween(durationMillis = 620, easing = LinearEasing)
@@ -77,7 +76,7 @@ fun NumpadButton(
 		targetValue = if (isPressed) 1f else 0f, animationSpec = if (isPressed) {
 			tween(durationMillis = 60, easing = LinearOutSlowInEasing)
 		} else {
-			tween(durationMillis = 560, easing = LinearEasing)
+			tween(durationMillis = 400, easing = LinearOutSlowInEasing)
 		}, label = "ButtonPressProgress"
 	)
 
@@ -174,7 +173,7 @@ private fun lerp(start: Float, stop: Float, fraction: Float): Float {
 	return start + (stop - start) * fraction
 }
 
-@Preview
+@Preview(device = "spec:width=500px,height=550px,dpi=440")
 @Composable
 private fun NumpadButtonPreviews() {
 	MinusTheme {

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/screenshot/MainScreenScreenshotTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/screenshot/MainScreenScreenshotTest.kt
@@ -89,6 +89,7 @@ private fun MainScreenPreviewContent(
                 showBudgetPeriodSheet = false,
                 forceBudgetPeriodSheetSetup = false,
                 selectedViewPeriod = BudgetPeriod.DAILY,
+                onPeriodSelected = {},
                 settingsDataStore = null,
                 undoSnackbarActionLabel = "Undo",
             )


### PR DESCRIPTION
## Description
Send correct UI State for the Main Screen when changing state value/split method on the BudgetSheet

## Change strategy
Minor enhancement on the Numpad button.
Send correct lambda function on the split method change 

## Implemented
- Faster text animation bounce for the Numpad
- Send correct lambda function action when changing split method.

## Working demo
https://github.com/user-attachments/assets/18ee95c2-262d-46e7-afaf-bb07748d3bff

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This PR closes #56 
