### PR TITLE
feat: implement dynamic budget split mode

### DIFF
--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/SplitModeE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/SplitModeE2ETest.kt
@@ -1,0 +1,468 @@
+package com.serranoie.app.minus.presentation.ui.e2e.budget
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
+import com.serranoie.app.minus.domain.model.BudgetState
+import com.serranoie.app.minus.presentation.ui.budget.BudgetUiState
+import com.serranoie.app.minus.presentation.ui.editor.AnimState
+import com.serranoie.app.minus.presentation.ui.editor.Editor
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BUDGET_PERIOD_APPLY_BUTTON_TAG
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BUDGET_PERIOD_CALCULATED_CARD_TAG
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BUDGET_PERIOD_EDIT_BUTTON_TAG
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BUDGET_PERIOD_SHEET_TAG
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BUDGET_PERIOD_SPLIT_MODE_ROW_TAG
+import com.serranoie.app.minus.presentation.ui.editor.sheets.BudgetPeriodSheet
+import com.serranoie.app.minus.presentation.ui.editor.sheets.budgetPeriodToggleTag
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.NumberFormat
+import java.time.LocalDate
+
+/**
+ * End-to-end coverage for the per-budget dynamic split mode feature.
+ *
+ * Anchored to the spec example: 16,644.45 budget, 200 spent, 30 days, with
+ * 28 days remaining should yield a DAILY amount of 587.30 in DYNAMIC mode
+ * and 554.82 in STATIC mode.
+ *
+ * The sheet is driven both standalone (via [renderSheet]) and through
+ * [Editor] (via [renderEditorWithSheet]) which is the actual parent that
+ * renders the [BudgetPeriodSheet] inside a `ModalBottomSheet`. We mount
+ * [Editor] rather than [com.serranoie.app.minus.presentation.ui.home.MainScreenContent]
+ * because the latter only emits the show-sheet intent — it never renders
+ * the sheet itself.
+ */
+class SplitModeE2ETest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val totalBudget = BigDecimal("16644.45")
+    private val totalSpent = BigDecimal("200.00")
+
+    /**
+     * 30-day window ending 27 days from "today", so `daysRemaining`
+     * (computed in the sheet as `ChronoUnit.DAYS.between(today, endDate) + 1`)
+     * resolves to 28 — matching the spec anchor case.
+     */
+    private fun dynamicWindow(): Pair<LocalDate, LocalDate> {
+        val end = LocalDate.now().plusDays(27)
+        val start = end.minusDays(29)
+        return start to end
+    }
+
+    private fun dynamicSettings(splitMode: BudgetSplitMode = BudgetSplitMode.DYNAMIC) =
+        dynamicWindow().let { (start, end) ->
+            BudgetSettings(
+                totalBudget = totalBudget,
+                period = BudgetPeriod.DAILY,
+                startDate = start,
+                endDate = end,
+                currencyCode = "USD",
+                daysInPeriod = 30,
+                splitMode = splitMode,
+            )
+        }
+
+    private fun dynamicState() = BudgetState(
+        remainingToday = BigDecimal("554.82"),
+        totalSpentToday = BigDecimal("0.00"),
+        dailyBudget = BigDecimal("554.82"),
+        daysRemaining = 28,
+        progress = (totalSpent.divide(totalBudget, 2, RoundingMode.HALF_UP).toFloat()).coerceIn(0f, 1f),
+        isOverBudget = false,
+        totalBudget = totalBudget,
+        totalSpentInPeriod = totalSpent,
+    )
+
+    private fun formatExpected(
+        value: BigDecimal,
+        currencyCode: String = "USD",
+        minimumFractionDigits: Int = 0,
+        maximumFractionDigits: Int = 2,
+    ): String {
+        val deviceLocale = composeTestRule.activity.resources.configuration.locales[0]
+        val symbol = when (currencyCode) {
+            "USD" -> "$"
+            else -> currencyCode
+        }
+        val numberFormatter = NumberFormat.getNumberInstance(deviceLocale).apply {
+            this.maximumFractionDigits = maximumFractionDigits
+            this.minimumFractionDigits = minimumFractionDigits
+        }
+        return "$symbol${numberFormatter.format(value)}"
+    }
+
+    private fun renderSheet(
+        budgetSettings: BudgetSettings? = dynamicSettings(),
+        budgetState: BudgetState? = dynamicState(),
+        startInEditMode: Boolean = false,
+        capturedIntents: MutableList<Any> = mutableListOf(),
+    ) {
+        composeTestRule.setContent {
+            MinusTheme {
+                BudgetPeriodSheet(
+                    budgetSettings = budgetSettings,
+                    budgetState = budgetState,
+                    selectedPeriod = BudgetPeriod.DAILY,
+                    currencyCode = "USD",
+                    onPeriodSelected = { capturedIntents += "PeriodSelected:$it" },
+                    onSaveBudget = { capturedIntents += it },
+                    onEditBudget = { capturedIntents += "EditBudget" },
+                    onFinishEarly = { capturedIntents += "FinishEarly" },
+                    startInEditMode = startInEditMode,
+                    pendingExpensesCount = 0,
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.mainClock.advanceTimeBy(400)
+    }
+
+    private fun renderEditorWithSheet(
+        budgetSettings: BudgetSettings = dynamicSettings(),
+        budgetState: BudgetState = dynamicState(),
+        capturedIntents: MutableList<Any> = mutableListOf(),
+    ) {
+        val budgetUiState = BudgetUiState(
+            budgetSettings = budgetSettings,
+            budgetState = budgetState,
+        )
+        composeTestRule.setContent {
+            CompositionLocalProvider {
+                MinusTheme {
+                    Editor(
+                        uiState = budgetUiState,
+                        animState = AnimState.IDLE,
+                        modifier = Modifier.fillMaxSize(),
+                        onFocus = {},
+                        onOpenHistory = {},
+                        onOpenSettings = { capturedIntents += "OpenSettings" },
+                        onOpenAnalytics = { capturedIntents += "OpenAnalytics" },
+                        onOpenWallet = { capturedIntents += "OpenWallet" },
+                        openWalletOnStart = false,
+                        showBudgetPeriodSheet = true,
+                        forceBudgetPeriodSheetSetup = false,
+                        selectedViewPeriod = BudgetPeriod.DAILY,
+                        onShowBudgetPeriodSheet = { capturedIntents += "ShowBudgetPeriodSheet" },
+                        onHideBudgetPeriodSheet = { capturedIntents += "HideBudgetPeriodSheet" },
+                        onPeriodSelected = { capturedIntents += "PeriodSelected:$it" },
+                        onCommentClick = {},
+                        onCommentUpdate = { capturedIntents += "CommentUpdate:$it" },
+                        onDeleteTag = { capturedIntents += "DeleteTag:$it" },
+                        onRecurrentToggle = {},
+                        onCreditToggle = {},
+                        onDismissRecurrentDialog = {},
+                        onDismissCreditCutoffDialog = {},
+                        onRecurrentExpenseConfirm = { _, _, _, _ -> },
+                        onCreditCutoffConfirm = {},
+                        onSaveBudget = { capturedIntents += it },
+                        directCategoryPopupEnabled = false,
+                        categoryGridModeEnabled = false,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.mainClock.advanceTimeBy(800)
+    }
+
+    @Test
+    fun when_dynamic_mode_with_spend_then_calculated_card_shows_587_30() {
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.DYNAMIC),
+            budgetState = dynamicState(),
+        )
+
+        // 587.30 = (16644.45 - 200) / 28
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("587.30"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_static_mode_then_calculated_card_shows_554_82() {
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            budgetState = dynamicState(),
+        )
+
+        // 554.82 = 16644.45 / 30
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("554.82"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_no_budget_state_then_calculated_card_still_renders_gracefully() {
+        // budgetState=null -> totalSpent defaults to 0, so DYNAMIC degenerates
+        // to (16644.45 / 28) = 594.44 for daily. The point of this test is to
+        // verify the sheet doesn't crash and the card is still on screen.
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.DYNAMIC),
+            budgetState = null,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_edit_mode_then_split_mode_row_is_visible() {
+        renderSheet(startInEditMode = true)
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_edit_mode_with_static_settings_then_split_mode_row_shows_static_label() {
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            startInEditMode = true,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Static").onLast().assertIsDisplayed()
+    }
+
+    @Test
+    fun when_edit_mode_with_dynamic_settings_then_split_mode_row_shows_dynamic_label() {
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.DYNAMIC),
+            startInEditMode = true,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Dynamic").onLast().assertIsDisplayed()
+    }
+
+    @Test
+    fun when_tap_split_mode_row_then_picker_dialog_opens() {
+        renderSheet(startInEditMode = true)
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithText("How should we split your budget?")
+            .onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_pick_dynamic_in_dialog_then_row_updates_to_dynamic_label() {
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            startInEditMode = true,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithText("Dynamic").onLast().performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithText("How should we split your budget?")
+            .onLast()
+            .assertIsNotDisplayed()
+        composeTestRule.onAllNodesWithText("Dynamic").onLast().assertIsDisplayed()
+    }
+
+    @Test
+    fun when_switch_to_dynamic_and_apply_then_save_intent_carries_dynamic_mode() {
+        val captured = mutableListOf<Any>()
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            startInEditMode = true,
+            capturedIntents = captured,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onAllNodesWithText("Dynamic").onLast().performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_APPLY_BUTTON_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        val saved = captured.filterIsInstance<BudgetSettings>().lastOrNull()
+        Truth.assertThat(saved).isNotNull()
+        Truth.assertThat(saved!!.splitMode).isEqualTo(BudgetSplitMode.DYNAMIC)
+    }
+
+    @Test
+    fun when_apply_with_static_default_then_save_intent_carries_static_mode() {
+        val captured = mutableListOf<Any>()
+        renderSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            startInEditMode = true,
+            capturedIntents = captured,
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_APPLY_BUTTON_TAG).performClick()
+        composeTestRule.waitForIdle()
+
+        val saved = captured.filterIsInstance<BudgetSettings>().lastOrNull()
+        Truth.assertThat(saved).isNotNull()
+        Truth.assertThat(saved!!.splitMode).isEqualTo(BudgetSplitMode.STATIC)
+    }
+
+    @Test
+    fun when_editor_renders_with_dynamic_sheet_open_then_calculated_card_shows_dynamic_number() {
+        renderEditorWithSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.DYNAMIC),
+            budgetState = dynamicState(),
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SHEET_TAG).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("587.30"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_editor_renders_with_static_sheet_open_then_calculated_card_shows_static_number() {
+        renderEditorWithSheet(
+            budgetSettings = dynamicSettings(BudgetSplitMode.STATIC),
+            budgetState = dynamicState(),
+        )
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_SHEET_TAG).assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("554.82"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_open_sheet_from_editor_then_edit_button_is_visible() {
+        renderEditorWithSheet()
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_EDIT_BUTTON_TAG).assertIsDisplayed()
+    }
+
+    /**
+     * Builds a (settings, state) pair with custom values, anchored to a
+     * 30-day window ending in `daysLeft` days. Used by the additional
+     * scenario tests below.
+     */
+    private fun customDynamicScenario(
+        budget: BigDecimal,
+        spent: BigDecimal,
+        daysLeft: Int,
+        splitMode: BudgetSplitMode = BudgetSplitMode.DYNAMIC,
+    ): Pair<BudgetSettings, BudgetState> {
+        val end = LocalDate.now().plusDays((daysLeft - 1).toLong())
+        val start = end.minusDays(29)
+        val settings = BudgetSettings(
+            totalBudget = budget,
+            period = BudgetPeriod.DAILY,
+            startDate = start,
+            endDate = end,
+            currencyCode = "USD",
+            daysInPeriod = 30,
+            splitMode = splitMode,
+        )
+        val state = BudgetState(
+            remainingToday = budget.subtract(spent).coerceAtLeast(BigDecimal.ZERO),
+            totalSpentToday = BigDecimal.ZERO,
+            dailyBudget = BigDecimal.ZERO, // not used by the calculated card
+            daysRemaining = daysLeft,
+            progress = if (budget > BigDecimal.ZERO) {
+                spent.divide(budget, 2, RoundingMode.HALF_UP).toFloat().coerceIn(0f, 1f)
+            } else 0f,
+            isOverBudget = spent > budget,
+            totalBudget = budget,
+            totalSpentInPeriod = spent,
+        )
+        return settings to state
+    }
+
+    @Test
+    fun when_dynamic_mid_period_half_spent_then_card_shows_166_67() {
+        // 5000 budget, 2500 spent, 15 days left -> 2500/15 = 166.67/day
+        val (settings, state) = customDynamicScenario(
+            budget = BigDecimal("5000"),
+            spent = BigDecimal("2500"),
+            daysLeft = 15,
+        )
+
+        renderSheet(budgetSettings = settings, budgetState = state)
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("166.67"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_dynamic_overspent_then_card_still_renders_without_crashing() {
+        // 1000 budget, 1500 spent -> remaining is negative -> 0 (no negatives on screen)
+        // The exact zero is pinned by the unit test. Here we just guard
+        // against a render crash and confirm the card stays on screen.
+        val (settings, state) = customDynamicScenario(
+            budget = BigDecimal("1000"),
+            spent = BigDecimal("1500"),
+            daysLeft = 10,
+        )
+
+        renderSheet(budgetSettings = settings, budgetState = state)
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_dynamic_last_day_full_budget_then_card_shows_full_amount() {
+        // 1-day period, 0 spent, 1 day left -> 1000.00/day (edge: daysRemaining = 1)
+        val (settings, state) = customDynamicScenario(
+            budget = BigDecimal("1000"),
+            spent = BigDecimal.ZERO,
+            daysLeft = 1,
+        )
+
+        renderSheet(budgetSettings = settings, budgetState = state)
+
+        composeTestRule.onNodeWithTag(BUDGET_PERIOD_CALCULATED_CARD_TAG)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("1000.00"))).onLast()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun when_dynamic_weekly_period_then_card_scales_daily_by_7() {
+        // 16644.45 - 200 = 16444.45 / 28 = 587.30/day -> 587.30 * 7 = 4111.10/week
+        val (settings, state) = customDynamicScenario(
+            budget = totalBudget,
+            spent = totalSpent,
+            daysLeft = 28,
+        )
+
+        renderSheet(budgetSettings = settings, budgetState = state)
+
+        // Switch the period chip from DAILY (the default) to WEEKLY
+        composeTestRule.onNodeWithTag(budgetPeriodToggleTag(BudgetPeriod.WEEKLY))
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onAllNodesWithText(formatExpected(BigDecimal("4111.10"))).onLast()
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/serranoie/app/minus/data/di/DatabaseModule.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/di/DatabaseModule.kt
@@ -32,6 +32,7 @@ object DatabaseModule {
             .addMigrations(AppDatabaseMigrations.MIGRATION_6_7)
             .addMigrations(AppDatabaseMigrations.MIGRATION_8_9)
             .addMigrations(AppDatabaseMigrations.MIGRATION_9_10)
+            .addMigrations(AppDatabaseMigrations.MIGRATION_10_11)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabase.kt
@@ -18,7 +18,7 @@ import com.serranoie.app.minus.data.local.entity.TransactionEntity
         CategoryEntity::class,
         QueuedTransactionEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabaseMigrations.kt
@@ -38,4 +38,12 @@ object AppDatabaseMigrations {
             db.execSQL("ALTER TABLE budget_settings ADD COLUMN creditCardCutoffDay INTEGER")
         }
     }
+
+    val MIGRATION_10_11: Migration = object : Migration(10, 11) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE budget_settings ADD COLUMN splitMode TEXT NOT NULL DEFAULT 'STATIC'"
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/data/local/entity/BudgetSettingsEntity.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/entity/BudgetSettingsEntity.kt
@@ -16,5 +16,6 @@ data class BudgetSettingsEntity(
     val rollOverEnabled: Boolean = false,
     val rollOverCarryForward: Boolean = false,
     val remainingBudgetStrategy: String = "ASK_ALWAYS",
-    val creditCardCutoffDay: Int? = null
+    val creditCardCutoffDay: Int? = null,
+    val splitMode: String = "STATIC"
 )

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.serranoie.app.minus.data.local.entity.TransactionEntity
 import com.serranoie.app.minus.domain.calculator.BudgetCalculator
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.Category
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
@@ -120,7 +121,12 @@ class BudgetRepositoryImpl @Inject constructor(
             } catch (_: Exception) {
                 RemainingBudgetStrategy.ASK_ALWAYS
             },
-            creditCardCutoffDay = this.creditCardCutoffDay
+            creditCardCutoffDay = this.creditCardCutoffDay,
+            splitMode = try {
+                BudgetSplitMode.valueOf(this.splitMode)
+            } catch (_: Exception) {
+                BudgetSplitMode.STATIC
+            }
         )
         logcat { "toDomain: entity=$this -> domain=$domain" }
         return domain
@@ -138,7 +144,8 @@ class BudgetRepositoryImpl @Inject constructor(
             rollOverEnabled = this.rollOverEnabled,
             rollOverCarryForward = this.rollOverCarryForward,
             remainingBudgetStrategy = this.remainingBudgetStrategy.name,
-            creditCardCutoffDay = this.creditCardCutoffDay
+            creditCardCutoffDay = this.creditCardCutoffDay,
+            splitMode = this.splitMode.name
         )
         logcat { "toEntity: domain=$this -> entity=$entity" }
         return entity

--- a/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/BudgetPeriod.kt
@@ -16,6 +16,17 @@ enum class RemainingBudgetStrategy {
     ASK_ALWAYS, SPLIT_EQUALLY, ADD_TO_FIRST_DAY,
 }
 
+/**
+ * How the period's total budget is divided for the per-period pill shown in the UI.
+ *
+ * - [STATIC]: totalBudget / (totalDays / period.toDays()), unchanged regardless of spend.
+ * - [DYNAMIC]: (totalBudget - totalSpent) / daysRemaining, so the pill updates as you spend.
+ */
+enum class BudgetSplitMode {
+    STATIC,
+    DYNAMIC,
+}
+
 enum class SymbolPosition {
     START,
     END,
@@ -142,6 +153,7 @@ data class BudgetSettings(
     val rollOverCarryForward: Boolean = false,
     val remainingBudgetStrategy: RemainingBudgetStrategy = RemainingBudgetStrategy.ASK_ALWAYS,
     val creditCardCutoffDay: Int? = null,
+    val splitMode: BudgetSplitMode = BudgetSplitMode.STATIC,
 ) {
     fun getDaysForPeriod(): Int {
         return when (period) {
@@ -178,6 +190,7 @@ data class BudgetSettings(
             rollOverCarryForward = false,
             remainingBudgetStrategy = RemainingBudgetStrategy.ASK_ALWAYS,
             creditCardCutoffDay = null,
+            splitMode = BudgetSplitMode.STATIC,
         )
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -89,13 +89,14 @@ import androidx.compose.ui.unit.sp
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.RemainingBudgetStrategy
 import com.serranoie.app.minus.domain.model.SupportedCurrency
 import com.serranoie.app.minus.domain.model.SupportedCurrencyData
 import com.serranoie.app.minus.presentation.ui.onboarding.FinishDateSelector
 import com.serranoie.app.minus.presentation.ui.onboarding.availablePeriodsFor
-import com.serranoie.app.minus.presentation.ui.onboarding.budgetForPeriod
+import com.serranoie.app.minus.presentation.ui.onboarding.splitBudget
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.bodyMediumCondensed
 import com.serranoie.app.minus.presentation.ui.theme.bodySmallCondensed
@@ -129,6 +130,7 @@ const val BUDGET_PERIOD_DATE_ROW_TAG = "BudgetPeriodSheet.DateRow"
 const val BUDGET_PERIOD_STRATEGY_ROW_TAG = "BudgetPeriodSheet.StrategyRow"
 const val BUDGET_PERIOD_CURRENCY_ROW_TAG = "BudgetPeriodSheet.CurrencyRow"
 const val BUDGET_PERIOD_SPLIT_TOGGLE_ROW_TAG = "BudgetPeriodSheet.SplitToggleRow"
+const val BUDGET_PERIOD_SPLIT_MODE_ROW_TAG = "BudgetPeriodSheet.SplitModeRow"
 const val BUDGET_PERIOD_CALCULATED_CARD_TAG = "BudgetPeriodSheet.CalculatedCard"
 
 fun budgetPeriodCardTag(period: BudgetPeriod) = "BudgetPeriodSheet.Period.${period.name}"
@@ -170,6 +172,17 @@ fun BudgetPeriodSheet(
     val startDateAsDate = remember(startDate) { startDate.toDate() }
     val endDateAsDate = remember(endDate) { endDate?.toDate() }
     val totalSpent = budgetState?.totalSpentInPeriod ?: BigDecimal.ZERO
+
+    // For dynamic split: how many days of the period are still ahead of us.
+    // Clamped to [0, totalDays] so we never divide by a negative or get values
+    // outside the period's window.
+    val today = remember { LocalDate.now() }
+    val daysRemaining =
+        remember(startDate, endDate, today) {
+            if (endDate == null) totalDays
+            else ((ChronoUnit.DAYS.between(today, endDate).toInt() + 1)
+                .coerceIn(0, totalDays))
+        }
 
     val available =
         if (totalDays > 0) availablePeriodsFor(totalDays) else listOf(BudgetPeriod.DAILY)
@@ -240,6 +253,7 @@ fun BudgetPeriodSheet(
                 totalBudget = totalBudget,
                 totalSpent = totalSpent,
                 totalDays = totalDays,
+                daysRemaining = daysRemaining,
                 startDateAsDate = startDateAsDate,
                 endDateAsDate = endDateAsDate,
                 available = available,
@@ -308,6 +322,7 @@ private fun ViewBudgetContent(
     totalBudget: BigDecimal,
     totalSpent: BigDecimal,
     totalDays: Int,
+    daysRemaining: Int,
     startDateAsDate: Date,
     endDateAsDate: Date?,
     available: List<BudgetPeriod>,
@@ -495,7 +510,10 @@ private fun ViewBudgetContent(
             CalculatedSplitCard(
                 periodCache = periodCache,
                 totalBudget = totalBudget,
+                totalSpent = totalSpent,
                 totalDays = totalDays,
+                daysRemaining = daysRemaining,
+                splitMode = budgetSettings?.splitMode ?: BudgetSplitMode.STATIC,
                 currencyFormat = currencyFormat,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -563,6 +581,7 @@ fun EditBudgetContent(
     val currentCurrency = budgetSettings?.currencyCode ?: "USD"
     val currentStrategy =
         budgetSettings?.remainingBudgetStrategy ?: RemainingBudgetStrategy.ASK_ALWAYS
+    val currentSplitMode = budgetSettings?.splitMode ?: BudgetSplitMode.STATIC
 
     val previousPeriodDays =
         remember(currentStart, currentEnd) {
@@ -594,10 +613,12 @@ fun EditBudgetContent(
     var endCache by remember(currentEnd) { mutableStateOf(currentEnd) }
     var currencyCache by remember(currentCurrency) { mutableStateOf(currentCurrency) }
     var strategyCache by remember(currentStrategy) { mutableStateOf(currentStrategy) }
+    var splitModeCache by remember(currentSplitMode) { mutableStateOf(currentSplitMode) }
 
     var showDateSelector by remember { mutableStateOf(false) }
     var showCurrencyPicker by remember { mutableStateOf(false) }
     var showStrategyPicker by remember { mutableStateOf(false) }
+    var showSplitModePicker by remember { mutableStateOf(false) }
     var showPreviousValues by remember { mutableStateOf(false) }
 
     val parsedBudget = budgetText.toBigDecimalOrNull()?.movePointLeft(currencyFractionDigits)
@@ -880,6 +901,20 @@ fun EditBudgetContent(
 
         Spacer(modifier = Modifier.height(8.dp))
 
+        SettingsRow(
+            modifier = Modifier.testTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG),
+            icon = Icons.Rounded.Sync,
+            label = stringResource(R.string.split_mode_label),
+            trailingText =
+                when (splitModeCache) {
+                    BudgetSplitMode.STATIC -> stringResource(R.string.split_mode_static)
+                    BudgetSplitMode.DYNAMIC -> stringResource(R.string.split_mode_dynamic)
+                },
+            onClick = { showSplitModePicker = true },
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         val currencyDisplay = SupportedCurrency.findByCode(currencyCache)
         SettingsRow(
             modifier = Modifier.testTag(BUDGET_PERIOD_CURRENCY_ROW_TAG),
@@ -959,10 +994,11 @@ fun EditBudgetContent(
                         daysInPeriod = periodDays,
                         currencyCode = currencyCache,
                         remainingBudgetStrategy = strategyCache,
+                        splitMode = splitModeCache,
                         period = period,
                     )
                 logcat {
-                    "Apply tapped: budget=$parsedBudget, start=$startCache, end=$endCache, periodDays=$periodDays, resolvedPeriod=$period, strategy=$strategyCache, currency=$currencyCache"
+                    "Apply tapped: budget=$parsedBudget, start=$startCache, end=$endCache, periodDays=$periodDays, resolvedPeriod=$period, strategy=$strategyCache, splitMode=$splitModeCache, currency=$currencyCache"
                 }
                 onApply(newSettings)
             },
@@ -1022,6 +1058,17 @@ fun EditBudgetContent(
             onSelect = { strategy ->
                 strategyCache = strategy
                 showStrategyPicker = false
+            },
+        )
+    }
+
+    if (showSplitModePicker) {
+        SplitModePickerDialog(
+            currentMode = splitModeCache,
+            onDismiss = { showSplitModePicker = false },
+            onSelect = { mode ->
+                splitModeCache = mode
+                showSplitModePicker = false
             },
         )
     }
@@ -1169,6 +1216,99 @@ private fun StrategyPickerDialog(
 }
 
 @Composable
+private fun SplitModePickerDialog(
+    currentMode: BudgetSplitMode,
+    onDismiss: () -> Unit,
+    onSelect: (BudgetSplitMode) -> Unit,
+) {
+    val modes = listOf(BudgetSplitMode.STATIC, BudgetSplitMode.DYNAMIC)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(R.string.split_mode_dialog_title),
+                style = MaterialTheme.typography.titleLargeEmphasized,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.split_mode_dialog_description),
+                    style = MaterialTheme.typography.bodySmallCondensed,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                modes.forEach { mode ->
+                    val isSelected = mode == currentMode
+                    val title = when (mode) {
+                        BudgetSplitMode.STATIC -> stringResource(R.string.split_mode_static)
+                        BudgetSplitMode.DYNAMIC -> stringResource(R.string.split_mode_dynamic)
+                    }
+                    val description = when (mode) {
+                        BudgetSplitMode.STATIC -> stringResource(R.string.split_mode_static_desc)
+                        BudgetSplitMode.DYNAMIC -> stringResource(R.string.split_mode_dynamic_desc)
+                    }
+                    OutlinedCard(
+                        onClick = { onSelect(mode) },
+                        modifier = Modifier.fillMaxWidth(),
+                        border = BorderStroke(
+                            width = if (isSelected) 2.dp else 1.dp,
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                            },
+                        ),
+                        colors = CardDefaults.outlinedCardColors(
+                            containerColor = if (isSelected) {
+                                MaterialTheme.colorScheme.primaryContainer.copy(
+                                    alpha = 0.3f
+                                )
+                            } else {
+                                MaterialTheme.colorScheme.surface
+                            },
+                        ),
+                    ) {
+                        Column(modifier = Modifier.padding(12.dp)) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = title,
+                                    style = MaterialTheme.typography.bodyMediumEmphasized,
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (isSelected) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            }
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = stringResource(R.string.close),
+                    style = MaterialTheme.typography.labelMediumEmphasized,
+                )
+            }
+        },
+    )
+}
+
+@Composable
 private fun periodLabel(period: BudgetPeriod): String = stringResource(
     when (period) {
         BudgetPeriod.DAILY -> R.string.budget_period_daily
@@ -1192,12 +1332,22 @@ private fun periodWordLabel(period: BudgetPeriod): String = stringResource(
 private fun CalculatedSplitCard(
     periodCache: BudgetPeriod,
     totalBudget: BigDecimal,
+    totalSpent: BigDecimal,
     totalDays: Int,
+    daysRemaining: Int,
+    splitMode: BudgetSplitMode,
     currencyFormat: NumberFormat,
     modifier: Modifier = Modifier,
 ) {
     val calculatedAmount = if (totalBudget > BigDecimal.ZERO && totalDays > 0) {
-        budgetForPeriod(totalBudget, totalDays, periodCache)
+        splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = totalSpent,
+            totalDays = totalDays,
+            daysRemaining = daysRemaining,
+            period = periodCache,
+            mode = splitMode,
+        )
     } else {
         BigDecimal.ZERO
     }
@@ -1240,13 +1390,17 @@ private fun CalculatedSplitCard(
 private fun BudgetPeriodSheetPreview() {
     MinusTheme {
         Surface {
+            // Pinned dates keep the dynamic split card stable across re-renders.
+            // see `MEMORY.md` note on Paparazzi/LocalDate drift.
+            val pinnedStart = LocalDate.of(2099, 6, 1)
+            val pinnedEnd = LocalDate.of(2099, 6, 30)
             BudgetPeriodSheet(
                 budgetSettings =
                     BudgetSettings(
                         totalBudget = BigDecimal("17725"),
                         period = BudgetPeriod.DAILY,
-                        startDate = LocalDate.now().minusDays(29),
-                        endDate = LocalDate.now(),
+                        startDate = pinnedStart,
+                        endDate = pinnedEnd,
                         currencyCode = "MXN",
                         daysInPeriod = 30,
                         rollOverEnabled = false,
@@ -1287,8 +1441,8 @@ private fun EditModePreview() {
                     BudgetSettings(
                         totalBudget = BigDecimal("17725"),
                         period = BudgetPeriod.DAILY,
-                        startDate = LocalDate.now().minusDays(29),
-                        endDate = LocalDate.now(),
+                        startDate = LocalDate.of(2099, 6, 1),
+                        endDate = LocalDate.of(2099, 6, 30),
                         currencyCode = "MXN",
                         daysInPeriod = 30,
                     ),
@@ -1312,8 +1466,8 @@ private fun EditEmptyModePreview() {
             budgetSettings = BudgetSettings(
                 totalBudget = BigDecimal("0"),
                 period = BudgetPeriod.DAILY,
-                startDate = LocalDate.now().minusDays(29),
-                endDate = LocalDate.now(),
+                startDate = LocalDate.of(2099, 6, 1),
+                endDate = LocalDate.of(2099, 6, 30),
                 currencyCode = "MXN",
                 daysInPeriod = 30,
             ),

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/FinishDateSelector.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/onboarding/FinishDateSelector.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.PeriodOptionChip
 import java.math.BigDecimal
@@ -81,17 +82,55 @@ fun availablePeriodsFor(totalDays: Int): List<BudgetPeriod> = buildList {
 	if (totalDays >= 30) add(BudgetPeriod.MONTHLY)
 }
 
+/**
+ * Static split: how much you can spend per period if the totalBudget is divided
+ * equally across all periods in the range. Unaffected by how much you've already spent.
+ *
+ * Kept for the onboarding flow where the period hasn't started yet, so dynamic
+ * has nothing meaningful to compute. Use [splitBudget] for everything else.
+ */
 fun budgetForPeriod(
 	totalBudget: BigDecimal,
 	totalDays: Int,
 	period: BudgetPeriod,
 ): BigDecimal {
 	if (totalBudget == BigDecimal.ZERO || totalDays <= 0) return BigDecimal.ZERO
-	
+
 	val periodDays = period.toDays()
 	val numPeriods = totalDays / periodDays
-	
+
 	return totalBudget.divide(BigDecimal(numPeriods), 2, RoundingMode.HALF_UP)
+}
+
+/**
+ * Per-period budget amount, honoring the [BudgetSplitMode].
+ *
+ * - STATIC: totalBudget / (totalDays / period.toDays()).
+ * - DYNAMIC: (totalBudget - totalSpent) / daysRemaining, then multiplied by the
+ *   period's day count. Falls back to 0 if [daysRemaining] is 0 (period ended)
+ *   or if the remaining balance is non-positive (don't show negative numbers).
+ */
+fun splitBudget(
+	totalBudget: BigDecimal,
+	totalSpent: BigDecimal,
+	totalDays: Int,
+	daysRemaining: Int,
+	period: BudgetPeriod,
+	mode: com.serranoie.app.minus.domain.model.BudgetSplitMode,
+): BigDecimal {
+	if (totalBudget == BigDecimal.ZERO || totalDays <= 0) return BigDecimal.ZERO
+	return when (mode) {
+		com.serranoie.app.minus.domain.model.BudgetSplitMode.STATIC ->
+			budgetForPeriod(totalBudget, totalDays, period)
+
+		com.serranoie.app.minus.domain.model.BudgetSplitMode.DYNAMIC -> {
+			if (daysRemaining <= 0) return BigDecimal.ZERO
+			val remaining = totalBudget.subtract(totalSpent)
+			if (remaining <= BigDecimal.ZERO) return BigDecimal.ZERO
+			val daily = remaining.divide(BigDecimal(daysRemaining), 2, RoundingMode.HALF_UP)
+			daily.multiply(BigDecimal(period.toDays()))
+		}
+	}
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -216,7 +255,18 @@ fun FinishDateSelector(
 					) {
 						available.forEach { period ->
 							val preview = if (totalBudget > BigDecimal.ZERO) {
-								budgetForPeriod(totalBudget, totalDays, period)
+								// Onboarding is pre-period, so the only meaningful view
+								// is the static split. Dynamic degenerates to the same
+								// number once the period starts, so we hard-code STATIC
+								// here to avoid showing misleading previews.
+								splitBudget(
+									totalBudget = totalBudget,
+									totalSpent = BigDecimal.ZERO,
+									totalDays = totalDays,
+									daysRemaining = totalDays,
+									period = period,
+									mode = BudgetSplitMode.STATIC,
+								)
 							} else null
 
 							PeriodOptionChip(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/PeriodOptionChip.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/PeriodOptionChip.kt
@@ -27,9 +27,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.presentation.ui.onboarding.availablePeriodsFor
-import com.serranoie.app.minus.presentation.ui.onboarding.budgetForPeriod
 import com.serranoie.app.minus.presentation.ui.onboarding.label
+import com.serranoie.app.minus.presentation.ui.onboarding.splitBudget
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import java.math.BigDecimal
 
@@ -93,9 +94,12 @@ fun PeriodOptionChip(
 @Composable
 fun PeriodOptionGroup(
 	totalBudget: BigDecimal,
+	totalSpent: BigDecimal = BigDecimal.ZERO,
 	totalDays: Int,
+	daysRemaining: Int = totalDays,
 	currencyCode: String = "USD",
 	selectedPeriod: BudgetPeriod,
+	splitMode: BudgetSplitMode = BudgetSplitMode.STATIC,
 	onPeriodSelected: (BudgetPeriod) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
@@ -106,7 +110,14 @@ fun PeriodOptionGroup(
 		horizontalArrangement = Arrangement.spacedBy(8.dp),
 	) {
 		availablePeriods.forEach { period ->
-			val budgetPreview = budgetForPeriod(totalBudget, totalDays, period)
+			val budgetPreview = splitBudget(
+				totalBudget = totalBudget,
+				totalSpent = totalSpent,
+				totalDays = totalDays,
+				daysRemaining = daysRemaining,
+				period = period,
+				mode = splitMode,
+			)
 			val isSelected = period == selectedPeriod
 
 			PeriodOptionChip(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,6 +450,15 @@
     <string name="strategy_add_to_first_day">Add to first day</string>
     <string name="strategy_add_to_first_day_desc">All surplus is added to the first day of the new period</string>
 
+    <!-- Budget Split Mode -->
+    <string name="split_mode_label">Split mode</string>
+    <string name="split_mode_dialog_title">How should we split your budget?</string>
+    <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
+    <string name="split_mode_static">Static</string>
+    <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
+    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
+
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>
     <string name="no_name">No name</string>

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/SplitBudgetTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/onboarding/SplitBudgetTest.kt
@@ -1,0 +1,412 @@
+package com.serranoie.app.minus.presentation.ui.onboarding
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
+import org.junit.Test
+import java.math.BigDecimal
+
+class SplitBudgetTest {
+
+    private val totalBudget = BigDecimal("16644.45")
+
+    @Test
+    fun `static daily on a 30 day period divides the budget equally`() {
+        // 16644.45 / 30 = 554.815 -> half-up = 554.82
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30,
+            daysRemaining = 30,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("554.82"))
+    }
+
+    @Test
+    fun `static weekly on a 30 day period yields four equal chunks`() {
+        // 16644.45 / (30/7) -> 30/7 = 4 (int div) -> 16644.45 / 4 = 4161.1125 -> 4161.11
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30,
+            daysRemaining = 30,
+            period = BudgetPeriod.WEEKLY,
+            mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("4161.11"))
+    }
+
+    @Test
+    fun `dynamic daily after 200 spent with 28 days left is 587_30`() {
+        // (16644.45 - 200) / 28 = 587.301785... -> 587.30
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal("200.00"),
+            totalDays = 30,
+            daysRemaining = 28,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("587.30"))
+    }
+
+    @Test
+    fun `dynamic weekly scales the daily amount by 7`() {
+        // The helper rounds the daily amount first, then multiplies by period days.
+        //   daily = 16444.45 / 28 = 587.30178... -> 587.30 (HALF_UP, 2 decimals)
+        //   weekly = 587.30 * 7 = 4111.10
+        // Note: this is NOT 4111.11 (which is what you'd get if you rounded
+        // the final result). The intermediate rounding is intentional — it
+        // matches the daily amount the user actually sees in the card.
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal("200.00"),
+            totalDays = 30,
+            daysRemaining = 28,
+            period = BudgetPeriod.WEEKLY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("4111.10"))
+    }
+
+    @Test
+    fun `dynamic returns zero when the user has overspent`() {
+        // totalBudget=1000, totalSpent=1500 -> remaining is negative -> ZERO
+        val result = splitBudget(
+            totalBudget = BigDecimal("1000"),
+            totalSpent = BigDecimal("1500"),
+            totalDays = 30,
+            daysRemaining = 10,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `dynamic returns zero when the period has ended`() {
+        // daysRemaining=0 -> div by zero guard fires -> ZERO
+        val result = splitBudget(
+            totalBudget = BigDecimal("1000"),
+            totalSpent = BigDecimal("200"),
+            totalDays = 30,
+            daysRemaining = 0,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `dynamic with no spend equals static`() {
+        // If the user hasn't spent anything yet, dynamic must collapse to static.
+        val dynamic = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30,
+            daysRemaining = 30,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+        val static = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30,
+            daysRemaining = 30,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(dynamic).isEqualTo(static)
+    }
+
+    @Test
+    fun `returns zero when total budget is zero regardless of mode`() {
+        val dynamic = splitBudget(
+            totalBudget = BigDecimal.ZERO,
+            totalSpent = BigDecimal("100"),
+            totalDays = 30,
+            daysRemaining = 28,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+        val static = splitBudget(
+            totalBudget = BigDecimal.ZERO,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30,
+            daysRemaining = 30,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(dynamic).isEqualTo(BigDecimal.ZERO)
+        assertThat(static).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `returns zero when total days is non-positive`() {
+        val result = splitBudget(
+            totalBudget = BigDecimal("1000"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 0,
+            daysRemaining = 0,
+            period = BudgetPeriod.DAILY,
+            mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal.ZERO)
+    }
+
+    // Each scenario is hand-computed so the test acts as a spec for the
+    // expected formula behaviour. The numbers are deliberately varied:
+    // round numbers, awkward fractions, and amounts that trigger the
+    // HALF_UP rounding rule (e.g. 100/3 = 33.33).
+    @Test
+    fun `dynamic mid-period with no spend returns full budget over remaining days`() {
+        // 7000 / 7 days = 1000.00/day exactly
+        val daily = splitBudget(
+            totalBudget = BigDecimal("7000"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30, daysRemaining = 7,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val weekly = splitBudget(
+            totalBudget = BigDecimal("7000"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30, daysRemaining = 7,
+            period = BudgetPeriod.WEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val monthly = splitBudget(
+            totalBudget = BigDecimal("7000"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30, daysRemaining = 7,
+            period = BudgetPeriod.MONTHLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("1000.00"))
+        assertThat(weekly).isEqualTo(BigDecimal("7000.00"))
+        assertThat(monthly).isEqualTo(BigDecimal("30000.00"))
+    }
+
+    @Test
+    fun `dynamic on the last day of the period produces the full remaining amount`() {
+        // Edge: daysRemaining = 1 must still produce a real number, not 0.
+        // 1000 / 1 = 1000.00
+        val daily = splitBudget(
+            totalBudget = BigDecimal("1000"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 1, daysRemaining = 1,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("1000.00"))
+    }
+
+    @Test
+    fun `dynamic with half of the budget spent and half the days left returns daily half of remaining`() {
+        // 30-day period, halfway in: 5000 spent, 15 days left -> 2500 / 15 = 166.67
+        // 166.67 * 7 = 1166.69  (NOT 1166.666 -> 1166.67)
+        // 166.67 * 30 = 5000.10
+        val daily = splitBudget(
+            totalBudget = BigDecimal("5000"),
+            totalSpent = BigDecimal("2500"),
+            totalDays = 30, daysRemaining = 15,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val weekly = splitBudget(
+            totalBudget = BigDecimal("5000"),
+            totalSpent = BigDecimal("2500"),
+            totalDays = 30, daysRemaining = 15,
+            period = BudgetPeriod.WEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val monthly = splitBudget(
+            totalBudget = BigDecimal("5000"),
+            totalSpent = BigDecimal("2500"),
+            totalDays = 30, daysRemaining = 15,
+            period = BudgetPeriod.MONTHLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("166.67"))
+        assertThat(weekly).isEqualTo(BigDecimal("1166.69"))
+        assertThat(monthly).isEqualTo(BigDecimal("5000.10"))
+    }
+
+    @Test
+    fun `dynamic biweekly on a 28 day period is twice the weekly amount`() {
+        // 28-day period, $200 spent, 14 days left
+        // remaining = 16444.45 - 200 = 16444.45
+        // daily = 16444.45 / 14 = 1174.6035... -> 1174.60
+        // biweekly = 1174.60 * 14 = 16444.40 (NOT 16444.45 — rounding again)
+        val biweekly = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal("200.00"),
+            totalDays = 28, daysRemaining = 14,
+            period = BudgetPeriod.BIWEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(biweekly).isEqualTo(BigDecimal("16444.40"))
+    }
+
+    @Test
+    fun `dynamic exercises HALF_UP rounding when division is not exact`() {
+        // 100 / 3 = 33.3333... -> 33.33 (3rd decimal is 3, rounds down)
+        // 33.33 * 7 = 233.31
+        // 33.33 * 14 = 466.62
+        // 33.33 * 30 = 999.90
+        val daily = splitBudget(
+            totalBudget = BigDecimal("100"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 3, daysRemaining = 3,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val weekly = splitBudget(
+            totalBudget = BigDecimal("100"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 3, daysRemaining = 3,
+            period = BudgetPeriod.WEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val biweekly = splitBudget(
+            totalBudget = BigDecimal("100"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 3, daysRemaining = 3,
+            period = BudgetPeriod.BIWEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val monthly = splitBudget(
+            totalBudget = BigDecimal("100"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 3, daysRemaining = 3,
+            period = BudgetPeriod.MONTHLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("33.33"))
+        assertThat(weekly).isEqualTo(BigDecimal("233.31"))
+        assertThat(biweekly).isEqualTo(BigDecimal("466.62"))
+        assertThat(monthly).isEqualTo(BigDecimal("999.90"))
+    }
+
+    @Test
+    fun `dynamic with HALF_UP boundary case rounds the 5 up`() {
+        // 15 / 8 = 1.875 -> 1.88 (HALF_UP, 3rd decimal is 5, rounds 2nd up)
+        // 1.88 * 7 = 13.16
+        // 1.88 * 30 = 56.40
+        val daily = splitBudget(
+            totalBudget = BigDecimal("15"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 8, daysRemaining = 8,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val weekly = splitBudget(
+            totalBudget = BigDecimal("15"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 8, daysRemaining = 8,
+            period = BudgetPeriod.WEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val monthly = splitBudget(
+            totalBudget = BigDecimal("15"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 8, daysRemaining = 8,
+            period = BudgetPeriod.MONTHLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("1.88"))
+        assertThat(weekly).isEqualTo(BigDecimal("13.16"))
+        assertThat(monthly).isEqualTo(BigDecimal("56.40"))
+    }
+
+    @Test
+    fun `dynamic with fractional budget and fractional days gives exact result`() {
+        // 123.45 / 3 = 41.15 exactly
+        // 41.15 * 7 = 288.05
+        val daily = splitBudget(
+            totalBudget = BigDecimal("123.45"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 7, daysRemaining = 3,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+        val weekly = splitBudget(
+            totalBudget = BigDecimal("123.45"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 7, daysRemaining = 3,
+            period = BudgetPeriod.WEEKLY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("41.15"))
+        assertThat(weekly).isEqualTo(BigDecimal("288.05"))
+    }
+
+    @Test
+    fun `dynamic with small budget and two days left returns exactly half`() {
+        // 10 / 2 = 5.00 exactly
+        val daily = splitBudget(
+            totalBudget = BigDecimal("10.00"),
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 3, daysRemaining = 2,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("5.00"))
+    }
+
+    @Test
+    fun `dynamic returns zero when exactly at the budget limit`() {
+        // totalSpent == totalBudget -> remaining = 0 -> guard fires -> 0
+        val daily = splitBudget(
+            totalBudget = BigDecimal("1000"),
+            totalSpent = BigDecimal("1000"),
+            totalDays = 30, daysRemaining = 10,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `dynamic with one cent remaining still produces a non-zero amount`() {
+        // 0.01 / 30 = 0.00033... -> 0.00 (rounds to 2 decimals)
+        // Note: this documents the current behaviour — a 1-cent remainder
+        // gets rounded down to $0.00 in the daily amount. Weekly = 0.00 * 7.
+        // If we ever want to surface sub-cent values, this test is the spec
+        // that would need to change (and so would the rounding scale).
+        val daily = splitBudget(
+            totalBudget = BigDecimal("1000.01"),
+            totalSpent = BigDecimal("1000.00"),
+            totalDays = 30, daysRemaining = 30,
+            period = BudgetPeriod.DAILY, mode = BudgetSplitMode.DYNAMIC,
+        )
+
+        assertThat(daily).isEqualTo(BigDecimal("0.00"))
+    }
+
+    @Test
+    fun `static biweekly on a 30 day period yields two equal chunks`() {
+        // 16644.45 / (30/14) = 16644.45 / 2 = 8322.225 -> 8322.23
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30, daysRemaining = 30,
+            period = BudgetPeriod.BIWEEKLY, mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("8322.23"))
+    }
+
+    @Test
+    fun `static monthly on a 30 day period returns the full budget`() {
+        val result = splitBudget(
+            totalBudget = totalBudget,
+            totalSpent = BigDecimal.ZERO,
+            totalDays = 30, daysRemaining = 30,
+            period = BudgetPeriod.MONTHLY, mode = BudgetSplitMode.STATIC,
+        )
+
+        assertThat(result).isEqualTo(BigDecimal("16644.45"))
+    }
+}


### PR DESCRIPTION
## Description
Added a new Dynamic split mode for the budget pill, alongside the existing static behavior. When enabled, the per-period amount is computed from the remaining budget (totalBudget - totalSpent) divided by the remaining days of the period.

## Change strategy
Introduce a BudgetSplitMode { STATIC, DYNAMIC } enum and a splitMode field on BudgetSettings, defaulting to STATIC so existing installs keep their current behavior with zero migration risk.

splitBudget branches on mode: 
- STATIC keeps the original totalBudget / totalDays × period.toDays() path.
- DYNAMIC divides remaining budget by remaining days first, then scales by the period. 

Daily amount is rounded HALF_UP to 2 decimals before scaling so the per-day number the user sees in the card is consistent with the per-week/month/biweekly figures.

## Implemented

- BudgetPeriod.kt: new BudgetSplitMode enum; BudgetSettings.splitMode field with STATIC default; BudgetSettings.Defaults updated.
- BudgetSettingsEntity.kt: new splitMode column (default "STATIC").
- AppDatabase.kt + AppDatabaseMigrations.kt: version bump + ALTER TABLE migration for the new column.
- BudgetRepositoryImpl.kt: toDomain / toEntity map the new field with safe enum parsing.
- BudgetPeriodSheet.kt: "Split mode" section with Static / Dynamic chips wired to local state and persisted on Apply.
- FinishDateSelector.kt, PeriodOptionChip.kt: minor layout/styling tweaks to fit the new section.

## Working demo
<!-- Attach any evidence of the change in action. -->

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
Testing feature, PR closes #77 