### PR TITLE
fix: update category ID when editing transaction category

### DIFF
--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/analytics/AnalyticsE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/analytics/AnalyticsE2ETest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.LocalWindowInsets
 import com.serranoie.app.minus.presentation.ui.analytics.Analytics
@@ -92,6 +93,10 @@ class AnalyticsE2ETest {
     private fun allTransactions(): List<Transaction> = foodTransactions() + moveTransactions() + funTransactions()
 
     private fun setAnalyticsContent() {
+        // Android 17 is stricter about activity launch timing. Ensure the test
+        // activity is fully resumed before setContent is called, and let the
+        // framework idle after so the Compose hierarchy is discoverable.
+        composeTestRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         composeTestRule.setContent {
             MinusTheme {
                 CompositionLocalProvider(LocalWindowInsets provides PaddingValues(0.dp)) {
@@ -108,6 +113,7 @@ class AnalyticsE2ETest {
                 }
             }
         }
+        composeTestRule.waitForIdle()
     }
 
     @Test

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/BudgetPeriodSheetEditModeE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/BudgetPeriodSheetEditModeE2ETest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
 import com.google.common.truth.Truth
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
@@ -36,6 +37,10 @@ class BudgetPeriodSheetEditModeE2ETest {
         onFinishEarly: (() -> Unit)? = null,
         selectedPeriod: BudgetPeriod = BudgetPeriod.DAILY,
     ) {
+        // Android 17 is stricter about activity launch timing. Ensure the test
+        // activity is fully resumed before setContent is called, and let the
+        // framework idle after so the Compose hierarchy is discoverable.
+        composeTestRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         composeTestRule.setContent {
             MinusTheme {
                 BudgetPeriodSheet(
@@ -52,6 +57,7 @@ class BudgetPeriodSheetEditModeE2ETest {
                 )
             }
         }
+        composeTestRule.waitForIdle()
     }
 
     @Test

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandler.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandler.kt
@@ -7,219 +7,225 @@ import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.usecase.AddTransactionUseCase
 import com.serranoie.app.minus.domain.usecase.DeleteTransactionUseCase
 import com.serranoie.app.minus.presentation.notification.NotificationScheduler
+import logcat.logcat
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.inject.Inject
-import logcat.logcat
 
 sealed interface ApplyTransactionResult {
-	data class ShowRecurrentDialog(
-		val amount: BigDecimal,
-		val normalizedInput: String,
-	) : ApplyTransactionResult
+    data class ShowRecurrentDialog(
+        val amount: BigDecimal,
+        val normalizedInput: String,
+    ) : ApplyTransactionResult
 
-	data class QueuedForNextPeriod(
-		val normalizedInput: String,
-	) : ApplyTransactionResult
+    data class QueuedForNextPeriod(
+        val normalizedInput: String,
+    ) : ApplyTransactionResult
 
-	data class Added(
-		val normalizedInput: String,
-	) : ApplyTransactionResult
+    data class Added(
+        val normalizedInput: String,
+    ) : ApplyTransactionResult
 
-	data object InvalidInput : ApplyTransactionResult
+    data object InvalidInput : ApplyTransactionResult
 }
 
 class BudgetTransactionHandler @Inject constructor(
-	internal val budgetRepository: BudgetRepository,
-	private val addTransactionUseCase: AddTransactionUseCase,
-	private val deleteTransactionUseCase: DeleteTransactionUseCase,
-	private val budgetExpressionEvaluator: BudgetExpressionEvaluator,
-	private val notificationScheduler: NotificationScheduler,
+    internal val budgetRepository: BudgetRepository,
+    private val addTransactionUseCase: AddTransactionUseCase,
+    private val deleteTransactionUseCase: DeleteTransactionUseCase,
+    private val budgetExpressionEvaluator: BudgetExpressionEvaluator,
+    private val notificationScheduler: NotificationScheduler,
 ) {
-	companion object {
-		private const val TAG = "BudgetTransactionHandler"
-	}
+    companion object {
+        private const val TAG = "BudgetTransactionHandler"
+    }
 
-	suspend fun applyTransaction(
-		input: String,
-		isCalculation: Boolean,
-		isRecurrentEnabled: Boolean,
-		isCreditEnabled: Boolean,
-		comment: String,
-		budgetSettings: BudgetSettings?,
-		resolveActivePeriodId: suspend () -> Long,
-	): ApplyTransactionResult {
-		var normalizedInput = input
+    suspend fun applyTransaction(
+        input: String,
+        isCalculation: Boolean,
+        isRecurrentEnabled: Boolean,
+        isCreditEnabled: Boolean,
+        comment: String,
+        budgetSettings: BudgetSettings?,
+        resolveActivePeriodId: suspend () -> Long,
+    ): ApplyTransactionResult {
+        var normalizedInput = input
 
-		if (isCalculation && normalizedInput.any { it in "+-×÷" }) {
-			val calculated = budgetExpressionEvaluator.evaluate(normalizedInput)
-			if (calculated != null) {
-				normalizedInput = calculated
-			}
-		}
+        if (isCalculation && normalizedInput.any { it in "+-×÷" }) {
+            val calculated = budgetExpressionEvaluator.evaluate(normalizedInput)
+            if (calculated != null) {
+                normalizedInput = calculated
+            }
+        }
 
-		if (!validateNumpadInput(normalizedInput)) return ApplyTransactionResult.InvalidInput
+        if (!validateNumpadInput(normalizedInput)) return ApplyTransactionResult.InvalidInput
 
-		val amount = try {
-			BigDecimal(normalizedInput)
-		} catch (_: NumberFormatException) {
-			return ApplyTransactionResult.InvalidInput
-		}
+        val amount = try {
+            BigDecimal(normalizedInput)
+        } catch (_: NumberFormatException) {
+            return ApplyTransactionResult.InvalidInput
+        }
 
-		if (amount < BigDecimal.ZERO) return ApplyTransactionResult.InvalidInput
+        if (amount < BigDecimal.ZERO) return ApplyTransactionResult.InvalidInput
 
-		if (isRecurrentEnabled) {
-			return ApplyTransactionResult.ShowRecurrentDialog(
-				amount = amount,
-				normalizedInput = normalizedInput,
-			)
-		}
+        if (isRecurrentEnabled) {
+            return ApplyTransactionResult.ShowRecurrentDialog(
+                amount = amount,
+                normalizedInput = normalizedInput,
+            )
+        }
 
-		val today = LocalDate.now()
-		if (budgetSettings != null && today.isAfter(budgetSettings.getPeriodEndDate())) {
-			val categoryId: Long? = if (comment.isNotBlank()) {
-				budgetRepository.findOrCreateCategory(comment.trim()).id
-			} else {
-				null
-			}
+        val today = LocalDate.now()
+        if (budgetSettings != null && today.isAfter(budgetSettings.getPeriodEndDate())) {
+            val categoryId: Long? = if (comment.isNotBlank()) {
+                budgetRepository.findOrCreateCategory(comment.trim()).id
+            } else {
+                null
+            }
 
-			val pendingTransaction = Transaction.create(
-				amount = amount,
-				comment = comment,
-				date = LocalDateTime.now(),
-				periodId = 0L,
-				categoryId = categoryId,
-				isCredit = isCreditEnabled,
-			)
-			budgetRepository.addQueuedTransaction(pendingTransaction)
-			return ApplyTransactionResult.QueuedForNextPeriod(normalizedInput = normalizedInput)
-		}
+            val pendingTransaction = Transaction.create(
+                amount = amount,
+                comment = comment,
+                date = LocalDateTime.now(),
+                periodId = 0L,
+                categoryId = categoryId,
+                isCredit = isCreditEnabled,
+            )
+            budgetRepository.addQueuedTransaction(pendingTransaction)
+            return ApplyTransactionResult.QueuedForNextPeriod(normalizedInput = normalizedInput)
+        }
 
-		val activePeriodId = resolveActivePeriodId()
-		val categoryId: Long? = if (comment.isNotBlank()) {
-			budgetRepository.findOrCreateCategory(comment.trim()).id
-		} else {
-			null
-		}
+        val activePeriodId = resolveActivePeriodId()
+        val categoryId: Long? = if (comment.isNotBlank()) {
+            budgetRepository.findOrCreateCategory(comment.trim()).id
+        } else {
+            null
+        }
 
-		val transaction = Transaction.create(
-			amount = amount,
-			comment = comment,
-			date = LocalDateTime.now(),
-			periodId = activePeriodId,
-			categoryId = categoryId,
-			isCredit = isCreditEnabled,
-		)
-		addTransactionUseCase(transaction)
-		return ApplyTransactionResult.Added(normalizedInput = normalizedInput)
-	}
+        val transaction = Transaction.create(
+            amount = amount,
+            comment = comment,
+            date = LocalDateTime.now(),
+            periodId = activePeriodId,
+            categoryId = categoryId,
+            isCredit = isCreditEnabled,
+        )
+        addTransactionUseCase(transaction)
+        return ApplyTransactionResult.Added(normalizedInput = normalizedInput)
+    }
 
-	suspend fun applyRecurrentExpense(
-		pendingAmount: BigDecimal?,
-		pendingComment: String,
-		frequency: RecurrentFrequency,
-		endDate: LocalDate,
-		subscriptionDay: Int?,
-		resolveActivePeriodId: suspend () -> Long,
-		isCredit: Boolean = false,
-		fallbackComment: String,
-	): Boolean {
-		val amount = pendingAmount ?: return false
-		val rawComment = pendingComment.trim()
-		val now = LocalDateTime.now()
+    suspend fun applyRecurrentExpense(
+        pendingAmount: BigDecimal?,
+        pendingComment: String,
+        frequency: RecurrentFrequency,
+        endDate: LocalDate,
+        subscriptionDay: Int?,
+        resolveActivePeriodId: suspend () -> Long,
+        isCredit: Boolean = false,
+        fallbackComment: String,
+    ): Boolean {
+        val amount = pendingAmount ?: return false
+        val rawComment = pendingComment.trim()
+        val now = LocalDateTime.now()
 
-		val finalComment = rawComment.ifEmpty { fallbackComment }
-		val activePeriodId = resolveActivePeriodId()
-		val transactionDate = resolveRecurrentTransactionDate(
-			frequency = frequency,
-			subscriptionDay = subscriptionDay,
-			now = now
-		)
+        val finalComment = rawComment.ifEmpty { fallbackComment }
+        val activePeriodId = resolveActivePeriodId()
+        val transactionDate = resolveRecurrentTransactionDate(
+            frequency = frequency, subscriptionDay = subscriptionDay, now = now
+        )
 
-		val categoryId: Long? = if (finalComment.isNotBlank()) {
-			budgetRepository.findOrCreateCategory(finalComment.trim()).id
-		} else {
-			null
-		}
+        val categoryId: Long? = if (finalComment.isNotBlank()) {
+            budgetRepository.findOrCreateCategory(finalComment.trim()).id
+        } else {
+            null
+        }
 
-		val transaction = Transaction.create(
-			amount = amount,
-			comment = finalComment,
-			date = transactionDate,
-			periodId = activePeriodId,
-			isRecurrent = true,
-			recurrentFrequency = frequency,
-			recurrentEndDate = endDate.atTime(now.toLocalTime()),
-			subscriptionDay = subscriptionDay,
-			categoryId = categoryId,
-			isCredit = isCredit,
-		)
-		addTransactionUseCase(transaction)
-		notificationScheduler.rescheduleRecurrentExpenseNotifications()
-		return true
-	}
+        val transaction = Transaction.create(
+            amount = amount,
+            comment = finalComment,
+            date = transactionDate,
+            periodId = activePeriodId,
+            isRecurrent = true,
+            recurrentFrequency = frequency,
+            recurrentEndDate = endDate.atTime(now.toLocalTime()),
+            subscriptionDay = subscriptionDay,
+            categoryId = categoryId,
+            isCredit = isCredit,
+        )
+        addTransactionUseCase(transaction)
+        notificationScheduler.rescheduleRecurrentExpenseNotifications()
+        return true
+    }
 
-	private fun resolveRecurrentTransactionDate(
-		frequency: RecurrentFrequency,
-		subscriptionDay: Int?,
-		now: LocalDateTime,
-	): LocalDateTime {
-		if (frequency != RecurrentFrequency.MONTHLY || subscriptionDay == null) {
-			return now
-		}
+    private fun resolveRecurrentTransactionDate(
+        frequency: RecurrentFrequency,
+        subscriptionDay: Int?,
+        now: LocalDateTime,
+    ): LocalDateTime {
+        if (frequency != RecurrentFrequency.MONTHLY || subscriptionDay == null) {
+            return now
+        }
 
-		val targetDay = subscriptionDay.coerceIn(1, now.toLocalDate().lengthOfMonth())
-		return now.withDayOfMonth(targetDay)
-	}
+        val targetDay = subscriptionDay.coerceIn(1, now.toLocalDate().lengthOfMonth())
+        return now.withDayOfMonth(targetDay)
+    }
 
-	suspend fun deleteTransaction(transaction: Transaction): Result<Unit> {
-		return runCatching {
-			// For virtual recurrent occurrences, use sourceTransactionId to delete the real saved transaction
-			val realId = transaction.sourceTransactionId ?: transaction.id
-			val transactionToDelete = if (transaction.sourceTransactionId != null) {
-				transaction.copy(id = realId, sourceTransactionId = null)
-			} else {
-				transaction
-			}
-			notificationScheduler.cancelRecurrentExpenseNotification(transactionToDelete)
-			deleteTransactionUseCase(transactionToDelete)
-			val stillExists = budgetRepository.getTransactionById(realId)
-			if (stillExists != null && !stillExists.isDeleted) {
-				logcat(TAG) { "deleteTransaction failed: row with id $realId still exists after delete" }
-				throw IllegalStateException("Delete operation did not remove the transaction")
-			}
-		}
-	}
+    suspend fun deleteTransaction(transaction: Transaction): Result<Unit> {
+        return runCatching {
+            // For virtual recurrent occurrences, use sourceTransactionId to delete the real saved transaction
+            val realId = transaction.sourceTransactionId ?: transaction.id
+            val transactionToDelete = if (transaction.sourceTransactionId != null) {
+                transaction.copy(id = realId, sourceTransactionId = null)
+            } else {
+                transaction
+            }
+            notificationScheduler.cancelRecurrentExpenseNotification(transactionToDelete)
+            deleteTransactionUseCase(transactionToDelete)
+            val stillExists = budgetRepository.getTransactionById(realId)
+            if (stillExists != null && !stillExists.isDeleted) {
+                logcat(TAG) { "deleteTransaction failed: row with id $realId still exists after delete" }
+                throw IllegalStateException("Delete operation did not remove the transaction")
+            }
+        }
+    }
 
-	suspend fun restoreTransaction(transaction: Transaction): Result<Unit> {
-		return runCatching {
-			addTransactionUseCase(transaction)
-			if (transaction.isRecurrent) {
-				notificationScheduler.rescheduleRecurrentExpenseNotifications()
-			}
-		}
-	}
+    suspend fun restoreTransaction(transaction: Transaction): Result<Unit> {
+        return runCatching {
+            addTransactionUseCase(transaction)
+            if (transaction.isRecurrent) {
+                notificationScheduler.rescheduleRecurrentExpenseNotifications()
+            }
+        }
+    }
 
-	suspend fun editTransaction(updatedTransaction: Transaction): Boolean {
-		if (updatedTransaction.amount < BigDecimal.ZERO) return false
-		budgetRepository.updateTransaction(updatedTransaction)
-		if (updatedTransaction.isRecurrent) {
-			notificationScheduler.scheduleRecurrentExpenseNotification(updatedTransaction)
-		} else {
-			notificationScheduler.cancelRecurrentExpenseNotification(updatedTransaction)
-		}
-		return true
-	}
+    suspend fun editTransaction(updatedTransaction: Transaction): Boolean {
+        if (updatedTransaction.amount < BigDecimal.ZERO) return false
 
-	private fun validateNumpadInput(input: String): Boolean {
-		if (input.isEmpty()) return false
-		if (input == ".") return false
-		return try {
-			val value = BigDecimal(input)
-			value > BigDecimal.ZERO
-		} catch (_: NumberFormatException) {
-			false
-		}
-	}
+        val resolvedTransaction = if (updatedTransaction.comment.isNotBlank()) {
+            val categoryId =
+                budgetRepository.findOrCreateCategory(updatedTransaction.comment.trim()).id
+            updatedTransaction.copy(categoryId = categoryId)
+        } else {
+            updatedTransaction.copy(categoryId = null)
+        }
+        budgetRepository.updateTransaction(resolvedTransaction)
+        if (resolvedTransaction.isRecurrent) {
+            notificationScheduler.scheduleRecurrentExpenseNotification(resolvedTransaction)
+        } else {
+            notificationScheduler.cancelRecurrentExpenseNotification(resolvedTransaction)
+        }
+        return true
+    }
+
+    private fun validateNumpadInput(input: String): Boolean {
+        if (input.isEmpty()) return false
+        if (input == ".") return false
+        return try {
+            val value = BigDecimal(input)
+            value > BigDecimal.ZERO
+        } catch (_: NumberFormatException) {
+            false
+        }
+    }
 }


### PR DESCRIPTION
## Description
When editing an expense, creating a new category on the edit screen won't save the new category created.

## Change strategy
update and/or create the ID created on the edit screen for the category

## Working demo


## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
PR closes #100