### PR TITLE
fix: use proper locales for notification builder

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationHelper.kt
@@ -48,28 +48,28 @@ class NotificationHelper @Inject constructor(
 
         val periodEndChannel = NotificationChannel(
             CHANNEL_PERIOD_END,
-            "Budget Period End",
+            context.getString(R.string.notification_channel_period_end_name),
             NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Notifications when your budget period ends with remaining balance"
+            description = context.getString(R.string.notification_channel_period_end_description)
             enableVibration(true)
         }
 
         val recurrentChannel = NotificationChannel(
             CHANNEL_RECURRENT,
-            "Recurrent Expenses",
+            context.getString(R.string.notification_channel_recurrent_name),
             NotificationManager.IMPORTANCE_DEFAULT
         ).apply {
-            description = "Notifications when recurrent expenses are due"
+            description = context.getString(R.string.notification_channel_recurrent_description)
             enableVibration(true)
         }
 
         val creditChannel = NotificationChannel(
             CHANNEL_CREDIT,
-            "Credit Card Reminders",
+            context.getString(R.string.notification_channel_credit_name),
             NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Reminders before credit card cutoff date"
+            description = context.getString(R.string.notification_channel_credit_description)
             enableVibration(true)
         }
 
@@ -115,7 +115,7 @@ class NotificationHelper @Inject constructor(
 
         val notification = NotificationCompat.Builder(context, CHANNEL_PERIOD_END)
             .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle("Periodo de ahorro finalizado")
+            .setContentTitle(context.getString(R.string.notification_period_end_title))
             .setContentText(message)
             .setStyle(NotificationCompat.BigTextStyle().bigText(message))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
@@ -132,11 +132,14 @@ class NotificationHelper @Inject constructor(
     private fun buildPeriodEndMessage(remainingBudget: String): String {
         val amount = remainingBudget.toDoubleOrNull() ?: 0.0
         return if (amount > 0) {
-            "El periodo terminó con $$remainingBudget sobrante. Tap para ver detalles."
+            context.getString(R.string.notification_period_end_message_positive, remainingBudget)
         } else if (amount < 0) {
-            "El periodo se acabó. Gastaste $${kotlin.math.abs(amount)} de más. Ver más detalles."
+            context.getString(
+                R.string.notification_period_end_message_negative,
+                kotlin.math.abs(amount).toString()
+            )
         } else {
-            "El periodo se acabó. No gastaste nada. Ver más detalles."
+            context.getString(R.string.notification_period_end_message_neutral)
         }
     }
 
@@ -158,11 +161,18 @@ class NotificationHelper @Inject constructor(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val title = "Gasto recurrente"
+        val title = context.getString(R.string.notification_recurrent_expense_title)
         val message = if (comment.isNotBlank()) {
-            "Tu gasto recurrente de \"$comment\" por \"$$amount\" es hoy."
+            context.getString(
+                R.string.notification_recurrent_expense_message_with_comment,
+                comment,
+                amount
+            )
         } else {
-            "Tu gasto recurrente con un total de \"$$amount\" es hoy."
+            context.getString(
+                R.string.notification_recurrent_expense_message_without_comment,
+                amount
+            )
         }
 
         val notification = NotificationCompat.Builder(context, CHANNEL_RECURRENT)
@@ -204,15 +214,24 @@ class NotificationHelper @Inject constructor(
         )
 
         val daysText = when (daysUntil) {
-            1L -> "mañana"
-            else -> "en $daysUntil días"
+            1L -> context.getString(R.string.notification_tomorrow)
+            else -> context.getString(R.string.notification_in_days, daysUntil)
         }
 
-        val title = "Suscripción próxima"
+        val title = context.getString(R.string.notification_upcoming_subscription_title)
         val message = if (comment.isNotBlank()) {
-            "Tu suscripción \"$comment\" de \"$amount\" se cobrará $daysText. Prepárate para el cargo."
+            context.getString(
+                R.string.notification_upcoming_subscription_message_with_comment,
+                comment,
+                amount,
+                daysText
+            )
         } else {
-            "Tienes una suscripción de \"$amount\" que se cobrará $daysText."
+            context.getString(
+                R.string.notification_upcoming_subscription_message_without_comment,
+                amount,
+                daysText
+            )
         }
 
         val notification = NotificationCompat.Builder(context, CHANNEL_RECURRENT)
@@ -254,12 +273,15 @@ class NotificationHelper @Inject constructor(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val message =
-            "Tu fecha de corte es el $cutoffDateText. Se recomienda saldar $totalAmount para evitar intereses."
+        val message = context.getString(
+            R.string.notification_credit_cutoff_message,
+            cutoffDateText,
+            totalAmount
+        )
 
         val notification = NotificationCompat.Builder(context, CHANNEL_CREDIT)
             .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle("Pago de tarjeta próximo")
+            .setContentTitle(context.getString(R.string.notification_credit_cutoff_title))
             .setContentText(message)
             .setStyle(NotificationCompat.BigTextStyle().bigText(message))
             .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/Numpad.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/Numpad.kt
@@ -315,9 +315,24 @@ fun Numpad(
 							.fillMaxWidth()
 							.weight(1F)
 					) {
+						if (effectiveDragProgress > 0.01f || isCalculation) {
+							NumpadButton(
+								modifier = Modifier
+									.weight(effectiveDragProgress.coerceAtLeast(0.01f))
+									.padding(BUTTON_GAP)
+									.graphicsLayer(alpha = effectiveDragProgress),
+								type = NumpadButtonType.OPERATOR,
+								text = getFloatDivider(),
+								onClick = {
+									onDotInput()
+									debugProgress =
+										(debugProgress + 1).coerceAtMost(TEST_NOTIFICATION_TAP_COUNT)
+									haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+								})
+						}
 						NumpadButton(
 							modifier = Modifier
-								.weight(if (isCalculation) 1f else 3f)
+								.weight(3f - (2f * effectiveDragProgress))
 								.padding(BUTTON_GAP),
 							type = NumpadButtonType.DEFAULT,
 							text = "0",
@@ -326,28 +341,44 @@ fun Numpad(
 								onNumberPressedForTutorial?.invoke()
 								haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
 							})
-						NumpadButton(
+						Box(
 							modifier = Modifier
-								.weight(if (isCalculation) 1f else 1.5f)
-								.padding(BUTTON_GAP),
-							type = NumpadButtonType.DEFAULT,
-							text = getFloatDivider(),
-							onClick = {
-								onDotInput()
-								debugProgress = (debugProgress + 1).coerceAtMost(TEST_NOTIFICATION_TAP_COUNT)
-								haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-							})
-						if (isCalculation) {
-							NumpadButton(
-								modifier = Modifier
-									.weight(1F)
-									.padding(BUTTON_GAP),
-								type = NumpadButtonType.OPERATOR,
-								text = "=",
-								onClick = {
-									onEqualsInput()
-									haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-								})
+								.weight(1.5f - (0.5f * effectiveDragProgress))
+								.fillMaxHeight()
+						) {
+							AnimatedContent(
+								targetState = isCalculation || effectiveDragProgress > 0.5f,
+								label = "LastButtonSwap",
+								transitionSpec = {
+									fadeIn(tween(150)) togetherWith fadeOut(tween(150))
+								}
+							) { showEquals ->
+								if (showEquals) {
+									NumpadButton(
+										modifier = Modifier
+											.fillMaxSize()
+											.padding(BUTTON_GAP),
+										type = NumpadButtonType.OPERATOR,
+										text = "=",
+										onClick = {
+											onEqualsInput()
+											haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+										})
+								} else {
+									NumpadButton(
+										modifier = Modifier
+											.fillMaxSize()
+											.padding(BUTTON_GAP),
+										type = NumpadButtonType.OPERATOR,
+										text = getFloatDivider(),
+										onClick = {
+											onDotInput()
+											debugProgress =
+												(debugProgress + 1).coerceAtMost(TEST_NOTIFICATION_TAP_COUNT)
+											haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+										})
+								}
+							}
 						}
 					}
 						}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -465,4 +465,25 @@
     <string name="ticket_total_amount">TOTAL AMOUNT</string>
     <string name="mark_as_paid">Mark as paid</string>
     <string name="mark_as_paid_success">Marked as paid</string>
+    <string name="widget_add_expense_compact_label">Add expense</string>
+    <string name="notification_channel_period_end_name">Budget Period End</string>
+    <string name="notification_channel_period_end_description">Notifications when your budget period ends with remaining balance</string>
+    <string name="notification_channel_recurrent_name">Recurring Expenses</string>
+    <string name="notification_channel_recurrent_description">Notifications when recurring expenses are due</string>
+    <string name="notification_channel_credit_name">Credit Card Reminders</string>
+    <string name="notification_channel_credit_description">Reminders before credit card cutoff date</string>
+    <string name="notification_period_end_title">Budget period finished</string>
+    <string name="notification_period_end_message_positive">The period ended with $%1$s remaining. Tap to see details.</string>
+    <string name="notification_period_end_message_negative">The period ended. You spent $%1$s extra. See more details.</string>
+    <string name="notification_period_end_message_neutral">The period ended. You didn\'t spend anything. See more details.</string>
+    <string name="notification_recurrent_expense_title">Recurring expense</string>
+    <string name="notification_recurrent_expense_message_with_comment">Your recurring expense of \"%1$s\" for \"%2$s\" is today.</string>
+    <string name="notification_recurrent_expense_message_without_comment">Your recurring expense with a total of \"%1$s\" is today.</string>
+    <string name="notification_tomorrow">tomorrow</string>
+    <string name="notification_in_days">in %1$d days</string>
+    <string name="notification_upcoming_subscription_title">Upcoming subscription</string>
+    <string name="notification_upcoming_subscription_message_with_comment">Your subscription \"%1$s\" of \"%2$s\" will be charged %3$s. Prepare for the charge.</string>
+    <string name="notification_upcoming_subscription_message_without_comment">You have a subscription of \"%1$s\" that will be charged %2$s.</string>
+    <string name="notification_credit_cutoff_title">Upcoming credit card payment</string>
+    <string name="notification_credit_cutoff_message">Your cutoff date is %1$s. It is recommended to pay %2$s to avoid any interest.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -466,4 +466,30 @@
     <string name="ticket_total_amount">MONTO TOTAL</string>
     <string name="mark_as_paid">Marcar como pagado</string>
     <string name="mark_as_paid_success">Marcado como pagado</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_period_end_name">Fin del periodo de ahorro</string>
+    <string name="notification_channel_period_end_description">Notificaciones cuando tu periodo de ahorro termina con balance sobrante</string>
+    <string name="notification_channel_recurrent_name">Gastos recurrentes</string>
+    <string name="notification_channel_recurrent_description">Notificaciones cuando los gastos recurrentes vencen</string>
+    <string name="notification_channel_credit_name">Recordatorios de tarjeta de crédito</string>
+    <string name="notification_channel_credit_description">Recordatorios antes de la fecha de corte de la tarjeta de crédito</string>
+
+    <string name="notification_period_end_title">Periodo de ahorro finalizado</string>
+    <string name="notification_period_end_message_positive">El periodo terminó con $%1$s sobrante. Toca para ver detalles.</string>
+    <string name="notification_period_end_message_negative">El periodo se acabó. Gastaste $%1$s de más. Ver más detalles.</string>
+    <string name="notification_period_end_message_neutral">El periodo se acabó. No gastaste nada. Ver más detalles.</string>
+
+    <string name="notification_recurrent_expense_title">Gasto recurrente</string>
+    <string name="notification_recurrent_expense_message_with_comment">Tu gasto recurrente de \"%1$s\" por \"%2$s\" es hoy.</string>
+    <string name="notification_recurrent_expense_message_without_comment">Tu gasto recurrente con un total de \"%1$s\" es hoy.</string>
+
+    <string name="notification_tomorrow">mañana</string>
+    <string name="notification_in_days">en %1$d días</string>
+    <string name="notification_upcoming_subscription_title">Suscripción próxima</string>
+    <string name="notification_upcoming_subscription_message_with_comment">Tu suscripción \"%1$s\" de \"%2$s\" se cobrará %3$s. Prepárate para el cargo.</string>
+    <string name="notification_upcoming_subscription_message_without_comment">Tienes una suscripción de \"%1$s\" que se cobrará %2$s.</string>
+
+    <string name="notification_credit_cutoff_title">Pago de tarjeta próximo</string>
+    <string name="notification_credit_cutoff_message">Tu fecha de corte es el %1$s. Se recomienda saldar %2$s para evitar intereses.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,10 +533,33 @@
     <string name="recurrence_end">Recurrence end</string>
 
     <!-- Transaction Detail Ticket Card -->
-    <string name="ticket_operation_number" translatable="false">Op. #%1$d</string>
-    <string name="ticket_expense">EXPENSE</string>
-    <string name="ticket_recurrent_expense">RECURRENT EXPENSE</string>
     <string name="ticket_total_amount">TOTAL AMOUNT</string>
     <string name="mark_as_paid">Mark as paid</string>
     <string name="mark_as_paid_success">Marked as paid</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_period_end_name">Budget Period End</string>
+    <string name="notification_channel_period_end_description">Notifications when your budget period ends with remaining balance</string>
+    <string name="notification_channel_recurrent_name">Recurring Expenses</string>
+    <string name="notification_channel_recurrent_description">Notifications when recurring expenses are due</string>
+    <string name="notification_channel_credit_name">Credit Card Reminders</string>
+    <string name="notification_channel_credit_description">Reminders before credit card cutoff date</string>
+
+    <string name="notification_period_end_title">Budget period finished</string>
+    <string name="notification_period_end_message_positive">The period ended with $%1$s remaining. Tap to see details.</string>
+    <string name="notification_period_end_message_negative">The period ended. You spent $%1$s extra. See more details.</string>
+    <string name="notification_period_end_message_neutral">The period ended. You didn\'t spend anything. See more details.</string>
+
+    <string name="notification_recurrent_expense_title">Recurring expense</string>
+    <string name="notification_recurrent_expense_message_with_comment">Your recurring expense of \"%1$s\" for \"%2$s\" is today.</string>
+    <string name="notification_recurrent_expense_message_without_comment">Your recurring expense with a total of \"%1$s\" is today.</string>
+
+    <string name="notification_tomorrow">tomorrow</string>
+    <string name="notification_in_days">in %1$d days</string>
+    <string name="notification_upcoming_subscription_title">Upcoming subscription</string>
+    <string name="notification_upcoming_subscription_message_with_comment">Your subscription \"%1$s\" of \"%2$s\" will be charged %3$s. Prepare for the charge.</string>
+    <string name="notification_upcoming_subscription_message_without_comment">You have a subscription of \"%1$s\" that will be charged %2$s.</string>
+
+    <string name="notification_credit_cutoff_title">Upcoming credit card payment</string>
+    <string name="notification_credit_cutoff_message">Your cutoff date is %1$s. It is recommended to pay %2$s to avoid any interest.</string>
 </resources>


### PR DESCRIPTION
## Description
Fix notification string values to use proper locales

## Change strategy
Implement and create proper locales for the notifications

## Implemented
- New string values for EN and ES languages
- Improved Numpad animation and position.

## Working demo
https://github.com/user-attachments/assets/288d680f-ce22-463f-91ee-be3e25a684e3

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
PR closes #127 
