### PR TITLE
feat: toggle for privacy mode on settings

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
@@ -133,6 +133,7 @@ fun Settings(
     onThemeChange: (String) -> Unit,
     onTypographyChange: (String) -> Unit,
     onMaterialYouToggle: () -> Unit,
+    onCensorModeToggle: () -> Unit = {},
     onCreditQuickToggleFeatureToggle: () -> Unit,
     isCategoryPickerDirectPopupEnabled: Boolean = false,
     isCategoryGridModeEnabled: Boolean = false,
@@ -327,7 +328,7 @@ fun Settings(
 
                     CustomPaddedListItem(
                         onClick = onMaterialYouToggle,
-                        position = PaddedListItemPosition.Last,
+                        position = PaddedListItemPosition.Middle,
                         modifier = Modifier.testTag("SettingsMaterialYouItem")
                     ) {
                         Icon(
@@ -353,6 +354,37 @@ fun Settings(
                             checked = isMaterialYouEnabled, onCheckedChange = {
                                 onMaterialYouToggle()
                             }, modifier = Modifier.testTag("SettingsMaterialYouSwitch")
+                        )
+                    }
+
+                    CustomPaddedListItem(
+                        onClick = onCensorModeToggle,
+                        position = PaddedListItemPosition.Last,
+                        modifier = Modifier.testTag("SettingsCensorModeItem")
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.RemoveRedEye,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_censor_mode_title),
+                                style = MaterialTheme.typography.bodyMediumEmphasized,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_censor_mode_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(end = 4.dp)
+                            )
+                        }
+                        Switch(
+                            checked = isCensored, onCheckedChange = {
+                                onCensorModeToggle()
+                            }, modifier = Modifier.testTag("SettingsCensorModeSwitch")
                         )
                     }
                 }
@@ -1319,6 +1351,7 @@ private fun PreviewSettings() {
             onThemeChange = {},
             onTypographyChange = {},
             onMaterialYouToggle = {},
+            onCensorModeToggle = {},
             onCreditQuickToggleFeatureToggle = {},
             onRecurrentPaymentsViewModeChange = {},
             onNotificationTimeChange = { _, _ -> },

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.serranoie.app.minus.presentation.ui.settings.csv.CsvTransferEntryPoint
-import com.serranoie.app.minus.presentation.util.LocalCensorMode
 import dagger.hilt.android.EntryPointAccessors
 
 @Composable
@@ -26,7 +25,6 @@ fun SettingsScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    val isCensored = LocalCensorMode.current
 
     val importLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
@@ -71,7 +69,7 @@ fun SettingsScreen(
     }
 
     Settings(
-        isCensored = isCensored,
+        isCensored = uiState.isCensored,
         currentTheme = uiState.currentTheme,
         currentTypography = uiState.currentTypography,
         isMaterialYouEnabled = uiState.isMaterialYouEnabled,
@@ -90,6 +88,7 @@ fun SettingsScreen(
         onThemeChange = viewModel::onThemeChange,
         onTypographyChange = viewModel::onTypographyChange,
         onMaterialYouToggle = viewModel::onMaterialYouToggle,
+        onCensorModeToggle = viewModel::onCensorModeToggle,
         onCreditQuickToggleFeatureToggle = viewModel::onCreditQuickToggleFeatureToggle,
         onRecurrentPaymentsViewModeChange = viewModel::onRecurrentPaymentsViewModeChange,
         onNotificationTimeChange = viewModel::onNotificationTimeChange,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
@@ -37,6 +37,7 @@ import com.serranoie.app.minus.presentation.ui.theme.TypographyMode
 import com.serranoie.app.minus.presentation.ui.tutorial.FIRST_LAUNCH_TUTORIAL_STAGE_KEY
 import com.serranoie.app.minus.presentation.ui.tutorial.FirstLaunchTutorialStage
 import com.serranoie.app.minus.presentation.ui.tutorial.PERIOD_MAPPING_MODE_KEY
+import com.serranoie.app.minus.presentation.util.CensorManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,6 +63,7 @@ data class SettingsUiState(
     val recurrentNotificationMinute: Int = 0,
     val exactAlarmEnabled: Boolean = true,
     val notificationPermissionGranted: Boolean = false,
+    val isCensored: Boolean = false,
     val periodMappingMode: PeriodMappingMode = PeriodMappingMode.ACTIVE_BUDGET,
     val savingsPreferences: SavingsPreferences = SavingsPreferences.DEFAULT,
 )
@@ -76,6 +78,7 @@ class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val settingsRepository: SettingsRepository,
     private val updateNotificationTimeUseCase: UpdatePeriodEndNotificationTimeUseCase,
+    private val censorManager: CensorManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -90,6 +93,15 @@ class SettingsViewModel @Inject constructor(
     init {
         loadPreferences()
         refreshNotificationPermission()
+        observeCensorMode()
+    }
+
+    private fun observeCensorMode() {
+        viewModelScope.launch {
+            censorManager.isCensored.collect { isCensored ->
+                _uiState.update { it.copy(isCensored = isCensored) }
+            }
+        }
     }
 
     fun refreshNotificationPermission() {
@@ -215,6 +227,10 @@ class SettingsViewModel @Inject constructor(
                 prefs[DYNAMIC_COLOR_KEY] = newValue
             }
         }
+    }
+
+    fun onCensorModeToggle() {
+        censorManager.setCensored(!_uiState.value.isCensored)
     }
 
     fun onCreditQuickToggleFeatureToggle() {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/util/CensorManager.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/util/CensorManager.kt
@@ -75,7 +75,7 @@ class CensorManager @Inject constructor(
 		censorToggleJob = null
 	}
 
-	private fun toggleCensor() {
+	fun toggleCensor() {
 		val newState = !_isCensored.value
 		_isCensored.value = newState
 
@@ -84,6 +84,15 @@ class CensorManager @Inject constructor(
 		Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
 
 		logcat { "Censor mode toggled: $newState (after 0.8s hold)" }
+	}
+
+	fun setCensored(enabled: Boolean) {
+		if (_isCensored.value == enabled) return
+		_isCensored.value = enabled
+		val messageRes = if (enabled) R.string.censor_mode_toast_enabled
+		else R.string.censor_mode_toast_disabled
+		Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
+		logcat { "Censor mode manually set: $enabled" }
 	}
 
 	override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -226,6 +226,8 @@
     <string name="settings_typography_subtitle">Change the app typography style</string>
     <string name="settings_material_you_title">Material You</string>
     <string name="settings_material_you_subtitle">Use wallpaper colors to apply a dynamic app theme</string>
+    <string name="settings_censor_mode_title">Privacy mode</string>
+    <string name="settings_censor_mode_subtitle">Hide and blur all financial values across the app</string>
     <string name="settings_feature_credit_toggle_title">Use Credit Card as payment</string>
     <string name="settings_feature_credit_toggle_subtitle">Tap to see more details</string>
     <string name="settings_feature_credit_toggle_details">When activated, you can now mark payments made with a credit card. \nBy declaring a billing date, you\'ll know how much to pay your bank before you have to pay interest, through a notification separate from the billing period.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -226,6 +226,8 @@
     <string name="settings_typography_subtitle">Change the app typography style</string>
     <string name="settings_material_you_title">Material You</string>
     <string name="settings_material_you_subtitle">Use wallpaper colors to apply a dynamic app theme</string>
+    <string name="settings_censor_mode_title">Privacy mode</string>
+    <string name="settings_censor_mode_subtitle">Hide and blur all financial values across the app</string>
     <string name="settings_feature_credit_toggle_title">Use Credit Card as payment</string>
     <string name="settings_feature_credit_toggle_subtitle">Tap to see more details</string>
     <string name="settings_feature_credit_toggle_details">When activated, you can now mark payments made with a credit card. \nBy declaring a billing date, you\'ll know how much to pay your bank before you have to pay interest, through a notification separate from the billing period.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -227,6 +227,8 @@
     <string name="settings_typography_subtitle">Cambiar el estilo de tipografía de la aplicación</string>
     <string name="settings_material_you_title">Material You</string>
     <string name="settings_material_you_subtitle">Utilice colores de fondo de pantalla para aplicar un tema de aplicación dinámico</string>
+    <string name="settings_censor_mode_title">Modo de privacidad</string>
+    <string name="settings_censor_mode_subtitle">Oculta y difumina todos los valores financieros en la aplicación</string>
     <string name="settings_feature_credit_toggle_title">Utilizar Tarjeta de Crédito como pago</string>
     <string name="settings_feature_credit_toggle_subtitle">Toca para ver los detalles</string>
     <string name="settings_feature_credit_toggle_details">Cuando está activado, ahora podrás marcar pagos hechos con tarjeta de crédito.\\nDeclarando una fecha de corte sabrás cuanto pagarle a tu banco antes que tengas que pagar intereses mediante una notificación independiente del periodo que estés.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -227,6 +227,8 @@
     <string name="settings_typography_subtitle">Changer le style de typographie de l\'application</string>
     <string name="settings_material_you_title">Material You</string>
     <string name="settings_material_you_subtitle">Utiliser les couleurs du fond d\'écran pour appliquer un thème dynamique</string>
+    <string name="settings_censor_mode_title">Privacy mode</string>
+    <string name="settings_censor_mode_subtitle">Hide and blur all financial values across the app</string>
     <string name="settings_feature_credit_toggle_title">Utiliser la carte de crédit comme paiement</string>
     <string name="settings_feature_credit_toggle_subtitle">Appuyez pour voir plus de détails</string>
     <string name="settings_feature_credit_toggle_details">Une fois activé, vous pouvez marquer les paiements effectués avec une carte de crédit. \nEn déclarant une date de facturation, vous saurez combien payer à votre banque avant de devoir payer des intérêts.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,8 @@
     <string name="settings_typography_subtitle">Change the app typography style</string>
     <string name="settings_material_you_title">Material You</string>
     <string name="settings_material_you_subtitle">Use wallpaper colors to apply a dynamic app theme</string>
+    <string name="settings_censor_mode_title">Privacy mode</string>
+    <string name="settings_censor_mode_subtitle">Hide and blur all financial values across the app</string>
     <string name="settings_feature_credit_toggle_title">Use Credit Card as payment</string>
     <string name="settings_feature_credit_toggle_subtitle">Tap to see more details</string>
     <string name="settings_feature_credit_toggle_details">When activated, you can now mark payments made with a credit card. \nBy declaring a billing date, you\'ll know how much to pay your bank before you have to pay interest, through a notification separate from the billing period.</string>


### PR DESCRIPTION
## Description
Issue on #121:
> Reported via email: users with broken proximity sensor cant toggle ON or OFF the privacy mode

## Change strategy
Add a toggle into the settings screen to toggle the privacy mode directly.

## Working demo
<img width="552" height="684" alt="image" src="https://github.com/user-attachments/assets/88e5c715-2d58-441b-a0c2-185e7ed309f5" />


## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
PR closes #121 