### PR TITLE
feat: implement step-by-step coachmark tutorial system

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.gradle.internal.api.BaseVariantOutputImpl
 import java.util.Properties
-import java.io.File
 
 plugins {
     alias(libs.plugins.android.application)
@@ -28,15 +27,6 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     }
 }
 
-// Paparazzi snapshot tests run in the test JVM. These system properties must be
-// passed explicitly to that JVM (gradle.properties alone only affects Gradle's
-// own JVM, not forked test JVMs).
-//
-// `app.cash.paparazzi.differ=offbytwo`  — allows 2-pixel offset per pixel
-// `paparazzi.maxPercentDifferenceDefault` — up to 5% of pixels may differ
-//
-// Together these absorb cross-platform rasterization drift (Linux CI vs
-// Windows/macOS dev machines) without hiding real layout regressions.
 tasks.withType<Test>().configureEach {
     systemProperty("app.cash.paparazzi.differ", "offbytwo")
     systemProperty("paparazzi.maxPercentDifferenceDefault", "5.0")
@@ -228,10 +218,6 @@ tasks.named("preBuild").configure {
 dependencies {
     implementation(project(":sync-contract"))
 
-    // Pin kotlin-stdlib to match the Kotlin Gradle Plugin version. Some transitive
-    // deps (Compose 2.3.x bundles, KSP downstream plugins) leak stdlib 2.4.0+
-    // into the classpath when the project itself is on Kotlin 2.2.x. Forcing
-    // exact match keeps the stdlib in sync with the compiler.
     constraints {
         implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.20") {
             because("stdlib pulled in transitively at 2.4.0 by Compose/KSP, compiler on 2.2.x")
@@ -319,26 +305,6 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.testmanifest.v183)
 }
 
-/*
- * Single source of truth for release notes is fastlane/metadata/android/en-US/
- * changelogs/<versionCode>.txt. Two Gradle tasks produce the runtime asset:
- *
- *   :app:prepareReleaseNotes      — writes the <versionCode>.txt from
- *                                   `git log` between tags (mirrors fastlane's
- *                                   :generate_changelog lane). Run this BEFORE
- *                                   tagging so the committed JSON is
- *                                   reproducible across IzzyOnDroid / F-Droid.
- *   :app:generateAppChangelogJson — reads those .txt files (+ optional
- *                                   fastlane/changelogs/<versionName>.json
- *                                   overrides) and writes
- *                                   app/src/main/assets/changelog.json so
- *                                   ChangelogRepository.kt has structured
- *                                   release notes without anyone hand-editing
- *                                   JSON.
- *
- * prepareReleaseNotes.finalizedBy(generateAppChangelogJson) so the canonical
- * workflow is a single command.
- */
 val prepareReleaseNotes by tasks.registering {
     group = "minus"
     description =

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,6 +228,19 @@ tasks.named("preBuild").configure {
 dependencies {
     implementation(project(":sync-contract"))
 
+    // Pin kotlin-stdlib to match the Kotlin Gradle Plugin version. Some transitive
+    // deps (Compose 2.3.x bundles, KSP downstream plugins) leak stdlib 2.4.0+
+    // into the classpath when the project itself is on Kotlin 2.2.x. Forcing
+    // exact match keeps the stdlib in sync with the compiler.
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.20") {
+            because("stdlib pulled in transitively at 2.4.0 by Compose/KSP, compiler on 2.2.x")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-reflect:2.2.20") {
+            because("keep kotlin-reflect aligned with stdlib + compiler")
+        }
+    }
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
@@ -52,6 +52,7 @@ const val SAVINGS_WANTS_PCT_KEY_NAME = "savings_wants_pct"
 const val SAVINGS_SAVINGS_PCT_KEY_NAME = "savings_savings_pct"
 const val SAVINGS_GOAL_AMOUNT_KEY_NAME = "savings_goal_amount"
 const val SAVINGS_GOAL_MONTHS_KEY_NAME = "savings_goal_months"
+const val TUTORIAL_BOX_COMPLETED_KEY_NAME = "tutorial_box_completed"
 
 private val ONBOARDING_COMPLETED = booleanPreferencesKey(ONBOARDING_COMPLETED_KEY_NAME)
 private val EARLY_FINISH_ACTIVE = booleanPreferencesKey(EARLY_FINISH_ACTIVE_KEY_NAME)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/MainActivity.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/MainActivity.kt
@@ -63,6 +63,7 @@ import com.serranoie.app.minus.data.repository.SETTINGS_DATASTORE_NAME
 import com.serranoie.app.minus.data.repository.SettingsRepository
 import com.serranoie.app.minus.data.repository.THEME_MODE_KEY_NAME
 import com.serranoie.app.minus.data.repository.TYPOGRAPHY_MODE_KEY_NAME
+import com.serranoie.app.minus.data.repository.TUTORIAL_BOX_COMPLETED_KEY_NAME
 import com.serranoie.app.minus.data.wearable.WearableService
 import com.serranoie.app.minus.domain.time.MidnightTransitionManager
 import com.serranoie.app.minus.navigation.AppNavGraph
@@ -118,6 +119,7 @@ val SAVINGS_WANTS_PCT_KEY = intPreferencesKey(SAVINGS_WANTS_PCT_KEY_NAME)
 val SAVINGS_SAVINGS_PCT_KEY = intPreferencesKey(SAVINGS_SAVINGS_PCT_KEY_NAME)
 val SAVINGS_GOAL_AMOUNT_KEY = stringPreferencesKey(SAVINGS_GOAL_AMOUNT_KEY_NAME)
 val SAVINGS_GOAL_MONTHS_KEY = intPreferencesKey(SAVINGS_GOAL_MONTHS_KEY_NAME)
+val TUTORIAL_BOX_COMPLETED_KEY = booleanPreferencesKey(TUTORIAL_BOX_COMPLETED_KEY_NAME)
 const val DEFAULT_NOTIFICATION_HOUR = 9
 const val DEFAULT_NOTIFICATION_MINUTE = 0
 const val DEFAULT_RECURRENT_NOTIFICATION_HOUR = 8

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -387,7 +387,7 @@ fun Editor(
                                 modifier = Modifier
                                     .size(48.dp)
                                     .let { m ->
-                                        if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 3) else m
+                                        if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 2) else m
                                     }
                             ) {
                                 BadgedBox(
@@ -671,7 +671,7 @@ private fun EditingContent(
                         onCommentUpdate = onCommentUpdate,
                         editorFocusController = editorFocusController,
                         modifier = Modifier.let { m ->
-                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 1) else m
+                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 3) else m
                         },
                         extendWidth = toolbarWidth,
                         onlyIcon = false,
@@ -706,7 +706,7 @@ private fun EditingContent(
                         .fillMaxWidth()
                         .padding(bottom = 26.dp)
                         .let { m ->
-                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 1) else m
+                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 3) else m
                         },
                 )
             }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -83,6 +83,8 @@ import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.SupportedCurrency
 import com.serranoie.app.minus.presentation.ui.budget.BudgetUiState
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBoxState
+import com.serranoie.app.minus.presentation.ui.tutorial.markForTutorial
 import com.serranoie.app.minus.presentation.ui.editor.calculation.evaluateCalculation
 import com.serranoie.app.minus.presentation.ui.editor.category.CategoryToolbar
 import com.serranoie.app.minus.presentation.ui.editor.category.EditableCategoryTag
@@ -150,6 +152,7 @@ fun Editor(
     showSettingsButton: Boolean = true,
     budgetPillHintAnchorModifier: Modifier = Modifier,
     analyticsHintAnchorModifier: Modifier = Modifier,
+    tutorialBoxState: TutorialBoxState? = null,
     modifier: Modifier = Modifier,
 ) {
     val view = LocalView.current
@@ -289,7 +292,11 @@ fun Editor(
                                         checked = uiState.isRecurrentEnabled,
                                         onCheckedChange = onRecurrentToggle,
                                         shapes = ButtonGroupDefaults.connectedTrailingButtonShapes(),
-                                        modifier = Modifier.semantics { role = Role.RadioButton },
+                                        modifier = Modifier
+                                            .semantics { role = Role.RadioButton }
+                                            .let { m ->
+                                                if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 4) else m
+                                            },
                                         colors = ToggleButtonDefaults.toggleButtonColors(
                                             containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(
                                                 alpha = 0.5f
@@ -326,7 +333,11 @@ fun Editor(
                                     checked = uiState.isRecurrentEnabled,
                                     onCheckedChange = onRecurrentToggle,
                                     shapes = ToggleButtonDefaults.shapes(),
-                                    modifier = Modifier.semantics { role = Role.RadioButton },
+                                    modifier = Modifier
+                                        .semantics { role = Role.RadioButton }
+                                        .let { m ->
+                                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 4) else m
+                                        },
                                     colors = ToggleButtonDefaults.toggleButtonColors(
                                         containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(
                                             alpha = 0.5f
@@ -373,7 +384,11 @@ fun Editor(
                                     onOpenSettings()
                                     view.weakHapticFeedback()
                                 },
-                                modifier = Modifier.size(48.dp)
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .let { m ->
+                                        if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 3) else m
+                                    }
                             ) {
                                 BadgedBox(
                                     badge = { if (isCensored) Badge() },
@@ -405,6 +420,7 @@ fun Editor(
         ) { state ->
             when (state) {
                 AnimState.EDITING -> {
+                    logcat("IMPL:TUTORIAL") { "Editor entered EDITING state → composing EditingContent (category tag + recurrent will register)" }
                     EditingContent(
                         input = uiState.numpadInput,
                         currencyCode = uiState.budgetSettings?.currencyCode ?: "USD",
@@ -420,6 +436,7 @@ fun Editor(
                         onShowCategoryGrid = onShowCategoryGrid,
                         onHideCategoryGrid = onHideCategoryGrid,
                         onDisableCalculationMode = onDisableCalculationMode,
+                        tutorialBoxState = tutorialBoxState,
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
@@ -506,6 +523,7 @@ private fun EditingContent(
     onShowCategoryGrid: () -> Unit = {},
     onHideCategoryGrid: () -> Unit = {},
     onDisableCalculationMode: () -> Unit = {},
+    tutorialBoxState: TutorialBoxState? = null,
     modifier: Modifier = Modifier
 ) {
     val currencyFormat = symbolOnlyCurrencyFormat(currencyCode)
@@ -652,6 +670,9 @@ private fun EditingContent(
                         tags = tags,
                         onCommentUpdate = onCommentUpdate,
                         editorFocusController = editorFocusController,
+                        modifier = Modifier.let { m ->
+                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 1) else m
+                        },
                         extendWidth = toolbarWidth,
                         onlyIcon = false,
                         onEdit = {},
@@ -683,7 +704,10 @@ private fun EditingContent(
                     onDisableCalculationMode = onDisableCalculationMode,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 26.dp),
+                        .padding(bottom = 26.dp)
+                        .let { m ->
+                            if (tutorialBoxState != null) m.markForTutorial(tutorialBoxState, index = 1) else m
+                        },
                 )
             }
         }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/FutureRecurrentSection.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/FutureRecurrentSection.kt
@@ -64,8 +64,6 @@ internal fun LazyListScope.futureRecurrentSection(
                     stringResource(R.string.show_subscriptions_outside_period)
                 },
                 horizontalPadding = 0.dp,
-                amplitude = 4f,
-                wavelength = 45f,
             )
         }
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -3,10 +3,18 @@ package com.serranoie.app.minus.presentation.ui.home
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBox
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialTooltip
+import com.serranoie.app.minus.presentation.ui.tutorial.rememberTutorialBoxState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.CATEGORY_GRID_MODE_KEY
 import com.serranoie.app.minus.presentation.CATEGORY_PICKER_DIRECT_POPUP_KEY
@@ -112,6 +120,19 @@ fun MainScreen(
         }
     }
 
+    val showNumpadTutorial = remember { mutableStateOf(true) }
+
+    // Note: we intentionally do NOT flip showNumpadTutorial to false in
+    // onTutorialCompleted. The walk's `isCompleted` flag (managed inside
+    // TutorialBoxState) already hides the overlay when the walk finishes; if we
+    // also flipped showNumpadTutorial to false, the rewind logic that brings the
+    // user back to gated targets (category tag, recurrent toggle) when they enter
+    // edit mode would have no effect because the overlay would stay hidden. With
+    // this wiring, the walk can complete, then un-complete when a gated target
+    // becomes available, and the overlay re-shows to walk through the gated
+    // targets on the user's first edit-mode entry.
+    val tutorialBoxState = rememberTutorialBoxState()
+
     ChangelogGate(
         currentVersionCode = run {
             val info = context.packageManager.getPackageInfo(
@@ -121,47 +142,79 @@ fun MainScreen(
             @Suppress("DEPRECATION") info.longVersionCode.toInt()
         },
     ) {
-        MainScreenContent(
-            mainScreenState = mainScreenState,
-            budgetUiState = budgetUiState,
-            onboardingCompleted = onboardingCompleted,
-            tutorialStage = tutorialStage,
-            showCreditQuickToggleFeature = showCreditQuickToggleFeature,
-            directCategoryPopupEnabled = directCategoryPopupEnabled,
-            categoryGridModeEnabled = categoryGridModeEnabled,
-            onProcessIntent = { intent ->
-                when (intent) {
-                    is MainScreenUiIntent.ProcessBudgetTransactionIntent -> {
-                        budgetViewModel.processIntent(intent.intent)
-                    }
-
-                    is MainScreenUiIntent.ProcessBudgetEditorIntent -> {
-                        budgetViewModel.processIntent(intent.intent)
-                    }
-
-                    is MainScreenUiIntent.ProcessBudgetNumpadIntent -> {
-                        budgetViewModel.processIntent(intent.intent)
-                    }
-
-                    else -> {
-                        mainScreenViewModel.processIntent(intent, tutorialStage)
-                    }
+        TutorialBox(
+            showTutorial = showNumpadTutorial.value,
+            onTutorialCompleted = { /* see comment above showNumpadTutorial */ },
+            state = tutorialBoxState,
+            tutorialTarget = { index ->
+                when (index) {
+                    0 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_numpad_title),
+                        description = stringResource(R.string.tutorial_numpad_description),
+                    )
+                    1 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_comment_title),
+                        description = stringResource(R.string.tutorial_comment_description),
+                    )
+                    2 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_budget_pill_title),
+                        description = stringResource(R.string.tutorial_budget_pill_description),
+                    )
+                    3 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_settings_title),
+                        description = stringResource(R.string.tutorial_settings_description),
+                    )
+                    4 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_recurrent_title),
+                        description = stringResource(R.string.tutorial_recurrent_description),
+                    )
+                    else -> Text(text = "")
                 }
             },
-            onNavigateToAnalytics = onNavigateToAnalytics,
-            onNavigateToSettings = onNavigateToSettings,
-            onNavigateToWallet = onNavigateToWallet,
-            openWalletOnStart = openWalletOnStart,
-            showBudgetPeriodSheet = mainScreenState.showBudgetPeriodSheet,
-            forceBudgetPeriodSheetSetup = mainScreenState.forceBudgetPeriodSheetSetup,
-            selectedViewPeriod = effectiveSelectedPeriod,
-            onPeriodSelected = { period ->
-                mainScreenViewModel.processIntent(
-                    MainScreenUiIntent.SetSelectedPeriod(period), tutorialStage
-                )
-            },
-            settingsDataStore = context.settingsDataStore,
-            undoSnackbarActionLabel = undoSnackbarActionLabel,
-        )
+        ) {
+            MainScreenContent(
+                mainScreenState = mainScreenState,
+                budgetUiState = budgetUiState,
+                onboardingCompleted = onboardingCompleted,
+                tutorialStage = tutorialStage,
+                showCreditQuickToggleFeature = showCreditQuickToggleFeature,
+                directCategoryPopupEnabled = directCategoryPopupEnabled,
+                categoryGridModeEnabled = categoryGridModeEnabled,
+                onProcessIntent = { intent ->
+                    when (intent) {
+                        is MainScreenUiIntent.ProcessBudgetTransactionIntent -> {
+                            budgetViewModel.processIntent(intent.intent)
+                        }
+
+                        is MainScreenUiIntent.ProcessBudgetEditorIntent -> {
+                            budgetViewModel.processIntent(intent.intent)
+                        }
+
+                        is MainScreenUiIntent.ProcessBudgetNumpadIntent -> {
+                            budgetViewModel.processIntent(intent.intent)
+                        }
+
+                        else -> {
+                            mainScreenViewModel.processIntent(intent, tutorialStage)
+                        }
+                    }
+                },
+                onNavigateToAnalytics = onNavigateToAnalytics,
+                onNavigateToSettings = onNavigateToSettings,
+                onNavigateToWallet = onNavigateToWallet,
+                openWalletOnStart = openWalletOnStart,
+                showBudgetPeriodSheet = mainScreenState.showBudgetPeriodSheet,
+                forceBudgetPeriodSheetSetup = mainScreenState.forceBudgetPeriodSheetSetup,
+                selectedViewPeriod = effectiveSelectedPeriod,
+                onPeriodSelected = { period ->
+                    mainScreenViewModel.processIntent(
+                        MainScreenUiIntent.SetSelectedPeriod(period), tutorialStage
+                    )
+                },
+                settingsDataStore = context.settingsDataStore,
+                undoSnackbarActionLabel = undoSnackbarActionLabel,
+                tutorialBoxState = tutorialBoxState,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -1,24 +1,21 @@
 package com.serranoie.app.minus.presentation.ui.home
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBox
-import com.serranoie.app.minus.presentation.ui.tutorial.TutorialTooltip
-import com.serranoie.app.minus.presentation.ui.tutorial.rememberTutorialBoxState
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import com.serranoie.app.minus.R
+import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.presentation.CATEGORY_GRID_MODE_KEY
 import com.serranoie.app.minus.presentation.CATEGORY_PICKER_DIRECT_POPUP_KEY
-import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.presentation.CREDIT_QUICK_TOGGLE_FEATURE_KEY
 import com.serranoie.app.minus.presentation.ONBOARDING_COMPLETED_KEY
 import com.serranoie.app.minus.presentation.settingsDataStore
@@ -27,12 +24,16 @@ import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadInt
 import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetTransactionIntent
 import com.serranoie.app.minus.presentation.ui.changelog.ChangelogGate
 import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBox
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialTooltip
 import com.serranoie.app.minus.presentation.ui.tutorial.firstLaunchTutorialStageFlow
+import com.serranoie.app.minus.presentation.ui.tutorial.rememberTutorialBoxState
 import kotlinx.coroutines.flow.map
 import logcat.logcat
 
 private const val TAG = "ISAAC:MainScreen"
 
+@RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun MainScreen(
     onNavigateToAnalytics: () -> Unit = {},
@@ -121,16 +122,6 @@ fun MainScreen(
     }
 
     val showNumpadTutorial = remember { mutableStateOf(true) }
-
-    // Note: we intentionally do NOT flip showNumpadTutorial to false in
-    // onTutorialCompleted. The walk's `isCompleted` flag (managed inside
-    // TutorialBoxState) already hides the overlay when the walk finishes; if we
-    // also flipped showNumpadTutorial to false, the rewind logic that brings the
-    // user back to gated targets (category tag, recurrent toggle) when they enter
-    // edit mode would have no effect because the overlay would stay hidden. With
-    // this wiring, the walk can complete, then un-complete when a gated target
-    // becomes available, and the overlay re-shows to walk through the gated
-    // targets on the user's first edit-mode entry.
     val tutorialBoxState = rememberTutorialBoxState()
 
     ChangelogGate(
@@ -149,20 +140,20 @@ fun MainScreen(
             tutorialTarget = { index ->
                 when (index) {
                     0 -> TutorialTooltip(
-                        title = stringResource(R.string.tutorial_numpad_title),
+                        title = null,
                         description = stringResource(R.string.tutorial_numpad_description),
                     )
-                    1 -> TutorialTooltip(
-                        title = stringResource(R.string.tutorial_comment_title),
-                        description = stringResource(R.string.tutorial_comment_description),
-                    )
                     2 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_settings_title),
+                        description = stringResource(R.string.tutorial_settings_description),
+                    )
+                    1 -> TutorialTooltip(
                         title = stringResource(R.string.tutorial_budget_pill_title),
                         description = stringResource(R.string.tutorial_budget_pill_description),
                     )
                     3 -> TutorialTooltip(
-                        title = stringResource(R.string.tutorial_settings_title),
-                        description = stringResource(R.string.tutorial_settings_description),
+                        title = stringResource(R.string.tutorial_comment_title),
+                        description = stringResource(R.string.tutorial_comment_description),
                     )
                     4 -> TutorialTooltip(
                         title = stringResource(R.string.tutorial_recurrent_title),

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -131,7 +131,7 @@ fun MainScreen(
     val tutorialScope = rememberCoroutineScope()
 
     LaunchedEffect(tutorialBoxCompleted) {
-        if (!tutorialBoxCompleted) {
+        if (!tutorialBoxCompleted && tutorialBoxState.isCompleted) {
             tutorialBoxState.resetForReplay()
         }
     }
@@ -152,6 +152,14 @@ fun MainScreen(
                 tutorialScope.launch {
                     context.settingsDataStore.edit { prefs ->
                         prefs[TUTORIAL_BOX_COMPLETED_KEY] = true
+                    }
+                }
+            },
+            onTutorialReopened = {
+                logcat(TAG) { "TutorialBox reopened (gated target became measurable) → persisting tutorialBoxCompleted=false" }
+                tutorialScope.launch {
+                    context.settingsDataStore.edit { prefs ->
+                        prefs[TUTORIAL_BOX_COMPLETED_KEY] = false
                     }
                 }
             },
@@ -177,6 +185,14 @@ fun MainScreen(
                     4 -> TutorialTooltip(
                         title = stringResource(R.string.tutorial_recurrent_title),
                         description = stringResource(R.string.tutorial_recurrent_description),
+                    )
+                    5 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_analytics_title),
+                        description = stringResource(R.string.tutorial_analytics_description),
+                    )
+                    6 -> TutorialTooltip(
+                        title = stringResource(R.string.tutorial_privacy_title),
+                        description = stringResource(R.string.tutorial_privacy_description),
                     )
                     else -> Text(text = "")
                 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -6,10 +6,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.datastore.preferences.core.edit
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.serranoie.app.minus.R
@@ -18,6 +18,7 @@ import com.serranoie.app.minus.presentation.CATEGORY_GRID_MODE_KEY
 import com.serranoie.app.minus.presentation.CATEGORY_PICKER_DIRECT_POPUP_KEY
 import com.serranoie.app.minus.presentation.CREDIT_QUICK_TOGGLE_FEATURE_KEY
 import com.serranoie.app.minus.presentation.ONBOARDING_COMPLETED_KEY
+import com.serranoie.app.minus.presentation.TUTORIAL_BOX_COMPLETED_KEY
 import com.serranoie.app.minus.presentation.settingsDataStore
 import com.serranoie.app.minus.presentation.ui.budget.BudgetViewModel
 import com.serranoie.app.minus.presentation.ui.budget.mvi.intent.BudgetNumpadIntent
@@ -28,7 +29,9 @@ import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBox
 import com.serranoie.app.minus.presentation.ui.tutorial.TutorialTooltip
 import com.serranoie.app.minus.presentation.ui.tutorial.firstLaunchTutorialStageFlow
 import com.serranoie.app.minus.presentation.ui.tutorial.rememberTutorialBoxState
+import com.serranoie.app.minus.presentation.ui.tutorial.tutorialBoxCompletedFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import logcat.logcat
 
 private const val TAG = "ISAAC:MainScreen"
@@ -121,8 +124,17 @@ fun MainScreen(
         }
     }
 
-    val showNumpadTutorial = remember { mutableStateOf(true) }
+    val tutorialBoxCompleted by context.tutorialBoxCompletedFlow()
+        .collectAsStateWithLifecycle(initialValue = false)
+    val showNumpadTutorial = !tutorialBoxCompleted
     val tutorialBoxState = rememberTutorialBoxState()
+    val tutorialScope = rememberCoroutineScope()
+
+    LaunchedEffect(tutorialBoxCompleted) {
+        if (!tutorialBoxCompleted) {
+            tutorialBoxState.resetForReplay()
+        }
+    }
 
     ChangelogGate(
         currentVersionCode = run {
@@ -134,8 +146,15 @@ fun MainScreen(
         },
     ) {
         TutorialBox(
-            showTutorial = showNumpadTutorial.value,
-            onTutorialCompleted = { /* see comment above showNumpadTutorial */ },
+            showTutorial = showNumpadTutorial,
+            onTutorialCompleted = {
+                logcat(TAG) { "TutorialBox completed → persisting tutorialBoxCompleted=true" }
+                tutorialScope.launch {
+                    context.settingsDataStore.edit { prefs ->
+                        prefs[TUTORIAL_BOX_COMPLETED_KEY] = true
+                    }
+                }
+            },
             state = tutorialBoxState,
             tutorialTarget = { index ->
                 when (index) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
@@ -97,6 +97,8 @@ import com.serranoie.app.minus.presentation.ui.theme.component.numpad.SavedCateg
 import com.serranoie.app.minus.presentation.ui.theme.isNightMode
 import com.serranoie.app.minus.presentation.ui.tutorial.FIRST_LAUNCH_TUTORIAL_STAGE_KEY
 import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
+import com.serranoie.app.minus.presentation.ui.tutorial.TutorialBoxState
+import com.serranoie.app.minus.presentation.ui.tutorial.markForTutorial
 import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import com.serranoie.app.minus.presentation.util.StatusBarPadding
 import kotlinx.coroutines.delay
@@ -129,6 +131,7 @@ fun MainScreenContent(
     onPeriodSelected: (BudgetPeriod) -> Unit,
     settingsDataStore: DataStore<Preferences>?,
     undoSnackbarActionLabel: String,
+    tutorialBoxState: TutorialBoxState? = null,
 ) {
     val topSheetState = rememberSwipeableState(TopSheetValue.HalfExpanded)
     var nightMode by remember { mutableStateOf(false) }
@@ -305,6 +308,7 @@ fun MainScreenContent(
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
                     onPeriodSelected = onPeriodSelected,
+                    tutorialBoxState = tutorialBoxState,
                 )
             } else {
                 // Expanded (>= 840dp): two-pane tablet layout
@@ -333,6 +337,7 @@ fun MainScreenContent(
                     forceBudgetPeriodSheetSetup = forceBudgetPeriodSheetSetup,
                     selectedViewPeriod = selectedViewPeriod,
                     onPeriodSelected = onPeriodSelected,
+                    tutorialBoxState = tutorialBoxState,
                 )
             }
 
@@ -422,6 +427,7 @@ private fun PhoneLayout(
     forceBudgetPeriodSheetSetup: Boolean,
     selectedViewPeriod: BudgetPeriod?,
     onPeriodSelected: (BudgetPeriod) -> Unit,
+    tutorialBoxState: TutorialBoxState? = null,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val navigationBarOffset = windowInsets.calculateBottomPadding()
@@ -579,6 +585,9 @@ private fun PhoneLayout(
                             null
                         }
                     Numpad(
+                        modifier = tutorialBoxState?.let { state ->
+                            Modifier.markForTutorial(state, index = 0)
+                        } ?: Modifier,
                         editorState = editorState,
                         numberHintAnchorModifier = Modifier,
                         applyHintAnchorModifier = Modifier,
@@ -790,8 +799,11 @@ private fun PhoneLayout(
                             ),
                         )
                     },
-                    budgetPillHintAnchorModifier = Modifier,
+                    budgetPillHintAnchorModifier = tutorialBoxState
+                        ?.let { state -> Modifier.markForTutorial(state, index = 2) }
+                        ?: Modifier,
                     analyticsHintAnchorModifier = Modifier,
+                    tutorialBoxState = tutorialBoxState,
                 )
             },
             sheetContentExpand = {
@@ -844,6 +856,7 @@ private fun TabletLayout(
     forceBudgetPeriodSheetSetup: Boolean,
     selectedViewPeriod: BudgetPeriod?,
     onPeriodSelected: (BudgetPeriod) -> Unit,
+    tutorialBoxState: TutorialBoxState? = null,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val navigationBarOffset = windowInsets.calculateBottomPadding()
@@ -853,6 +866,7 @@ private fun TabletLayout(
         (contentWidth / 2f)
             .coerceAtMost(with(localDensity) { 500.dp.toPx() })
             .coerceAtMost(contentHeight / 2)
+            .coerceAtLeast(contentHeight)
     val rowHeightPx = defaultInternalKeyboardHeightBase / 4
     val defaultInternalKeyboardHeight = rowHeightPx * 4
     val calcModeKeyboardHeight = rowHeightPx * 5
@@ -1036,8 +1050,11 @@ private fun TabletLayout(
                     },
                     showAnalyticsButton = false,
                     showSettingsButton = false,
-                    budgetPillHintAnchorModifier = Modifier,
+                    budgetPillHintAnchorModifier = tutorialBoxState
+                        ?.let { state -> Modifier.markForTutorial(state, index = 2) }
+                        ?: Modifier,
                     analyticsHintAnchorModifier = Modifier,
+                    tutorialBoxState = tutorialBoxState,
                 )
             }
 
@@ -1092,6 +1109,9 @@ private fun TabletLayout(
                             null
                         }
                     Numpad(
+                        modifier = tutorialBoxState?.let { state ->
+                            Modifier.markForTutorial(state, index = 0)
+                        } ?: Modifier,
                         editorState = editorState,
                         numberHintAnchorModifier = Modifier,
                         applyHintAnchorModifier = Modifier,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
@@ -800,7 +800,7 @@ private fun PhoneLayout(
                         )
                     },
                     budgetPillHintAnchorModifier = tutorialBoxState
-                        ?.let { state -> Modifier.markForTutorial(state, index = 2) }
+                        ?.let { state -> Modifier.markForTutorial(state, index = 1) }
                         ?: Modifier,
                     analyticsHintAnchorModifier = Modifier,
                     tutorialBoxState = tutorialBoxState,
@@ -1051,7 +1051,7 @@ private fun TabletLayout(
                     showAnalyticsButton = false,
                     showSettingsButton = false,
                     budgetPillHintAnchorModifier = tutorialBoxState
-                        ?.let { state -> Modifier.markForTutorial(state, index = 2) }
+                        ?.let { state -> Modifier.markForTutorial(state, index = 1) }
                         ?: Modifier,
                     analyticsHintAnchorModifier = Modifier,
                     tutorialBoxState = tutorialBoxState,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreenContent.kt
@@ -266,6 +266,7 @@ fun MainScreenContent(
                 expanded = shouldExpandRail,
                 onNavigateToAnalytics = onNavigateToAnalytics,
                 onNavigateToSettings = onNavigateToSettings,
+                tutorialBoxState = tutorialBoxState,
             )
         }
 
@@ -363,8 +364,13 @@ private fun MainNavigationRail(
     expanded: Boolean,
     onNavigateToAnalytics: () -> Unit,
     onNavigateToSettings: () -> Unit,
+    tutorialBoxState: TutorialBoxState? = null,
 ) {
     val itemModifier = if (expanded) Modifier.fillMaxWidth() else Modifier
+    val analyticsItemModifier = itemModifier.let { base ->
+        if (tutorialBoxState != null) base.markForTutorial(tutorialBoxState, index = 5)
+        else base
+    }
 
     NavigationRail(
         modifier = if (expanded) Modifier.width(104.dp) else Modifier,
@@ -373,7 +379,7 @@ private fun MainNavigationRail(
     ) {
         Spacer(Modifier.weight(1f))
         NavigationRailItem(
-            modifier = itemModifier,
+            modifier = analyticsItemModifier,
             selected = false,
             onClick = onNavigateToAnalytics,
             icon = { Icon(Icons.Rounded.BarChart, contentDescription = "Analytics") },
@@ -802,7 +808,9 @@ private fun PhoneLayout(
                     budgetPillHintAnchorModifier = tutorialBoxState
                         ?.let { state -> Modifier.markForTutorial(state, index = 1) }
                         ?: Modifier,
-                    analyticsHintAnchorModifier = Modifier,
+                    analyticsHintAnchorModifier = tutorialBoxState
+                        ?.let { state -> Modifier.markForTutorial(state, index = 5) }
+                        ?: Modifier,
                     tutorialBoxState = tutorialBoxState,
                 )
             },
@@ -1053,7 +1061,9 @@ private fun TabletLayout(
                     budgetPillHintAnchorModifier = tutorialBoxState
                         ?.let { state -> Modifier.markForTutorial(state, index = 1) }
                         ?: Modifier,
-                    analyticsHintAnchorModifier = Modifier,
+                    analyticsHintAnchorModifier = tutorialBoxState
+                        ?.let { state -> Modifier.markForTutorial(state, index = 5) }
+                        ?: Modifier,
                     tutorialBoxState = tutorialBoxState,
                 )
             }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Publish
 import androidx.compose.material.icons.filled.QuestionMark
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.Savings
 import androidx.compose.material.icons.filled.Sell
@@ -515,7 +516,7 @@ fun Settings(
                             showRecurrentPaymentsViewModeDialog = true
                             view.weakHapticFeedback()
                         },
-                        position = PaddedListItemPosition.Last,
+                        position = PaddedListItemPosition.Middle,
                         modifier = Modifier.testTag("SettingsRecurrentPaymentsViewModeItem")
                     ) {
                         Icon(
@@ -541,6 +542,34 @@ fun Settings(
                             style = MaterialTheme.typography.labelLargeCondensed,
                             color = MaterialTheme.colorScheme.primary
                         )
+                    }
+
+                    CustomPaddedListItem(
+                        onClick = {
+                            view.toggleFeedback()
+                            onResetTutorial()
+                        },
+                        position = PaddedListItemPosition.Last,
+                        modifier = Modifier.testTag("SettingsResetTutorialItem")
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_reset_tutorial_title),
+                                style = MaterialTheme.typography.bodyMediumEmphasized,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_reset_tutorial_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }
@@ -911,41 +940,6 @@ fun Settings(
                     }
                 }
             }
-
-//
-// 			item {
-// 				PaddedListGroup(
-// 					title = stringResource(R.string.settings_section_tutorial)
-// 				) {
-// 					CustomPaddedListItem(
-// 						onClick = {
-// 							onResetTutorial()
-// 							view.toggleFeedback()
-// 						},
-// 						position = PaddedListItemPosition.Single,
-// 						modifier = Modifier.testTag("SettingsResetTutorialItem")
-// 					) {
-// 						Icon(
-// 							imageVector = Icons.Default.Refresh,
-// 							contentDescription = null,
-// 							tint = MaterialTheme.colorScheme.primary
-// 						)
-// 						Spacer(modifier = Modifier.width(16.dp))
-// 						Column(modifier = Modifier.weight(1f)) {
-// 							Text(
-// 								text = stringResource(R.string.settings_reset_tutorial_title),
-// 								style = MaterialTheme.typography.bodyMediumEmphasized,
-// 								color = MaterialTheme.colorScheme.onSurface
-// 							)
-// 							Text(
-// 								text = stringResource(R.string.settings_reset_tutorial_subtitle),
-// 								style = MaterialTheme.typography.bodySmall,
-// 								color = MaterialTheme.colorScheme.onSurfaceVariant
-// 							)
-// 						}
-// 					}
-// 				}
-// 			}
         }
 
         if (showThemeDialog) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ import com.serranoie.app.minus.presentation.DYNAMIC_COLOR_KEY
 import com.serranoie.app.minus.presentation.RECURRENT_NOTIFICATION_HOUR_KEY
 import com.serranoie.app.minus.presentation.RECURRENT_NOTIFICATION_MINUTE_KEY
 import com.serranoie.app.minus.presentation.THEME_MODE_KEY
+import com.serranoie.app.minus.presentation.TUTORIAL_BOX_COMPLETED_KEY
 import com.serranoie.app.minus.presentation.TYPOGRAPHY_MODE_KEY
 import com.serranoie.app.minus.presentation.appTheme
 import com.serranoie.app.minus.presentation.appTypography
@@ -334,6 +335,7 @@ class SettingsViewModel @Inject constructor(
     fun onResetTutorial() {
         viewModelScope.launch {
             context.settingsDataStore.edit { prefs ->
+                prefs[TUTORIAL_BOX_COMPLETED_KEY] = false
                 prefs[FIRST_LAUNCH_TUTORIAL_STAGE_KEY] =
                     FirstLaunchTutorialStage.TAP_ANY_NUMBER.name
             }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/FirstLaunchTutorial.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/FirstLaunchTutorial.kt
@@ -2,6 +2,7 @@ package com.serranoie.app.minus.presentation.ui.tutorial
 
 import android.content.Context
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.serranoie.app.minus.presentation.TUTORIAL_BOX_COMPLETED_KEY
 import com.serranoie.app.minus.presentation.settingsDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -35,5 +36,11 @@ enum class FirstLaunchTutorialStage {
 fun Context.firstLaunchTutorialStageFlow(): Flow<FirstLaunchTutorialStage> {
     return settingsDataStore.data.map { prefs ->
         FirstLaunchTutorialStage.from(prefs[FIRST_LAUNCH_TUTORIAL_STAGE_KEY])
+    }
+}
+
+fun Context.tutorialBoxCompletedFlow(): Flow<Boolean> {
+    return settingsDataStore.data.map { prefs ->
+        prefs[TUTORIAL_BOX_COMPLETED_KEY] ?: false
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
@@ -49,6 +49,7 @@ fun TutorialBox(
     onTutorialCompleted: () -> Unit,
     state: TutorialBoxState,
     tutorialTarget: @Composable (index: Int) -> Unit,
+    onTutorialReopened: () -> Unit = {},
     content: @Composable () -> Unit,
 ) {
     var canvasSize by remember { mutableStateOf(Size.Zero) }
@@ -56,9 +57,13 @@ fun TutorialBox(
     val isCompleted by remember { derivedStateOf { state.isCompleted } }
     val currentIndex by remember { derivedStateOf { state.currentIndexState.value } }
     val activeBounds by remember { derivedStateOf { state.currentBounds } }
+    val isVirtual by remember {
+        derivedStateOf { state.currentIndexState.value in VirtualIndices }
+    }
     val shouldShow by remember(showTutorial, canvasSize) {
         derivedStateOf {
-            showTutorial && !isCompleted && activeBounds != null && canvasSize.isSpecified
+            showTutorial && !isCompleted && (isVirtual || activeBounds != null) &&
+                canvasSize.isSpecified
         }
     }
 
@@ -73,11 +78,12 @@ fun TutorialBox(
     ) {
         content()
 
-        if (shouldShow && activeBounds != null) {
+        if (shouldShow && (isVirtual || activeBounds != null)) {
             TutorialOverlay(
-                bounds = activeBounds!!,
+                bounds = activeBounds ?: Rect.Zero,
                 canvasSize = canvasSize,
                 index = currentIndex,
+                isVirtual = isVirtual,
                 tutorialTarget = tutorialTarget,
                 onTap = { state.advance() },
             )
@@ -87,13 +93,17 @@ fun TutorialBox(
     LaunchedEffect(currentIndex, state.targetBounds.size) {
         if (currentIndex != -1 &&
             !isCompleted &&
+            !isVirtual &&
             state.currentBounds == null
         ) {
-            logcat(TUTORIAL_LOG_TAG) {
-                "TutorialBox: current target $currentIndex " +
-                    "has no bounds, auto-advancing"
+            delay(250.milliseconds)
+            if (state.currentBounds == null) {
+                logcat(TUTORIAL_LOG_TAG) {
+                    "TutorialBox: current target $currentIndex " +
+                        "still has no bounds after settle delay, auto-advancing"
+                }
+                state.advance()
             }
-            state.advance()
         }
     }
 
@@ -120,18 +130,18 @@ fun TutorialBox(
                 if (state.isCompleted) {
                     state.isCompleted = false
                     state.currentIndexState.value = lowest
+                    onTutorialReopened()
                     logcat(TUTORIAL_LOG_TAG) {
                         "rewind-apply: index=$lowest AFTER completion " +
-                            "(targetPos=$targetPos)"
+                            "(targetPos=$targetPos) — fired onTutorialReopened"
                     }
                 } else {
                     val currentPos = order
                         .indexOf(state.currentIndexState.value)
                         .coerceAtLeast(0)
-                    if (currentPos > targetPos) {
+                    if (currentPos != targetPos) {
                         val outgoing = state.currentIndexState.value
-
-                        if (outgoing in order && outgoing != 3 && outgoing != 4) {
+                        if (outgoing in order && outgoing !in GatedIndices) {
                             state.visitedIndices.add(outgoing)
                         }
                         state.currentIndexState.value = lowest
@@ -143,7 +153,7 @@ fun TutorialBox(
                     } else {
                         logcat(TUTORIAL_LOG_TAG) {
                             "rewind-apply: skipped index=$lowest " +
-                                "(currentPos=$currentPos not > targetPos=$targetPos)"
+                                "(currentPos=$currentPos == targetPos=$targetPos)"
                         }
                     }
                 }
@@ -161,10 +171,11 @@ private fun TutorialOverlay(
     bounds: Rect,
     canvasSize: Size,
     index: Int,
+    isVirtual: Boolean,
     tutorialTarget: @Composable (Int) -> Unit,
     onTap: () -> Unit,
 ) {
-    if (bounds.isEmpty) return
+    if (!isVirtual && bounds.isEmpty) return
 
     val scrimColor = Color.Black.copy(alpha = 0.55f)
     val highlightStrokeColor = MaterialTheme.colorScheme.primary
@@ -177,20 +188,26 @@ private fun TutorialOverlay(
     val tooltipMaxWidth = with(density) { tooltipMaxWidthPx.toDp() }
     val tooltipMinHeightEstimate = 96f
 
-    val cutout = Rect(
-        left = bounds.left - paddingPx,
-        top = bounds.top - paddingPx,
-        right = bounds.right + paddingPx,
-        bottom = bounds.bottom + paddingPx,
-    )
-
-    val (tooltipX, tooltipY) = computeTooltipPosition(
-        targetBounds = bounds,
-        canvasSize = canvasSize,
-        gapPx = tooltipGapPx,
-        tooltipWidthPx = tooltipMaxWidthPx,
-        tooltipHeightPx = tooltipMinHeightEstimate,
-    )
+    val (tooltipX, tooltipY) = if (isVirtual) {
+        // No on-screen anchor — centre the tooltip on the canvas.
+        val centredX = (canvasSize.width - tooltipMaxWidthPx) / 2f
+        val centredY = (canvasSize.height - tooltipMinHeightEstimate) / 2f
+        centredX.toInt() to centredY.toInt()
+    } else {
+        val cutout = Rect(
+            left = bounds.left - paddingPx,
+            top = bounds.top - paddingPx,
+            right = bounds.right + paddingPx,
+            bottom = bounds.bottom + paddingPx,
+        )
+        computeTooltipPosition(
+            targetBounds = cutout,
+            canvasSize = canvasSize,
+            gapPx = tooltipGapPx,
+            tooltipWidthPx = tooltipMaxWidthPx,
+            tooltipHeightPx = tooltipMinHeightEstimate,
+        )
+    }
 
     Box(
         modifier = Modifier
@@ -202,28 +219,38 @@ private fun TutorialOverlay(
             ),
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val outer = Path().apply {
-                addRect(Rect(offset = Offset.Zero, size = this@Canvas.size))
-            }
-            val hole = Path().apply {
-                addRoundRect(
-                    RoundRect(
-                        rect = cutout,
-                        cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
-                    ),
+            if (isVirtual) {
+                drawRect(color = scrimColor)
+            } else {
+                val cutout = Rect(
+                    left = bounds.left - paddingPx,
+                    top = bounds.top - paddingPx,
+                    right = bounds.right + paddingPx,
+                    bottom = bounds.bottom + paddingPx,
+                )
+                val outer = Path().apply {
+                    addRect(Rect(offset = Offset.Zero, size = this@Canvas.size))
+                }
+                val hole = Path().apply {
+                    addRoundRect(
+                        RoundRect(
+                            rect = cutout,
+                            cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                        ),
+                    )
+                }
+                val scrimPath = Path().apply {
+                    op(outer, hole, PathOperation.Difference)
+                }
+                drawPath(path = scrimPath, color = scrimColor)
+                drawRoundRect(
+                    color = highlightStrokeColor,
+                    topLeft = Offset(cutout.left, cutout.top),
+                    size = Size(cutout.width, cutout.height),
+                    cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                    style = Stroke(width = 3f),
                 )
             }
-            val scrimPath = Path().apply {
-                op(outer, hole, PathOperation.Difference)
-            }
-            drawPath(path = scrimPath, color = scrimColor)
-            drawRoundRect(
-                color = highlightStrokeColor,
-                topLeft = Offset(cutout.left, cutout.top),
-                size = Size(cutout.width, cutout.height),
-                cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
-                style = Stroke(width = 3f),
-            )
         }
 
         Surface(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
@@ -1,0 +1,342 @@
+package com.serranoie.app.minus.presentation.ui.tutorial
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import logcat.logcat
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+
+/**
+ * Wraps [content] with a first-launch coachmark overlay.
+ *
+ * When [showTutorial] is `true` and [state] has at least one registered target, draws a
+ * dim scrim with a focus cutout around the current target and a tooltip card
+ * (rendered by [tutorialTarget]) positioned next to the target. Tapping anywhere on the
+ * overlay advances to the next target; after the last target, [onTutorialCompleted] is
+ * invoked exactly once.
+ *
+ * Implementation note: the overlay is a sibling of [content] in a [Box] and uses
+ * [onGloballyPositioned] to learn its own size, NOT [androidx.compose.foundation.layout.BoxWithConstraints].
+ * `BoxWithConstraints` uses subcomposition and was causing layout interference with the
+ * content (which is also a subcomposing layout via its own `BoxWithConstraints`).
+ *
+ * @param showTutorial toggles the overlay on/off; pass a Boolean derived from a
+ *   remembered `MutableState` so re-compositions don't re-create the state.
+ * @param onTutorialCompleted invoked once when the user taps through the last target.
+ *   The caller typically flips a "do not show again" flag here.
+ * @param state the [TutorialBoxState] shared with [markForTutorial] call sites.
+ * @param tutorialTarget composable that renders the tooltip body for the currently
+ *   highlighted target. Receives the target's index so it can pick the right text.
+ * @param content the actual app UI to coachmark over.
+ */
+@Composable
+fun TutorialBox(
+    showTutorial: Boolean,
+    onTutorialCompleted: () -> Unit,
+    state: TutorialBoxState,
+    tutorialTarget: @Composable (index: Int) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    var canvasSize by remember { mutableStateOf(Size.Zero) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { coords ->
+                val w = coords.size.width.toFloat()
+                val h = coords.size.height.toFloat()
+                if (w > 0f && h > 0f) canvasSize = Size(w, h)
+            },
+    ) {
+        content()
+
+        val activeBounds = state.currentBounds
+        val shouldShow = showTutorial && !state.isCompleted && activeBounds != null && canvasSize.isSpecified
+        logcat(TUTORIAL_LOG_TAG) {
+            "TutorialBox render: showTutorial=$showTutorial " +
+                "isCompleted=${state.isCompleted} " +
+                "activeBounds=$activeBounds " +
+                "canvasSize=$canvasSize " +
+                "currentIndex=${state.currentIndexState.value} " +
+                "registrationOrder=${state.registrationOrder.toList()} " +
+                "shouldShow=$shouldShow"
+        }
+        if (shouldShow) {
+            TutorialOverlay(
+                bounds = activeBounds,
+                canvasSize = canvasSize,
+                index = state.currentIndexState.value,
+                tutorialTarget = tutorialTarget,
+                onTap = { state.advance() },
+            )
+        }
+    }
+
+    LaunchedEffect(state.isCompleted) {
+        logcat(TUTORIAL_LOG_TAG) { "TutorialBox isCompleted changed → ${state.isCompleted}, firing onTutorialCompleted=${state.isCompleted}" }
+        if (state.isCompleted) onTutorialCompleted()
+    }
+}
+
+@Composable
+private fun TutorialOverlay(
+    bounds: Rect,
+    canvasSize: Size,
+    index: Int,
+    tutorialTarget: @Composable (Int) -> Unit,
+    onTap: () -> Unit,
+) {
+    if (bounds.isEmpty) return
+
+    val scrimColor = Color.Black.copy(alpha = 0.55f)
+    val highlightStrokeColor = MaterialTheme.colorScheme.primary
+    val interactionSource = remember { MutableInteractionSource() }
+    val density = LocalDensity.current
+    val paddingPx = with(density) { 6.dp.toPx() }
+    val cornerRadiusPx = with(density) { 12.dp.toPx() }
+    val tooltipGapPx = with(density) { 16.dp.toPx() }
+    val tooltipMaxWidthPx = with(density) { 260.dp.toPx() }
+    val tooltipMaxWidth = with(density) { tooltipMaxWidthPx.toDp() }
+    val tooltipMinHeightEstimate = 96f
+
+    val cutout = Rect(
+        left = bounds.left - paddingPx,
+        top = bounds.top - paddingPx,
+        right = bounds.right + paddingPx,
+        bottom = bounds.bottom + paddingPx,
+    )
+
+    val (tooltipX, tooltipY) = computeTooltipPosition(
+        targetBounds = bounds,
+        canvasSize = canvasSize,
+        gapPx = tooltipGapPx,
+        tooltipWidthPx = tooltipMaxWidthPx,
+        tooltipHeightPx = tooltipMinHeightEstimate,
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onTap,
+            ),
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val outer = Path().apply {
+                addRect(Rect(offset = Offset.Zero, size = this@Canvas.size))
+            }
+            val hole = Path().apply {
+                addRoundRect(
+                    RoundRect(
+                        rect = cutout,
+                        cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                    ),
+                )
+            }
+            val scrimPath = Path().apply {
+                op(outer, hole, PathOperation.Difference)
+            }
+            drawPath(path = scrimPath, color = scrimColor)
+            drawRoundRect(
+                color = highlightStrokeColor,
+                topLeft = Offset(cutout.left, cutout.top),
+                size = Size(cutout.width, cutout.height),
+                cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                style = Stroke(width = 3f),
+            )
+        }
+
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp,
+            modifier = Modifier
+                .offset { IntOffset(tooltipX, tooltipY) }
+                .widthIn(max = tooltipMaxWidth)
+                .padding(horizontal = 16.dp),
+        ) {
+            Box(modifier = Modifier.padding(16.dp)) {
+                tutorialTarget(index)
+            }
+        }
+    }
+}
+
+/**
+ * Pick the side of the target with the most free space and anchor the tooltip just
+ * outside the cutout. Clamps the result so the tooltip never falls off-screen even on
+ * small phones.
+ */
+private fun computeTooltipPosition(
+    targetBounds: Rect,
+    canvasSize: Size,
+    gapPx: Float,
+    tooltipWidthPx: Float,
+    tooltipHeightPx: Float,
+): Pair<Int, Int> {
+    val spaceAbove = targetBounds.top
+    val spaceBelow = canvasSize.height - targetBounds.bottom
+    val spaceLeft = targetBounds.left
+    val spaceRight = canvasSize.width - targetBounds.right
+
+    val placement = when {
+        spaceBelow >= tooltipHeightPx + gapPx -> TooltipPlacement.Below
+        spaceAbove >= tooltipHeightPx + gapPx -> TooltipPlacement.Above
+        spaceRight >= tooltipWidthPx + gapPx -> TooltipPlacement.Right
+        spaceLeft >= tooltipWidthPx + gapPx -> TooltipPlacement.Left
+        else -> TooltipPlacement.Below
+    }
+
+    val tooltipWidth = tooltipWidthPx.coerceAtMost(canvasSize.width - 32f)
+    val centerX = (targetBounds.left + targetBounds.right) / 2f
+    val centerY = (targetBounds.top + targetBounds.bottom) / 2f
+
+    val (rawX, rawY) = when (placement) {
+        TooltipPlacement.Below -> {
+            val anchoredX = (centerX - tooltipWidth / 2f).coerceIn(16f, canvasSize.width - tooltipWidth - 16f)
+            anchoredX to (targetBounds.bottom + gapPx)
+        }
+        TooltipPlacement.Above -> {
+            val anchoredX = (centerX - tooltipWidth / 2f).coerceIn(16f, canvasSize.width - tooltipWidth - 16f)
+            anchoredX to (targetBounds.top - gapPx - tooltipHeightPx)
+        }
+        TooltipPlacement.Right -> {
+            (targetBounds.right + gapPx) to (centerY - tooltipHeightPx / 2f)
+        }
+        TooltipPlacement.Left -> {
+            (targetBounds.left - gapPx - tooltipWidth) to (centerY - tooltipHeightPx / 2f)
+        }
+    }
+
+    val safeX = rawX.coerceIn(0f, (canvasSize.width - tooltipWidth).coerceAtLeast(0f))
+    val safeY = rawY.coerceIn(0f, (canvasSize.height - tooltipHeightPx).coerceAtLeast(0f))
+    return safeX.toInt() to safeY.toInt()
+}
+
+private val Size.isSpecified: Boolean
+    get() = width > 0f && height > 0f
+
+private enum class TooltipPlacement { Above, Below, Left, Right }
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640)
+@Composable
+private fun TutorialBoxPreview() {
+    MinusTheme {
+        val state = rememberTutorialBoxState()
+        TutorialBox(
+            showTutorial = true,
+            onTutorialCompleted = {},
+            state = state,
+            tutorialTarget = { index ->
+                Text(
+                    text = when (index) {
+                        0 -> "This is the first element you should look at."
+                        1 -> "And this is the second one, further down."
+                        else -> "Tutorial step $index"
+                    },
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp)
+            ) {
+                Surface(
+                    tonalElevation = 2.dp,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.markForTutorial(state, 0)
+                ) {
+                    Text(
+                        text = "Highlight Me 1",
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(64.dp))
+
+                Surface(
+                    tonalElevation = 2.dp,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.markForTutorial(state, 1)
+                ) {
+                    Text(
+                        text = "Highlight Me 2",
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Renders the tooltip body shown inside the [TutorialBox] coachmark overlay for a
+ * single step. Title in `titleMedium` (bold) on top, description in `bodyMedium`
+ * (regular) below with an 8dp gap — kept inside the [Surface] that [TutorialBox] draws
+ * around `tutorialTarget`, so this composable just paints text, no chrome.
+ */
+@Composable
+fun TutorialTooltip(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (description.isNotBlank()) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
@@ -3,10 +3,10 @@ package com.serranoie.app.minus.presentation.ui.tutorial
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -18,6 +18,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,32 +38,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import logcat.logcat
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import kotlinx.coroutines.delay
+import logcat.logcat
+import kotlin.time.Duration.Companion.milliseconds
 
-/**
- * Wraps [content] with a first-launch coachmark overlay.
- *
- * When [showTutorial] is `true` and [state] has at least one registered target, draws a
- * dim scrim with a focus cutout around the current target and a tooltip card
- * (rendered by [tutorialTarget]) positioned next to the target. Tapping anywhere on the
- * overlay advances to the next target; after the last target, [onTutorialCompleted] is
- * invoked exactly once.
- *
- * Implementation note: the overlay is a sibling of [content] in a [Box] and uses
- * [onGloballyPositioned] to learn its own size, NOT [androidx.compose.foundation.layout.BoxWithConstraints].
- * `BoxWithConstraints` uses subcomposition and was causing layout interference with the
- * content (which is also a subcomposing layout via its own `BoxWithConstraints`).
- *
- * @param showTutorial toggles the overlay on/off; pass a Boolean derived from a
- *   remembered `MutableState` so re-compositions don't re-create the state.
- * @param onTutorialCompleted invoked once when the user taps through the last target.
- *   The caller typically flips a "do not show again" flag here.
- * @param state the [TutorialBoxState] shared with [markForTutorial] call sites.
- * @param tutorialTarget composable that renders the tooltip body for the currently
- *   highlighted target. Receives the target's index so it can pick the right text.
- * @param content the actual app UI to coachmark over.
- */
 @Composable
 fun TutorialBox(
     showTutorial: Boolean,
@@ -72,6 +52,15 @@ fun TutorialBox(
     content: @Composable () -> Unit,
 ) {
     var canvasSize by remember { mutableStateOf(Size.Zero) }
+
+    val isCompleted by remember { derivedStateOf { state.isCompleted } }
+    val currentIndex by remember { derivedStateOf { state.currentIndexState.value } }
+    val activeBounds by remember { derivedStateOf { state.currentBounds } }
+    val shouldShow by remember(showTutorial, canvasSize) {
+        derivedStateOf {
+            showTutorial && !isCompleted && activeBounds != null && canvasSize.isSpecified
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -84,31 +73,86 @@ fun TutorialBox(
     ) {
         content()
 
-        val activeBounds = state.currentBounds
-        val shouldShow = showTutorial && !state.isCompleted && activeBounds != null && canvasSize.isSpecified
-        logcat(TUTORIAL_LOG_TAG) {
-            "TutorialBox render: showTutorial=$showTutorial " +
-                "isCompleted=${state.isCompleted} " +
-                "activeBounds=$activeBounds " +
-                "canvasSize=$canvasSize " +
-                "currentIndex=${state.currentIndexState.value} " +
-                "registrationOrder=${state.registrationOrder.toList()} " +
-                "shouldShow=$shouldShow"
-        }
-        if (shouldShow) {
+        if (shouldShow && activeBounds != null) {
             TutorialOverlay(
-                bounds = activeBounds,
+                bounds = activeBounds!!,
                 canvasSize = canvasSize,
-                index = state.currentIndexState.value,
+                index = currentIndex,
                 tutorialTarget = tutorialTarget,
                 onTap = { state.advance() },
             )
         }
     }
 
-    LaunchedEffect(state.isCompleted) {
-        logcat(TUTORIAL_LOG_TAG) { "TutorialBox isCompleted changed → ${state.isCompleted}, firing onTutorialCompleted=${state.isCompleted}" }
-        if (state.isCompleted) onTutorialCompleted()
+    LaunchedEffect(currentIndex, state.targetBounds.size) {
+        if (currentIndex != -1 &&
+            !isCompleted &&
+            state.currentBounds == null
+        ) {
+            logcat(TUTORIAL_LOG_TAG) {
+                "TutorialBox: current target $currentIndex " +
+                    "has no bounds, auto-advancing"
+            }
+            state.advance()
+        }
+    }
+
+    LaunchedEffect(state.pendingRewindCandidates.size) {
+        if (state.pendingRewindCandidates.isNotEmpty()) {
+            val currentIndexBeforeDelay = state.currentIndexState.value
+            val isCompletedBeforeDelay = state.isCompleted
+            delay(50.milliseconds)
+            
+            if (state.currentIndexState.value != currentIndexBeforeDelay ||
+                state.isCompleted != isCompletedBeforeDelay
+            ) {
+                state.pendingRewindCandidates.clear()
+                return@LaunchedEffect
+            }
+            if (state.pendingRewindCandidates.isEmpty()) return@LaunchedEffect
+            val order = state.registrationOrder
+            val lowest = state.pendingRewindCandidates
+                .minByOrNull { order.indexOf(it) }
+            
+            state.pendingRewindCandidates.clear()
+            if (lowest != null) {
+                val targetPos = order.indexOf(lowest)
+                if (state.isCompleted) {
+                    state.isCompleted = false
+                    state.currentIndexState.value = lowest
+                    logcat(TUTORIAL_LOG_TAG) {
+                        "rewind-apply: index=$lowest AFTER completion " +
+                            "(targetPos=$targetPos)"
+                    }
+                } else {
+                    val currentPos = order
+                        .indexOf(state.currentIndexState.value)
+                        .coerceAtLeast(0)
+                    if (currentPos > targetPos) {
+                        val outgoing = state.currentIndexState.value
+
+                        if (outgoing in order && outgoing != 3 && outgoing != 4) {
+                            state.visitedIndices.add(outgoing)
+                        }
+                        state.currentIndexState.value = lowest
+                        logcat(TUTORIAL_LOG_TAG) {
+                            "rewind-apply: index=$lowest " +
+                                "(currentPos=$currentPos, targetPos=$targetPos) " +
+                                "marked outgoing index=$outgoing as visited"
+                        }
+                    } else {
+                        logcat(TUTORIAL_LOG_TAG) {
+                            "rewind-apply: skipped index=$lowest " +
+                                "(currentPos=$currentPos not > targetPos=$targetPos)"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(isCompleted) {
+        if (isCompleted) onTutorialCompleted()
     }
 }
 
@@ -200,11 +244,6 @@ private fun TutorialOverlay(
     }
 }
 
-/**
- * Pick the side of the target with the most free space and anchor the tooltip just
- * outside the cutout. Clamps the result so the tooltip never falls off-screen even on
- * small phones.
- */
 private fun computeTooltipPosition(
     targetBounds: Rect,
     canvasSize: Size,
@@ -267,57 +306,19 @@ private fun TutorialBoxPreview() {
             state = state,
             tutorialTarget = { index ->
                 Text(
-                    text = when (index) {
-                        0 -> "This is the first element you should look at."
-                        1 -> "And this is the second one, further down."
-                        else -> "Tutorial step $index"
-                    },
+                    text = "Tutorial step $index",
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(32.dp)
-            ) {
-                Surface(
-                    tonalElevation = 2.dp,
-                    shape = RoundedCornerShape(8.dp),
-                    modifier = Modifier.markForTutorial(state, 0)
-                ) {
-                    Text(
-                        text = "Highlight Me 1",
-                        modifier = Modifier.padding(16.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(64.dp))
-
-                Surface(
-                    tonalElevation = 2.dp,
-                    shape = RoundedCornerShape(8.dp),
-                    modifier = Modifier.markForTutorial(state, 1)
-                ) {
-                    Text(
-                        text = "Highlight Me 2",
-                        modifier = Modifier.padding(16.dp)
-                    )
-                }
-            }
+            Box(modifier = Modifier.fillMaxSize())
         }
     }
 }
 
-/**
- * Renders the tooltip body shown inside the [TutorialBox] coachmark overlay for a
- * single step. Title in `titleMedium` (bold) on top, description in `bodyMedium`
- * (regular) below with an 8dp gap — kept inside the [Surface] that [TutorialBox] draws
- * around `tutorialTarget`, so this composable just paints text, no chrome.
- */
 @Composable
 fun TutorialTooltip(
-    title: String,
+    title: String?,
     description: String,
     modifier: Modifier = Modifier,
 ) {
@@ -325,11 +326,13 @@ fun TutorialTooltip(
         modifier = modifier,
         verticalArrangement = Arrangement.Top,
     ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        if (title != null) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
         if (description.isNotBlank()) {
             Spacer(Modifier.height(6.dp))
             Text(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
@@ -1,0 +1,244 @@
+package com.serranoie.app.minus.presentation.ui.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import logcat.logcat
+
+internal const val TUTORIAL_LOG_TAG = "IMPL:TUTORIAL"
+
+/**
+ * Holds the runtime state for a first-launch tutorial session.
+ *
+ * Each [markForTutorial] call site records its [index] and on-screen bounds into this
+ * state. [TutorialBox] reads the state to know which target to highlight, and advances
+ * [currentIndex] on click. After the last registered target is consumed, [isCompleted]
+ * flips to `true` and the parent typically calls `onTutorialCompleted`.
+ *
+ * @see rememberTutorialBoxState
+ * @see markForTutorial
+ * @see TutorialBox
+ */
+@Stable
+class TutorialBoxState {
+    /**
+     * Backing map of target index → on-screen bounds, in window coordinates.
+     * Populated by [markForTutorial] via [onGloballyPositioned].
+     */
+    internal val targetBounds: SnapshotStateMap<Int, Rect> = androidx.compose.runtime.mutableStateMapOf()
+
+    /**
+     * Order in which indices were registered. The walk order for the coachmark is the
+     * registration order, not the natural numeric order — this way callers can pass
+     * arbitrary `index` ints (including negative ones or large ones) without worrying
+     * about sorting.
+     */
+    internal val registrationOrder: SnapshotStateList<Int> = mutableStateListOf()
+
+    /** Index of the target currently being highlighted. `-1` before any advance. */
+    internal val currentIndexState = mutableStateOf(-1)
+
+    /** `true` once the user has tapped through every registered target. */
+    var isCompleted: Boolean by mutableStateOf(false)
+        internal set
+
+    /**
+     * Indices the overlay has actually rendered at least once. Used by the rewind
+     * logic in [markForTutorial] to avoid re-showing a gated tutorial every time
+     * the user enters edit mode after the walk has already been completed once.
+     */
+    internal val visitedIndices: androidx.compose.runtime.snapshots.SnapshotStateSet<Int> =
+        androidx.compose.runtime.mutableStateSetOf()
+
+    /**
+     * Indices that have been measured with non-empty bounds at least once. Tracked
+     * separately from [registrationOrder] (which is pre-populated with the full walk
+     * order) so the rewind logic in [markForTutorial] can distinguish "this target
+     * is in the walk plan" from "this target has actually been laid out". Without
+     * this distinction, the pre-populated entries would look like first-time
+     * registrations every frame and the rewind would never fire.
+     */
+    internal val measuredIndices: androidx.compose.runtime.snapshots.SnapshotStateSet<Int> =
+        androidx.compose.runtime.mutableStateSetOf()
+
+    /** Returns the bounds of the currently highlighted target, or `null` if none. */
+    val currentBounds: Rect?
+        get() = targetBounds[currentIndexState.value]
+
+    /** Total number of distinct targets that have registered themselves. */
+    val totalTargets: Int
+        get() = registrationOrder.size
+
+    /**
+     * Returns the bounds for the target at [index], or `null` if it hasn't been laid
+     * out yet (composable that called [markForTutorial] hasn't been measured).
+     */
+    fun boundsFor(index: Int): Rect? = targetBounds[index]
+
+    /**
+     * Advance to the next registered target. If this is the last target, flips
+     * [isCompleted] to `true`. No-op when already completed or no targets registered.
+     */
+    fun advance() {
+        if (isCompleted) {
+            logcat(TUTORIAL_LOG_TAG) { "advance: ignored, already completed" }
+            return
+        }
+        val order = registrationOrder
+        if (order.isEmpty()) {
+            logcat(TUTORIAL_LOG_TAG) { "advance: ignored, registrationOrder is empty" }
+            return
+        }
+        // Mark the current target as visited — the user is moving past it now.
+        if (currentIndexState.value in order) {
+            visitedIndices.add(currentIndexState.value)
+        }
+        // currentIndexState stores the index value (e.g. 0, 1, 4), not the position
+        // in `order`. We need the position to find the next walk step.
+        val currentPos = order.indexOf(currentIndexState.value).coerceAtLeast(0)
+        var nextPos = currentPos + 1
+        // Skip indices whose target hasn't measured bounds yet (e.g. category tag
+        // when editor is in IDLE mode, recurrent toggle when no spend is being
+        // edited). Without this, the walk would advance to an unrenderable step
+        // and the user would be stuck because the overlay wouldn't show.
+        while (nextPos < order.size && order[nextPos] !in targetBounds) {
+            logcat(TUTORIAL_LOG_TAG) {
+                "advance: skipping position=$nextPos index=${order[nextPos]} (no bounds yet)"
+            }
+            nextPos++
+        }
+        logcat(TUTORIAL_LOG_TAG) {
+            "advance: from position=$currentPos (index=${order.getOrNull(currentPos)}) " +
+                "→ next position=$nextPos (index=${order.getOrNull(nextPos)}) " +
+                "visitedIndices=$visitedIndices " +
+                "registrationOrder=$order"
+        }
+        if (nextPos >= order.size) {
+            isCompleted = true
+            logcat(TUTORIAL_LOG_TAG) { "advance: walk finished, isCompleted=true" }
+        } else {
+            currentIndexState.value = order[nextPos]
+        }
+    }
+
+    /**
+     * Move the highlight back to the first registered target. Used when the user
+     * re-enters the screen and we want the walk to start over.
+     */
+    internal fun reset() {
+        isCompleted = false
+        currentIndexState.value = if (registrationOrder.isEmpty()) -1 else registrationOrder.first()
+    }
+}
+
+/**
+ * The intended walk order across the whole tutorial, regardless of when each
+ * target actually registers. Index 0 = Numpad, 1 = category/comment, 2 = BudgetPill,
+ * 3 = Settings, 4 = Recurrent toggle. Indices 1 and 4 are gated on the editor being
+ * in EDITING mode, so they only get bounds once the user taps a number; the walk
+ * should still visit them in this order when they become available.
+ */
+private val DefaultWalkOrder: List<Int> = listOf(0, 1, 4, 2, 3)
+
+/**
+ * Remembers a [TutorialBoxState] for the lifetime of the current composition. Pass the
+ * returned state into [TutorialBox] and any [markForTutorial] calls in the content.
+ *
+ * The returned state has its [TutorialBoxState.registrationOrder] pre-populated with
+ * [DefaultWalkOrder] so the walk sequence is fixed even before every target has
+ * measured. Targets that haven't been laid out yet (e.g. category tag when the
+ * editor is in IDLE mode) sit in the walk but have no bounds; [TutorialBoxState.advance]
+ * skips them so the user is never stuck on an unrenderable step.
+ */
+@Composable
+fun rememberTutorialBoxState(): TutorialBoxState = remember {
+    TutorialBoxState().also { it.registrationOrder.addAll(DefaultWalkOrder) }
+}
+
+/**
+ * Modifier that registers the element's on-screen bounds as a coachmark target for the
+ * given [index]. Multiple elements can register themselves with the same [state] using
+ * distinct [index] values; [TutorialBox] will walk through them in registration order.
+ *
+ * Safe to use inside deeply nested composables — only the actively composed and laid out
+ * elements will report bounds, so layouts that aren't currently visible (e.g. the
+ * non-active layout branch in `MainScreenContent`) won't contribute stale data.
+ */
+fun Modifier.markForTutorial(
+    state: TutorialBoxState,
+    index: Int,
+): Modifier = this.onGloballyPositioned { coordinates ->
+    val bounds = coordinates.boundsInWindow()
+    if (bounds.isFinite && !bounds.isEmpty) {
+        val wasRegistered = index in state.registrationOrder
+        if (!wasRegistered) {
+            state.registrationOrder.add(index)
+        }
+        // Track FIRST measurement with valid bounds separately from
+        // registrationOrder membership. `wasRegistered` will be `true` on every
+        // call after the first because the walk order is pre-populated, so we need
+        // a separate signal to know "this is the first time we've actually seen
+        // this target" — otherwise the rewind never fires.
+        val isFirstMeasurement = index !in state.measuredIndices
+        state.measuredIndices.add(index)
+        state.targetBounds[index] = bounds
+        // First target to register becomes the current highlight on the very first frame
+        // the overlay shows.
+        if (state.currentIndexState.value == -1) {
+            state.currentIndexState.value = state.registrationOrder.first()
+        }
+        // Rewind logic: if a target is being measured for the first time AND the
+        // walk has already moved past its position (or completed), rewind the walk
+        // to it. This handles the "gated" targets (1 = category tag, 4 = recurrent
+        // toggle) which only become measurable once the editor enters EDITING state
+        // — without this, the user could tap fast through the walk before entering
+        // edit mode, the walk would complete skipping the gated targets, and the
+        // gated targets would never be shown. With the rewind, the walk rewinds
+        // whenever a gated target becomes available for the first time AND the
+        // user hasn't seen it yet (i.e. it's not in visitedIndices), so the
+        // gated tutorials only fire on the first edit-mode entry, not on every
+        // subsequent one.
+        if (isFirstMeasurement && index !in state.visitedIndices) {
+            val targetPos = state.registrationOrder.indexOf(index)
+            val currentPos = state.registrationOrder
+                .indexOf(state.currentIndexState.value)
+                .coerceAtLeast(0)
+            if (state.isCompleted) {
+                state.isCompleted = false
+                state.currentIndexState.value = index
+                logcat(TUTORIAL_LOG_TAG) {
+                    "rewind: index=$index first-measured AFTER walk completed, " +
+                        "rewinding walk to it (position=$targetPos)"
+                }
+            } else if (currentPos > targetPos) {
+                state.currentIndexState.value = index
+                logcat(TUTORIAL_LOG_TAG) {
+                    "rewind: index=$index first-measured late, " +
+                        "walk was at position=$currentPos, rewinding to position=$targetPos"
+                }
+            }
+        }
+        logcat(TUTORIAL_LOG_TAG) {
+            "markForTutorial: index=$index bounds=$bounds " +
+                "firstMeasure=$isFirstMeasurement " +
+                "firstRegister=$wasRegistered " +
+                "registrationOrder=${state.registrationOrder.toList()} " +
+                "currentIndex=${state.currentIndexState.value} " +
+                "isCompleted=${state.isCompleted}"
+        }
+    } else {
+        logcat(TUTORIAL_LOG_TAG) {
+            "markForTutorial: index=$index SKIPPED (empty/inf bounds=$bounds)"
+        }
+    }
+}

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
@@ -83,9 +83,13 @@ class TutorialBoxState {
         }
     }
 
-    internal fun reset() {
+    fun resetForReplay() {
         isCompleted = false
-        currentIndexState.value = if (registrationOrder.isEmpty()) -1 else registrationOrder.first()
+        currentIndexState.value =
+            if (registrationOrder.isEmpty()) -1 else registrationOrder.first()
+        visitedIndices.clear()
+        measuredIndices.clear()
+        pendingRewindCandidates.clear()
     }
 }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
@@ -93,11 +93,18 @@ class TutorialBoxState {
     }
 }
 
-private val DefaultWalkOrder: List<Int> = listOf(0, 1, 2, 3, 4)
+private val DefaultWalkOrder: List<Int> = listOf(0, 1, 2, 3, 4, 5, 6)
+
+internal val VirtualIndices: Set<Int> = setOf(6)
+
+internal val GatedIndices: Set<Int> = setOf(3, 4)
 
 @Composable
 fun rememberTutorialBoxState(): TutorialBoxState = remember {
-    TutorialBoxState().also { it.registrationOrder.addAll(DefaultWalkOrder) }
+    TutorialBoxState().also {
+        it.registrationOrder.addAll(DefaultWalkOrder)
+        VirtualIndices.forEach { idx -> it.targetBounds[idx] = Rect.Zero }
+    }
 }
 
 fun Modifier.markForTutorial(
@@ -136,6 +143,8 @@ fun Modifier.markForTutorial(
                 if (state.isCompleted) {
                     state.pendingRewindCandidates.add(index)
                 } else if (currentPos > targetPos) {
+                    state.pendingRewindCandidates.add(index)
+                } else if (index in GatedIndices && currentPos < targetPos && state.registrationOrder[currentPos] !in GatedIndices) {
                     state.pendingRewindCandidates.add(index)
                 }
             }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
@@ -1,15 +1,20 @@
 package com.serranoie.app.minus.presentation.ui.tutorial
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.snapshots.SnapshotStateSet
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -17,78 +22,26 @@ import logcat.logcat
 
 internal const val TUTORIAL_LOG_TAG = "IMPL:TUTORIAL"
 
-/**
- * Holds the runtime state for a first-launch tutorial session.
- *
- * Each [markForTutorial] call site records its [index] and on-screen bounds into this
- * state. [TutorialBox] reads the state to know which target to highlight, and advances
- * [currentIndex] on click. After the last registered target is consumed, [isCompleted]
- * flips to `true` and the parent typically calls `onTutorialCompleted`.
- *
- * @see rememberTutorialBoxState
- * @see markForTutorial
- * @see TutorialBox
- */
 @Stable
 class TutorialBoxState {
-    /**
-     * Backing map of target index → on-screen bounds, in window coordinates.
-     * Populated by [markForTutorial] via [onGloballyPositioned].
-     */
-    internal val targetBounds: SnapshotStateMap<Int, Rect> = androidx.compose.runtime.mutableStateMapOf()
+    internal val targetBounds: SnapshotStateMap<Int, Rect> = mutableStateMapOf()
 
-    /**
-     * Order in which indices were registered. The walk order for the coachmark is the
-     * registration order, not the natural numeric order — this way callers can pass
-     * arbitrary `index` ints (including negative ones or large ones) without worrying
-     * about sorting.
-     */
     internal val registrationOrder: SnapshotStateList<Int> = mutableStateListOf()
 
-    /** Index of the target currently being highlighted. `-1` before any advance. */
     internal val currentIndexState = mutableStateOf(-1)
 
-    /** `true` once the user has tapped through every registered target. */
     var isCompleted: Boolean by mutableStateOf(false)
         internal set
 
-    /**
-     * Indices the overlay has actually rendered at least once. Used by the rewind
-     * logic in [markForTutorial] to avoid re-showing a gated tutorial every time
-     * the user enters edit mode after the walk has already been completed once.
-     */
-    internal val visitedIndices: androidx.compose.runtime.snapshots.SnapshotStateSet<Int> =
-        androidx.compose.runtime.mutableStateSetOf()
+    internal val visitedIndices: SnapshotStateSet<Int> = mutableStateSetOf()
 
-    /**
-     * Indices that have been measured with non-empty bounds at least once. Tracked
-     * separately from [registrationOrder] (which is pre-populated with the full walk
-     * order) so the rewind logic in [markForTutorial] can distinguish "this target
-     * is in the walk plan" from "this target has actually been laid out". Without
-     * this distinction, the pre-populated entries would look like first-time
-     * registrations every frame and the rewind would never fire.
-     */
-    internal val measuredIndices: androidx.compose.runtime.snapshots.SnapshotStateSet<Int> =
-        androidx.compose.runtime.mutableStateSetOf()
+    internal val measuredIndices: SnapshotStateSet<Int> = mutableStateSetOf()
 
-    /** Returns the bounds of the currently highlighted target, or `null` if none. */
+    internal val pendingRewindCandidates: SnapshotStateSet<Int> = mutableStateSetOf()
+
     val currentBounds: Rect?
         get() = targetBounds[currentIndexState.value]
 
-    /** Total number of distinct targets that have registered themselves. */
-    val totalTargets: Int
-        get() = registrationOrder.size
-
-    /**
-     * Returns the bounds for the target at [index], or `null` if it hasn't been laid
-     * out yet (composable that called [markForTutorial] hasn't been measured).
-     */
-    fun boundsFor(index: Int): Rect? = targetBounds[index]
-
-    /**
-     * Advance to the next registered target. If this is the last target, flips
-     * [isCompleted] to `true`. No-op when already completed or no targets registered.
-     */
     fun advance() {
         if (isCompleted) {
             logcat(TUTORIAL_LOG_TAG) { "advance: ignored, already completed" }
@@ -99,29 +52,28 @@ class TutorialBoxState {
             logcat(TUTORIAL_LOG_TAG) { "advance: ignored, registrationOrder is empty" }
             return
         }
-        // Mark the current target as visited — the user is moving past it now.
+
         if (currentIndexState.value in order) {
             visitedIndices.add(currentIndexState.value)
         }
-        // currentIndexState stores the index value (e.g. 0, 1, 4), not the position
-        // in `order`. We need the position to find the next walk step.
+
         val currentPos = order.indexOf(currentIndexState.value).coerceAtLeast(0)
         var nextPos = currentPos + 1
-        // Skip indices whose target hasn't measured bounds yet (e.g. category tag
-        // when editor is in IDLE mode, recurrent toggle when no spend is being
-        // edited). Without this, the walk would advance to an unrenderable step
-        // and the user would be stuck because the overlay wouldn't show.
-        while (nextPos < order.size && order[nextPos] !in targetBounds) {
+
+        while (nextPos < order.size && (order[nextPos] !in targetBounds || order[nextPos] in visitedIndices)) {
+            val skipIndex = order[nextPos]
+            val reason = if (skipIndex !in targetBounds) "no bounds yet" else "already shown"
             logcat(TUTORIAL_LOG_TAG) {
-                "advance: skipping position=$nextPos index=${order[nextPos]} (no bounds yet)"
+                "advance: skipping position=$nextPos index=$skipIndex ($reason)"
             }
             nextPos++
         }
         logcat(TUTORIAL_LOG_TAG) {
-            "advance: from position=$currentPos (index=${order.getOrNull(currentPos)}) " +
-                "→ next position=$nextPos (index=${order.getOrNull(nextPos)}) " +
-                "visitedIndices=$visitedIndices " +
-                "registrationOrder=$order"
+            "advance: from position=$currentPos (index=${order.getOrNull(currentPos)}) " + "→ next position=$nextPos (index=${
+                order.getOrNull(
+                    nextPos
+                )
+            }) " + "visitedIndices=$visitedIndices " + "registrationOrder=$order"
         }
         if (nextPos >= order.size) {
             isCompleted = true
@@ -131,114 +83,60 @@ class TutorialBoxState {
         }
     }
 
-    /**
-     * Move the highlight back to the first registered target. Used when the user
-     * re-enters the screen and we want the walk to start over.
-     */
     internal fun reset() {
         isCompleted = false
         currentIndexState.value = if (registrationOrder.isEmpty()) -1 else registrationOrder.first()
     }
 }
 
-/**
- * The intended walk order across the whole tutorial, regardless of when each
- * target actually registers. Index 0 = Numpad, 1 = category/comment, 2 = BudgetPill,
- * 3 = Settings, 4 = Recurrent toggle. Indices 1 and 4 are gated on the editor being
- * in EDITING mode, so they only get bounds once the user taps a number; the walk
- * should still visit them in this order when they become available.
- */
-private val DefaultWalkOrder: List<Int> = listOf(0, 1, 4, 2, 3)
+private val DefaultWalkOrder: List<Int> = listOf(0, 1, 2, 3, 4)
 
-/**
- * Remembers a [TutorialBoxState] for the lifetime of the current composition. Pass the
- * returned state into [TutorialBox] and any [markForTutorial] calls in the content.
- *
- * The returned state has its [TutorialBoxState.registrationOrder] pre-populated with
- * [DefaultWalkOrder] so the walk sequence is fixed even before every target has
- * measured. Targets that haven't been laid out yet (e.g. category tag when the
- * editor is in IDLE mode) sit in the walk but have no bounds; [TutorialBoxState.advance]
- * skips them so the user is never stuck on an unrenderable step.
- */
 @Composable
 fun rememberTutorialBoxState(): TutorialBoxState = remember {
     TutorialBoxState().also { it.registrationOrder.addAll(DefaultWalkOrder) }
 }
 
-/**
- * Modifier that registers the element's on-screen bounds as a coachmark target for the
- * given [index]. Multiple elements can register themselves with the same [state] using
- * distinct [index] values; [TutorialBox] will walk through them in registration order.
- *
- * Safe to use inside deeply nested composables — only the actively composed and laid out
- * elements will report bounds, so layouts that aren't currently visible (e.g. the
- * non-active layout branch in `MainScreenContent`) won't contribute stale data.
- */
 fun Modifier.markForTutorial(
     state: TutorialBoxState,
     index: Int,
-): Modifier = this.onGloballyPositioned { coordinates ->
-    val bounds = coordinates.boundsInWindow()
-    if (bounds.isFinite && !bounds.isEmpty) {
-        val wasRegistered = index in state.registrationOrder
-        if (!wasRegistered) {
-            state.registrationOrder.add(index)
-        }
-        // Track FIRST measurement with valid bounds separately from
-        // registrationOrder membership. `wasRegistered` will be `true` on every
-        // call after the first because the walk order is pre-populated, so we need
-        // a separate signal to know "this is the first time we've actually seen
-        // this target" — otherwise the rewind never fires.
-        val isFirstMeasurement = index !in state.measuredIndices
-        state.measuredIndices.add(index)
-        state.targetBounds[index] = bounds
-        // First target to register becomes the current highlight on the very first frame
-        // the overlay shows.
-        if (state.currentIndexState.value == -1) {
-            state.currentIndexState.value = state.registrationOrder.first()
-        }
-        // Rewind logic: if a target is being measured for the first time AND the
-        // walk has already moved past its position (or completed), rewind the walk
-        // to it. This handles the "gated" targets (1 = category tag, 4 = recurrent
-        // toggle) which only become measurable once the editor enters EDITING state
-        // — without this, the user could tap fast through the walk before entering
-        // edit mode, the walk would complete skipping the gated targets, and the
-        // gated targets would never be shown. With the rewind, the walk rewinds
-        // whenever a gated target becomes available for the first time AND the
-        // user hasn't seen it yet (i.e. it's not in visitedIndices), so the
-        // gated tutorials only fire on the first edit-mode entry, not on every
-        // subsequent one.
-        if (isFirstMeasurement && index !in state.visitedIndices) {
-            val targetPos = state.registrationOrder.indexOf(index)
-            val currentPos = state.registrationOrder
-                .indexOf(state.currentIndexState.value)
-                .coerceAtLeast(0)
-            if (state.isCompleted) {
-                state.isCompleted = false
-                state.currentIndexState.value = index
-                logcat(TUTORIAL_LOG_TAG) {
-                    "rewind: index=$index first-measured AFTER walk completed, " +
-                        "rewinding walk to it (position=$targetPos)"
-                }
-            } else if (currentPos > targetPos) {
-                state.currentIndexState.value = index
-                logcat(TUTORIAL_LOG_TAG) {
-                    "rewind: index=$index first-measured late, " +
-                        "walk was at position=$currentPos, rewinding to position=$targetPos"
-                }
+): Modifier = this.composed {
+    DisposableEffect(index) {
+        onDispose {
+            state.targetBounds.remove(index)
+            state.measuredIndices.remove(index)
+            logcat(TUTORIAL_LOG_TAG) {
+                "markForTutorial: index=$index DISPOSED, cleared bounds " + "currentIndex=${state.currentIndexState.value} " + "isCompleted=${state.isCompleted}"
             }
         }
-        logcat(TUTORIAL_LOG_TAG) {
-            "markForTutorial: index=$index bounds=$bounds " +
-                "firstMeasure=$isFirstMeasurement " +
-                "firstRegister=$wasRegistered " +
-                "registrationOrder=${state.registrationOrder.toList()} " +
-                "currentIndex=${state.currentIndexState.value} " +
-                "isCompleted=${state.isCompleted}"
-        }
-    } else {
-        logcat(TUTORIAL_LOG_TAG) {
-            "markForTutorial: index=$index SKIPPED (empty/inf bounds=$bounds)"
+    }
+    onGloballyPositioned { coordinates ->
+        val bounds = coordinates.boundsInWindow()
+        if (bounds.isFinite && !bounds.isEmpty) {
+            val wasRegistered = index in state.registrationOrder
+            if (!wasRegistered) {
+                state.registrationOrder.add(index)
+            }
+
+            val isFirstMeasurement = index !in state.measuredIndices
+            state.measuredIndices.add(index)
+            state.targetBounds[index] = bounds
+
+            if (state.currentIndexState.value == -1) {
+                state.currentIndexState.value = state.registrationOrder.first()
+            }
+
+            if (isFirstMeasurement && index !in state.visitedIndices) {
+                val targetPos = state.registrationOrder.indexOf(index)
+                val currentPos =
+                    state.registrationOrder.indexOf(state.currentIndexState.value).coerceAtLeast(0)
+                if (state.isCompleted) {
+                    state.pendingRewindCandidates.add(index)
+                } else if (currentPos > targetPos) {
+                    state.pendingRewindCandidates.add(index)
+                }
+            }
+        } else {
+            state.targetBounds.remove(index)
         }
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2,6 +2,17 @@
 <resources>
     <string name="app_name">Menos</string>
 
+    <string name="tutorial_numpad_title">Teclado numérico</string>
+    <string name="tutorial_numpad_description">Ingresa el monto que gastaste. Toca los dígitos, usa la flecha para corregir y toca el check verde para guardar. Desliza hacia arriba en el teclado para ingresar un cálculo como 5+3.</string>
+    <string name="tutorial_comment_title">Añadir categoría</string>
+    <string name="tutorial_comment_description">Añade una categoría o nota corta para recordar en qué gastaste. Tus categorías más recientes aparecen como chips para etiquetar con un solo toque.</string>
+    <string name="tutorial_budget_pill_title">Período de presupuesto</string>
+    <string name="tutorial_budget_pill_description">Consulta cuánto presupuesto te queda para el período actual. Toca para cambiar entre las vistas diaria, semanal y mensual, o para abrir la hoja de configuración del período.</string>
+    <string name="tutorial_settings_title">Ajustes</string>
+    <string name="tutorial_settings_description">Abre Ajustes para activar funciones como la cuadrícula de categorías y el atajo de crédito, activar el modo privado, cambiar la moneda, configurar widgets o restablecer este tutorial.</string>
+    <string name="tutorial_recurrent_title">Pago recurrente</string>
+    <string name="tutorial_recurrent_description">Toca aquí para marcar este gasto como un pago recurrente (semanal, quincenal o mensual). La aplicación te recordará registrarlo según el calendario.</string>
+
     <string name="today">Hoy</string>
     <string name="yesterday">Ayer</string>
     <string name="tomorrow">Mañana</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="tutorial_settings_description">Open Settings to enable features, set up home-screen widgets, or reset this tutorial.</string>
     <string name="tutorial_recurrent_title">Recurrent payments</string>
     <string name="tutorial_recurrent_description">Tap here to mark this spend as a recurring payment (weekly, biweekly, or monthly). The app will remind you to log it on schedule.</string>
+    <string name="tutorial_analytics_title">View your analytics</string>
+    <string name="tutorial_analytics_description">Open Analytics to see how your spending breaks down over time, by category, and against your budget goals.</string>
+    <string name="tutorial_privacy_title">Privacy mode</string>
+    <string name="tutorial_privacy_description">Cover the top of the phone (where the front camera sits) with your hand for about a second to blur every amount on screen. Cover it again to turn it off.</string>
 
     <string name="empty" translatable="false">—</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="tutorial_budget_pill_description">Tap to switch between daily, weekly, and monthly budget views, or to edit the period setup.</string>
     <string name="tutorial_settings_title">Settings</string>
     <string name="tutorial_settings_description">Open Settings to enable features, set up home-screen widgets, or reset this tutorial.</string>
-    <string name="tutorial_recurrent_title">Recurrent payment</string>
+    <string name="tutorial_recurrent_title">Recurrent payments</string>
     <string name="tutorial_recurrent_description">Tap here to mark this spend as a recurring payment (weekly, biweekly, or monthly). The app will remind you to log it on schedule.</string>
 
     <string name="empty" translatable="false">—</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,17 @@
 <resources>
     <string name="app_name">Minus</string>
 
+    <string name="tutorial_numpad_title">Numpad</string>
+    <string name="tutorial_numpad_description">Enter the amount you spent and tap the green checkmark to save. Swipe up on the numpad to calculate.</string>
+    <string name="tutorial_comment_title">Add a category</string>
+    <string name="tutorial_comment_description">Add a category or short note to remember what the spend was for.</string>
+    <string name="tutorial_budget_pill_title">Budget progress</string>
+    <string name="tutorial_budget_pill_description">Tap to switch between daily, weekly, and monthly budget views, or to edit the period setup.</string>
+    <string name="tutorial_settings_title">Settings</string>
+    <string name="tutorial_settings_description">Open Settings to enable features, set up home-screen widgets, or reset this tutorial.</string>
+    <string name="tutorial_recurrent_title">Recurrent payment</string>
+    <string name="tutorial_recurrent_description">Tap here to mark this spend as a recurring payment (weekly, biweekly, or monthly). The app will remind you to log it on schedule.</string>
+
     <string name="empty" translatable="false">—</string>
 
     <string name="today">Today</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 detekt = "1.23.7"
-kotlin = "2.3.10"
+kotlin = "2.2.20"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,11 +12,11 @@ pluginManagement {
 	}
 }
 dependencyResolutionManagement {
-	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-	repositories {
-		google()
-		mavenCentral()
-	}
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
 }
 
 rootProject.name = "Minus"


### PR DESCRIPTION
## Description
Add missing tutorial section for new comers into the app.

## Change strategy
Implemented new components alongside first time users into the tutorial coach mark highlight of basic components like the numpad, gestures, recurring payment toggle and settings.

## Implemented
- TutorialBox component and it's modifier extension to quickly add a tutorial emphasis if needed
- Persistence and data store value to trigger tutorial

## Working demo
https://github.com/user-attachments/assets/35dd60d3-7c5b-491c-9107-431c8048a71e

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This PR closes #60 
