### PR TITLE
nit: improve budget overview widget "days left" layout

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/widget/BudgetOverviewWidget.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/widget/BudgetOverviewWidget.kt
@@ -160,7 +160,7 @@ class BudgetOverviewWidget : GlanceAppWidget() {
                             modifier = GlanceModifier
                                 .background(GlanceTheme.colors.onSurfaceVariant)
                                 .cornerRadius(16.dp)
-                                .padding(horizontal = 8.dp, vertical = 2.dp)
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
                         ) {
                             Text(
                                 text = daysCountFormat(daysCount), style = TextStyle(

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -151,7 +151,7 @@
     <string name="left">Faltante</string>
     <string name="remaining">Restante</string>
     <string name="total_spent">Total gastado</string>
-    <string name="days_left">días restantes</string>
+    <string name="days_left">días\nrestantes</string>
     <string name="budget_overview">Resumen del presupuesto</string>
     <string name="spent_per_day">Gastado por día</string>
     <string name="budget_period_daily">A diario</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,7 +183,7 @@
     <string name="left">Left</string>
     <string name="remaining">Remaining</string>
     <string name="total_spent">Total Spent</string>
-    <string name="days_left">days left</string>
+    <string name="days_left">days\nleft</string>
     <string name="budget_overview">Budget Overview</string>
 
     <string name="spent_per_day">Spent per day</string>


### PR DESCRIPTION
## Description
Wrong padding on widget overview and day countdown

## Change strategy
Insert a line break `\n` and fix padding inside some widgets.

## Working demo
<img width="570" height="290" alt="image" src="https://github.com/user-attachments/assets/973c3f09-4019-4b3e-a6d7-7b7abccc261d" />

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
closes #133 