### PR TITLE
fix: tablet UI on smaller screens

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
@@ -21,7 +21,6 @@ enum class SymbolPosition {
     END,
 }
 
-
 data class SupportedCurrency(
     val code: String,
     val symbol: String,


### PR DESCRIPTION
## Description
Facing an error when users will get the Tablet mode UI when the DPI of the screen was smaller or certain screen sizes will trigger it.

## Change strategy
Change and follow [android breakpoints](https://developer.android.com/develop/ui/compose/layouts/adaptive/support-different-display-sizes) to show proper TabletLayout on certain DPI/screen sizes

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This PR closes #78 
