### PR TITLE
feat: support currency-specific decimal formatting

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
@@ -21,6 +21,7 @@ enum class SymbolPosition {
     END,
 }
 
+
 data class SupportedCurrency(
     val code: String,
     val symbol: String,
@@ -36,6 +37,11 @@ data class SupportedCurrency(
         val locale = LocalConfiguration.current.locales[0]
         return displayName(locale)
     }
+
+    val defaultFractionDigits: Int
+        get() = SupportedCurrencyData.BY_CODE[code]?.defaultFractionDigits ?: 2
+
+    val hasDecimals: Boolean get() = SupportedCurrencyData.BY_CODE[code]?.hasDecimals ?: true
 
     companion object {
         val ALL = listOf(
@@ -173,5 +179,62 @@ data class BudgetSettings(
             remainingBudgetStrategy = RemainingBudgetStrategy.ASK_ALWAYS,
             creditCardCutoffDay = null,
         )
+    }
+}
+
+data class SupportedCurrencyData(
+    val code: String,
+    val symbol: String,
+    val symbolPosition: SymbolPosition = SymbolPosition.START,
+    val defaultFractionDigits: Int,
+) {
+    val hasDecimals: Boolean get() = defaultFractionDigits > 0
+
+    companion object {
+        private val SUPPORTED_CODES: List<Pair<String, SymbolPosition>> = listOf(
+            "USD" to SymbolPosition.START, "MXN" to SymbolPosition.START, "EUR" to SymbolPosition.START,
+            "GBP" to SymbolPosition.START, "HKD" to SymbolPosition.START, "SGD" to SymbolPosition.START,
+            "JPY" to SymbolPosition.START, "CNY" to SymbolPosition.START, "KRW" to SymbolPosition.START,
+            "INR" to SymbolPosition.START, "PKR" to SymbolPosition.START, "BDT" to SymbolPosition.START,
+            "MYR" to SymbolPosition.START, "IDR" to SymbolPosition.START, "VND" to SymbolPosition.END,
+            "BRL" to SymbolPosition.START, "ARS" to SymbolPosition.START, "COP" to SymbolPosition.START,
+            "CLP" to SymbolPosition.START, "PEN" to SymbolPosition.START, "CAD" to SymbolPosition.START,
+            "AUD" to SymbolPosition.START, "NZD" to SymbolPosition.START, "CHF" to SymbolPosition.START,
+            "SEK" to SymbolPosition.START, "NOK" to SymbolPosition.START, "DKK" to SymbolPosition.START,
+            "PLN" to SymbolPosition.END, "TRY" to SymbolPosition.START, "RUB" to SymbolPosition.START,
+            "THB" to SymbolPosition.START, "PHP" to SymbolPosition.START, "TWD" to SymbolPosition.START,
+            "ILS" to SymbolPosition.START, "ZAR" to SymbolPosition.START, "NGN" to SymbolPosition.START,
+            "EGP" to SymbolPosition.START, "MAD" to SymbolPosition.START, "TND" to SymbolPosition.START,
+            "LYD" to SymbolPosition.START, "DZD" to SymbolPosition.START, "SDG" to SymbolPosition.START,
+            "KES" to SymbolPosition.START, "GHS" to SymbolPosition.START, "XOF" to SymbolPosition.START,
+            "GMD" to SymbolPosition.START, "SLE" to SymbolPosition.START, "LRD" to SymbolPosition.START,
+            "GNF" to SymbolPosition.START, "MRU" to SymbolPosition.START, "CVE" to SymbolPosition.START,
+            "STN" to SymbolPosition.START, "TZS" to SymbolPosition.START, "UGX" to SymbolPosition.START,
+            "ETB" to SymbolPosition.START, "RWF" to SymbolPosition.START, "BIF" to SymbolPosition.START,
+            "DJF" to SymbolPosition.START, "SOS" to SymbolPosition.START, "ERN" to SymbolPosition.START,
+            "XAF" to SymbolPosition.START, "CDF" to SymbolPosition.START, "ZMW" to SymbolPosition.START,
+            "MWK" to SymbolPosition.START, "MZN" to SymbolPosition.START, "AOA" to SymbolPosition.START,
+            "BWP" to SymbolPosition.START, "LSL" to SymbolPosition.START, "SZL" to SymbolPosition.START,
+            "NAD" to SymbolPosition.START, "MUR" to SymbolPosition.START, "SCR" to SymbolPosition.START,
+            "MGA" to SymbolPosition.START, "ZWL" to SymbolPosition.START, "HUF" to SymbolPosition.END,
+            "UAH" to SymbolPosition.END,
+        )
+
+        private fun fractionDigits(code: String): Int =
+            runCatching { Currency.getInstance(code).defaultFractionDigits }
+                .getOrElse { 2 }
+
+        val BY_CODE: Map<String, SupportedCurrencyData> =
+            SUPPORTED_CODES.associate { (code, position) ->
+                val supported = SupportedCurrency.ALL.find { it.code == code }
+                code to SupportedCurrencyData(
+                    code = code,
+                    symbol = supported?.symbol ?: code,
+                    symbolPosition = position,
+                    defaultFractionDigits = fractionDigits(code),
+                )
+            }
+
+        fun findByCode(code: String): SupportedCurrencyData? = BY_CODE[code.uppercase()]
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -92,6 +92,7 @@ import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.RemainingBudgetStrategy
 import com.serranoie.app.minus.domain.model.SupportedCurrency
+import com.serranoie.app.minus.domain.model.SupportedCurrencyData
 import com.serranoie.app.minus.presentation.ui.onboarding.FinishDateSelector
 import com.serranoie.app.minus.presentation.ui.onboarding.availablePeriodsFor
 import com.serranoie.app.minus.presentation.ui.onboarding.budgetForPeriod
@@ -552,10 +553,17 @@ fun EditBudgetContent(
         SupportedCurrency.findByCode(currentCurrency)?.symbol ?: "$"
     }
 
-    var budgetText by remember(currentBudget) {
+    val currencyFractionDigits = remember(currentCurrency) {
+        SupportedCurrencyData.findByCode(currentCurrency)?.defaultFractionDigits ?: 2
+    }
+
+    var budgetText by remember(currentBudget, currencyFractionDigits) {
         mutableStateOf(
             if (currentBudget > BigDecimal.ZERO) {
-                (currentBudget.multiply(BigDecimal(100)).toBigInteger()).toString()
+                currentBudget.movePointRight(currencyFractionDigits)
+                    .setScale(0, java.math.RoundingMode.HALF_UP)
+                    .toBigInteger()
+                    .toString()
             } else {
                 ""
             }
@@ -571,7 +579,8 @@ fun EditBudgetContent(
     var showStrategyPicker by remember { mutableStateOf(false) }
     var showPreviousValues by remember { mutableStateOf(false) }
 
-    val parsedBudget = budgetText.toBigDecimalOrNull()?.divide(BigDecimal(100)) ?: BigDecimal.ZERO
+    val parsedBudget = budgetText.toBigDecimalOrNull()?.movePointLeft(currencyFractionDigits)
+        ?: BigDecimal.ZERO
     val totalDays = endCache?.let { ChronoUnit.DAYS.between(startCache, it).toInt() + 1 } ?: 0
     val canApply = parsedBudget > BigDecimal.ZERO && totalDays > 0
 
@@ -613,7 +622,9 @@ fun EditBudgetContent(
                     val filtered = newValue.filter { it.isDigit() }
                     budgetText = filtered
                 },
-                visualTransformation = CurrencyAmountInputVisualTransformation(),
+                visualTransformation = CurrencyAmountInputVisualTransformation(
+                    fractionDigits = currencyFractionDigits,
+                ),
                 textStyle = MaterialTheme.typography.titleMediumCondensed.copy(
                     fontSize = 48.sp,
                     fontWeight = FontWeight.Bold,
@@ -700,7 +711,10 @@ fun EditBudgetContent(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             Text(
-                                text = "$currencySymbol${currentBudget.toPlainString()}",
+                                text = remember(currentBudget, currentCurrency) {
+                                    symbolOnlyCurrencyFormat(currentCurrency)
+                                        .format(currentBudget)
+                                },
                                 style = MaterialTheme.typography.titleMediumCondensed,
                                 fontWeight = FontWeight.Bold
                             )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -147,7 +147,7 @@ fun BudgetPeriodSheet(
 ) {
     val haptic = LocalHapticFeedback.current
     val currencyFormat = remember(currencyCode) {
-        symbolOnlyCurrencyFormat(currencyCode, maximumFractionDigits = 0)
+        symbolOnlyCurrencyFormat(currencyCode)
     }
 
     val startDate = budgetSettings?.startDate ?: LocalDate.now()

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/HistoryDateDivider.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/HistoryDateDivider.kt
@@ -82,7 +82,7 @@ fun HistoryDateDivider(
 			enter = fadeIn(animationSpec = tween(durationMillis = 150)),
 			exit = fadeOut(animationSpec = tween(durationMillis = 150))
 		) {
-			val currencyFormat = symbolOnlyCurrencyFormat(currencyCode, maximumFractionDigits = 0)
+			val currencyFormat = symbolOnlyCurrencyFormat(currencyCode)
 			DayTotalItem(
 				total = totalAmount!!,
 				currencyFormat = currencyFormat,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/util/NumberFormat.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/util/NumberFormat.kt
@@ -22,18 +22,24 @@ fun getFloatDivider(): String {
 /**
  * Formats a currency value using only the symbol (e.g., "$1,234.56" instead of "USD $1,234.56").
  * Uses the [SupportedCurrency] list for symbol lookup, falling back to the system locale formatter.
+ * [maximumFractionDigits] defaults to the currency's natural decimal count (-1 = use currency default).
  */
 fun formatCurrencySymbolOnly(
 	value: BigDecimal,
 	currencyCode: String,
-	maximumFractionDigits: Int = 2,
+	maximumFractionDigits: Int = -1, // -1 means use currency's default
 	minimumFractionDigits: Int = 0,
 ): String {
 	val supported = SupportedCurrency.findByCode(currencyCode)
+	val resolvedMaxDigits = if (maximumFractionDigits < 0) {
+		supported?.defaultFractionDigits ?: 2
+	} else {
+		maximumFractionDigits
+	}
 	val symbol = supported?.symbol
 	if (symbol != null) {
 		val numberFormatter = NumberFormat.getNumberInstance(Locale.getDefault()).apply {
-			this.maximumFractionDigits = maximumFractionDigits
+			this.maximumFractionDigits = resolvedMaxDigits
 			this.minimumFractionDigits = minimumFractionDigits
 		}
 		val formatted = numberFormatter.format(value)
@@ -43,18 +49,16 @@ fun formatCurrencySymbolOnly(
 			"$symbol$formatted"
 		}
 	}
-	// Fallback to standard currency formatter
 	return try {
 		val formatter = NumberFormat.getCurrencyInstance(Locale.getDefault()).apply {
 			currency = java.util.Currency.getInstance(currencyCode)
-			this.maximumFractionDigits = maximumFractionDigits
+			this.maximumFractionDigits = resolvedMaxDigits
 			this.minimumFractionDigits = minimumFractionDigits
 		}
 		formatter.format(value)
 	} catch (e: Exception) {
-		// Fallback to number format with the raw currencyCode if Currency.getInstance fails
 		val numberFormatter = NumberFormat.getNumberInstance(Locale.getDefault()).apply {
-			this.maximumFractionDigits = maximumFractionDigits
+			this.maximumFractionDigits = resolvedMaxDigits
 			this.minimumFractionDigits = minimumFractionDigits
 		}
 		"$currencyCode${numberFormatter.format(value)}"
@@ -63,24 +67,30 @@ fun formatCurrencySymbolOnly(
 
 /**
  * Creates a NumberFormat that renders currency with symbol only (no currency code).
+ * [maximumFractionDigits] defaults to the currency's natural decimal count (-1 = use currency default).
  */
 fun symbolOnlyCurrencyFormat(
 	currencyCode: String,
-	maximumFractionDigits: Int = 2,
+	maximumFractionDigits: Int = -1,  // -1 means use currency's default
 	minimumFractionDigits: Int = 0,
 ): NumberFormat {
 	val supported = SupportedCurrency.findByCode(currencyCode)
+	val resolvedMaxDigits = if (maximumFractionDigits < 0) {
+		supported?.defaultFractionDigits ?: 2
+	} else {
+		maximumFractionDigits
+	}
 	val currencySymbol = supported?.symbol ?: "$"
 	val symbolAtEnd = supported?.symbolPosition == SymbolPosition.END
 	return (NumberFormat.getNumberInstance(Locale.getDefault()) as DecimalFormat).apply {
-		this.maximumFractionDigits = maximumFractionDigits
+		this.maximumFractionDigits = resolvedMaxDigits
 		this.minimumFractionDigits = minimumFractionDigits
 		if (symbolAtEnd) {
 			positiveSuffix = currencySymbol
-			negativeSuffix = "-" + currencySymbol
+			negativeSuffix = "-$currencySymbol"
 		} else {
 			positivePrefix = currencySymbol
-			negativePrefix = "-" + currencySymbol
+			negativePrefix = "-$currencySymbol"
 		}
 		try {
 			currency = java.util.Currency.getInstance(currencyCode)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/util/VisualTransformationAsCurrency.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/util/VisualTransformationAsCurrency.kt
@@ -20,20 +20,13 @@ import java.util.Currency
 import java.util.Locale
 import kotlin.math.min
 
-/**
- * Simplified currency format that only supports USD/MXN with $ symbol.
- */
 fun formatCurrency(amount: BigDecimal): String {
     val format = NumberFormat.getCurrencyInstance(Locale.US)
     format.currency = Currency.getInstance("USD")
     return format.format(amount)
 }
 
-/**
- * Gets the currency symbol ($ for USD/MXN).
- */
 fun getCurrencySymbol(): String = "$"
-
 
 fun getAnnotatedString(
     value: String,
@@ -51,19 +44,20 @@ fun getAnnotatedString(
     value: String,
     hintParts: List<Pair<Int, Int>>,
     hintColor: Color,
-): AnnotatedString {
-    return getAnnotatedString(value, hintParts, hintParts.map { SpanStyle(color = hintColor) })
-}
+): AnnotatedString =
+    getAnnotatedString(value, hintParts, hintParts.map { SpanStyle(color = hintColor) })
 
 fun getAnnotatedString(
     value: String,
     hintPart: Pair<Int, Int>,
     hintColor: Color,
-): AnnotatedString {
-    return getAnnotatedString(value, listOf(hintPart), hintColor)
-}
+): AnnotatedString = getAnnotatedString(value, listOf(hintPart), hintColor)
 
-private fun calcShift(before: String, after: String, position: Int): Int {
+private fun calcShift(
+    before: String,
+    after: String,
+    position: Int,
+): Int {
     var shift = 0
 
     for (i in 0 until position) {
@@ -75,11 +69,7 @@ private fun calcShift(before: String, after: String, position: Int): Int {
     return shift
 }
 
-/**
- * Visual transformation that formats input as USD/MXN currency with $ symbol.
- */
 private fun visualTransformationAsCurrency(
-    context: Context,
     input: AnnotatedString,
     hintColor: Color,
 ): TransformedText {
@@ -96,31 +86,34 @@ private fun visualTransformationAsCurrency(
 
     val forceShowAfterDot = input.text.contains(".0")
     val before = output.substringBefore("${floatDivider}0")
-    val after = if (forceShowAfterDot) {
-        output.substringAfter(floatDivider, "")
-    } else {
-        output.substringAfter("${floatDivider}0", "")
-    }
+    val after =
+        if (forceShowAfterDot) {
+            output.substringAfter(floatDivider, "")
+        } else {
+            output.substringAfter("${floatDivider}0", "")
+        }
 
-    val divider = if (fixed.third.isNotEmpty() || forceShowAfterDot) {
-        "$floatDivider${fixed.third}"
-    } else {
-        ""
-    }
+    val divider =
+        if (fixed.third.isNotEmpty() || forceShowAfterDot) {
+            "$floatDivider${fixed.third}"
+        } else {
+            ""
+        }
 
     output = if (input.text.isEmpty()) "" else before + divider + after
 
-    val offsetTranslator = object : OffsetMapping {
-        override fun originalToTransformed(offset: Int): Int {
-            val shift = calcShift(input.text.replace(".", floatDivider), output, offset)
-            return (offset + shift).coerceIn(0, output.length)
-        }
+    val offsetTranslator =
+        object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                val shift = calcShift(input.text.replace(".", floatDivider), output, offset)
+                return (offset + shift).coerceIn(0, output.length)
+            }
 
-        override fun transformedToOriginal(offset: Int): Int {
-            val shift = calcShift(input.text.replace(".", floatDivider), output, offset)
-            return (offset - shift).coerceIn(0, input.length)
+            override fun transformedToOriginal(offset: Int): Int {
+                val shift = calcShift(input.text.replace(".", floatDivider), output, offset)
+                return (offset - shift).coerceIn(0, input.length)
+            }
         }
-    }
 
     return if (input.text.isEmpty()) {
         TransformedText(
@@ -150,29 +143,30 @@ private fun visualTransformationAsCurrency(
     }
 }
 
-/**
- * Creates a visual transformation function for currency input.
- * Only supports USD/MXN with $ symbol.
- */
 fun visualTransformationAsCurrency(
-    context: Context,
     hintColor: Color,
-): ((input: AnnotatedString) -> TransformedText) {
-    return {
-        visualTransformationAsCurrency(context, it, hintColor)
+): ((input: AnnotatedString) -> TransformedText) =
+    {
+        visualTransformationAsCurrency(it, hintColor)
     }
-}
 
 /**
- * Currency amount input visual transformation following the blog post approach.
- * Takes raw digits as input and formats them as currency with two decimal places.
+ * Takes raw digits as input and formats them as currency with [fractionDigits]
+ * decimal places (matching the active currency's natural precision - e.g. 2 for
+ * USD, 0 for JPY/KRW/COP).
  *
  * Original input => Integer part + Decimal part => Output
- * 123 => 1 + 23 => 1.23
- * 542010 => 5420 + 10 => 5420.10
- * 1 => 0 + 01 => 0.01
+ * 123 => 1 + 23 => 1.23         (fractionDigits = 2)
+ * 542010 => 5420 + 10 => 5420.10 (fractionDigits = 2)
+ * 1 => 0 + 01 => 0.01           (fractionDigits = 2)
+ * 1234 => 1234 => 1,234         (fractionDigits = 0, JPY-style)
  */
-class CurrencyAmountInputVisualTransformation : VisualTransformation {
+class CurrencyAmountInputVisualTransformation(
+    private val fractionDigits: Int = 2,
+) : VisualTransformation {
+    init {
+        require(fractionDigits >= 0) { "fractionDigits must be >= 0, was $fractionDigits" }
+    }
 
     override fun filter(text: AnnotatedString): TransformedText {
         val symbols = DecimalFormat().decimalFormatSymbols
@@ -181,60 +175,79 @@ class CurrencyAmountInputVisualTransformation : VisualTransformation {
 
         val inputText = text.text
 
-        // Handle empty input - show "0.00" as placeholder
+        // Handle empty input - show currency-shaped placeholder
         if (inputText.isEmpty()) {
-            val newText = AnnotatedString(
-                "0${decimalSeparator}00",
-                text.spanStyles,
-                text.paragraphStyles
-            )
-            // For empty input, use simple identity mapping
-            val offsetMapping = object : OffsetMapping {
-                override fun originalToTransformed(offset: Int) = offset.coerceIn(0, 4)
-                override fun transformedToOriginal(offset: Int) = offset.coerceIn(0, 0)
-            }
+            val placeholder =
+                if (fractionDigits == 0) {
+                    "0"
+                } else {
+                    "0$decimalSeparator${"0".repeat(fractionDigits)}"
+                }
+            val newText =
+                AnnotatedString(
+                    placeholder,
+                    text.spanStyles,
+                    text.paragraphStyles,
+                )
+            val offsetMapping =
+                object : OffsetMapping {
+                    override fun originalToTransformed(offset: Int) =
+                        offset.coerceIn(0, placeholder.length)
+
+                    override fun transformedToOriginal(offset: Int) = offset.coerceIn(0, 0)
+                }
             return TransformedText(newText, offsetMapping)
         }
 
-        // Get integer part (all digits except last 2)
-        val intPart = if (inputText.length > 2) {
-            inputText.substring(0, inputText.length - 2)
+        val intPart: String
+        val fractionPart: String
+        if (fractionDigits == 0) {
+            intPart = inputText
+            fractionPart = ""
         } else {
-            "0"
+            intPart =
+                if (inputText.length > fractionDigits) {
+                    inputText.dropLast(fractionDigits)
+                } else {
+                    "0"
+                }
+
+            var frac =
+                if (inputText.length >= fractionDigits) {
+                    inputText.substring(inputText.length - fractionDigits, inputText.length)
+                } else {
+                    inputText
+                }
+
+            if (frac.length < fractionDigits) {
+                frac = frac.padStart(fractionDigits, '0')
+            }
+            fractionPart = frac
         }
 
-        // Get decimal part (last 2 digits)
-        var fractionPart = if (inputText.length >= 2) {
-            inputText.substring(inputText.length - 2, inputText.length)
-        } else {
-            inputText
-        }
-
-        // Add zeros if the fraction part length is not 2
-        if (fractionPart.length < 2) {
-            fractionPart = fractionPart.padStart(2, '0')
-        }
-
-        // Add thousands separators to integer part
         val thousandsReplacementPattern = Regex("\\B(?=(?:\\d{3})+(?!\\d))")
-        val formattedIntWithThousandsSeparator = intPart.replace(
-            thousandsReplacementPattern,
-            thousandsSeparator.toString()
-        )
+        val formattedIntWithThousandsSeparator =
+            intPart.replace(
+                thousandsReplacementPattern,
+                thousandsSeparator.toString(),
+            )
 
-        // Build the final formatted string
-        val newText = AnnotatedString(
-            formattedIntWithThousandsSeparator + decimalSeparator + fractionPart,
-            text.spanStyles,
-            text.paragraphStyles
-        )
+        val newText =
+            AnnotatedString(
+                if (fractionDigits == 0) {
+                    formattedIntWithThousandsSeparator
+                } else {
+                    "$formattedIntWithThousandsSeparator$decimalSeparator$fractionPart"
+                },
+                text.spanStyles,
+                text.paragraphStyles,
+            )
 
-        // Create offset mapping from the actual transformed text so cursor positions stay valid
-        // around decimal and thousands separators.
-        val offsetMapping = CurrencyAmountOffsetMapping(
-            originalLength = inputText.length,
-            transformedText = newText.text,
-        )
+        val offsetMapping =
+            CurrencyAmountOffsetMapping(
+                originalLength = inputText.length,
+                transformedText = newText.text,
+            )
 
         return TransformedText(newText, offsetMapping)
     }
@@ -249,11 +262,11 @@ class CurrencyAmountOffsetMapping(
     private val originalLength: Int,
     transformedText: String,
 ) : OffsetMapping {
-
     private val transformedLength = transformedText.length
-    private val originalDigitOffsets = transformedText
-        .mapIndexedNotNull { index, char -> if (char.isDigit()) index else null }
-        .takeLast(originalLength)
+    private val originalDigitOffsets =
+        transformedText
+            .mapIndexedNotNull { index, char -> if (char.isDigit()) index else null }
+            .takeLast(originalLength)
 
     override fun originalToTransformed(offset: Int): Int {
         val safeOffset = offset.coerceIn(0, originalLength)
@@ -266,18 +279,19 @@ class CurrencyAmountOffsetMapping(
 
     override fun transformedToOriginal(offset: Int): Int {
         val safeOffset = offset.coerceIn(0, transformedLength)
-        return originalDigitOffsets.count { digitOffset -> digitOffset < safeOffset }
+        return originalDigitOffsets
+            .count { digitOffset -> digitOffset < safeOffset }
             .coerceIn(0, originalLength)
     }
 }
 
-fun isNumber(char: Char): Boolean {
-    return try {
-        char.toString().toInt(); true
-    } catch (e: Exception) {
+fun isNumber(char: Char): Boolean =
+    try {
+        char.toString().toInt()
+        true
+    } catch (_: Exception) {
         false
     }
-}
 
 fun Triple<String, String, String>.join(third: Boolean = true): String =
     this.first + this.second + if (third) this.third else ""
@@ -288,16 +302,20 @@ fun fixedNumberString(input: String): String {
     val after = input.substringAfter(".", "")
 
     var addZero = false
-    var beforeFiltered = before
-        .replace("\\D".toRegex(), "")
-        .trimStart { addZero = addZero || it == '0'; it == '0'}
+    var beforeFiltered =
+        before.replace("\\D".toRegex(), "").trimStart {
+            addZero = addZero || it == '0'
+            it == '0'
+        }
 
     if (addZero) beforeFiltered = "0$beforeFiltered"
     addZero = false
 
-    var afterFiltered = after
-        .replace("\\D".toRegex(), "")
-        .trimEnd { addZero = addZero || it == '0'; it == '0' }
+    var afterFiltered =
+        after.replace("\\D".toRegex(), "").trimEnd {
+            addZero = addZero || it == '0'
+            it == '0'
+        }
 
     if (addZero && afterFiltered.isEmpty()) afterFiltered = "${afterFiltered}0"
 
@@ -312,7 +330,7 @@ fun fixedNumberString(input: String): String {
 
 fun tryConvertStringToNumber(input: String): Triple<String, String, String> {
     val afterDot = input.dropWhile { it != '.' }
-    val beforeDot = input.substring(0, input.length - afterDot.length)
+    val beforeDot = input.dropLast(afterDot.length)
 
     val start = beforeDot.filter { isNumber(it) }.dropWhile { it == '0' }
     val hintStart = if (start.isEmpty()) "0" else ""
@@ -321,15 +339,16 @@ fun tryConvertStringToNumber(input: String): Triple<String, String, String> {
     if (end.isEmpty() && input.lastOrNull() == '.') {
         hintEnd = "0"
     }
-    val middle = if (end.isNotEmpty() || (input.lastOrNull() == '.')) {
-        "."
-    } else {
-        ""
-    }
+    val middle =
+        if (end.isNotEmpty() || (input.lastOrNull() == '.')) {
+            "."
+        } else {
+            ""
+        }
 
     return Triple(
         hintStart,
-        "$start$middle${end.substring(0, min(2, end.length))}",
+        "$start$middle${end.take(min(2, end.length))}",
         hintEnd,
     )
 }
@@ -337,42 +356,49 @@ fun tryConvertStringToNumber(input: String): Triple<String, String, String> {
 @Preview(name = "Currency visual transformations", showBackground = true)
 @Composable
 private fun VisualTransformationAsCurrencyPreview() {
-    val context = LocalContext.current
-    val legacyTransformation = visualTransformationAsCurrency(
-        context = context,
-        hintColor = Color.Green,
-    )
+    val legacyTransformation =
+        visualTransformationAsCurrency(hintColor = Color.Green)
     val amountInputTransformation = CurrencyAmountInputVisualTransformation()
     val decimalInputs = listOf("", "0", "12", "1000", "12233.45")
     val digitInputs = listOf("", "1", "12", "123", "542010", "123456789")
 
     Column {
-        Text(text = "visualTransformationAsCurrency(context, hintColor)")
         decimalInputs.forEach { input ->
-            Text(text = "${input.ifEmpty { "empty" }} → ${legacyTransformation(AnnotatedString(input)).text}")
+            Text(
+                text = "${input.ifEmpty { "empty" }} -> ${
+                    legacyTransformation(
+                        AnnotatedString(
+                            input,
+                        ),
+                    ).text
+                }",
+            )
         }
 
         Text(text = "CurrencyAmountInputVisualTransformation")
         digitInputs.forEach { input ->
-            val transformed = remember(input) {
-                amountInputTransformation.filter(AnnotatedString(input))
-            }
-            val start = remember(transformed) {
-                transformed.offsetMapping.originalToTransformed(0)
-            }
-            val end = remember(transformed, input) {
-                transformed.offsetMapping.originalToTransformed(input.length)
-            }
+            val transformed =
+                remember(input) {
+                    amountInputTransformation.filter(AnnotatedString(input))
+                }
+            val start =
+                remember(transformed) {
+                    transformed.offsetMapping.originalToTransformed(0)
+                }
+            val end =
+                remember(transformed, input) {
+                    transformed.offsetMapping.originalToTransformed(input.length)
+                }
             Text(
-                text = "${input.ifEmpty { "empty" }} → ${transformed.text} | caret $start..$end"
+                text = "${input.ifEmpty { "empty" }} -> ${transformed.text} | caret $start..$end",
             )
         }
 
         Text(text = "formatCurrency(BigDecimal)")
         listOf(BigDecimal.ZERO, BigDecimal("12.34"), BigDecimal("1234567.89")).forEach { amount ->
-            Text(text = "$amount → ${formatCurrency(amount)}")
+            Text(text = "$amount -> ${formatCurrency(amount)}")
         }
 
-        Text(text = "getCurrencySymbol() → ${getCurrencySymbol()}")
+        Text(text = "getCurrencySymbol() -> ${getCurrencySymbol()}")
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/widget/WidgetCurrencyFormatter.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/widget/WidgetCurrencyFormatter.kt
@@ -16,7 +16,6 @@ fun formatWidgetCurrency(currency: String, amount: Int): String {
     return formatCurrencySymbolOnly(
         value = BigDecimal(amount),
         currencyCode = currency,
-        maximumFractionDigits = 0,
         minimumFractionDigits = 0,
     )
 }


### PR DESCRIPTION
## Description
Certain currencies don't handle decimals _didn't know about that 😅_

## Change strategy
Implemented correct formatting to the currency selected automatically e.g: Japan (JPY), South Korea (KRW), Paraguay (PYG), Chile (CLP).

## Implemented
- Login inside the currency formatting like defaultFractionDigits and hasDecimals to show/handle them or not.

## Working demo
<!-- Attach any evidence of the change in action. -->

https://github.com/user-attachments/assets/6ea42be0-0ba0-4fdc-bf6a-12ab99581653



## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
PR closes #85 
<!-- Risks, follow-ups, or anything reviewers should know. -->
