### PR TITLE
fix: refine budget analytics logic by considering recurring expenses

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import logcat.logcat
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
@@ -129,13 +128,15 @@ class AnalyticsViewModel @Inject constructor(
             lastPeriodEnd = lastPeriodEnd,
         )
 
-        val (recurringInPeriod, oneTimeSpends) = splitRecurringAndOneTime(
+        val (paidRecurring, upcomingRecurring, oneTimeSpends) = splitRecurringAndOneTime(
             allTransactions = allTransactions,
             filteredTransactions = transactions,
             periodStart = settings.startDate,
             periodEnd = settings.getPeriodEndDate(),
             today = today,
         )
+
+        val actualSpends = (oneTimeSpends + paidRecurring).distinctBy { it.id }
 
         val startDate = if (shouldShowEndedSnapshot && endedPeriodStartDate != null) {
             Date.from(
@@ -183,13 +184,13 @@ class AnalyticsViewModel @Inject constructor(
         val periodFinished = periodFinishedNaturally || earlyFinishActive
 
         val wholeBudget = if (shouldShowEndedSnapshot && remainingFromLastPeriod != null) {
-            val spent = transactions.filter { !it.isDeleted }.sumOf { it.amount }
+            val spent = actualSpends.sumOf { it.amount }
             spent.add(remainingFromLastPeriod)
         } else {
             settings.totalBudget
         }
 
-        val totalSpent = transactions.filter { !it.isDeleted }.sumOf { it.amount }
+        val totalSpent = actualSpends.sumOf { it.amount }
         val remainingBudget = wholeBudget.subtract(totalSpent)
 
         val plannedPeriodDays =
@@ -221,7 +222,7 @@ class AnalyticsViewModel @Inject constructor(
         } else 0f
         val isOverBudget = totalSpent > wholeBudget
         val totalSpentToday =
-            transactions.filter { tx -> !tx.isDeleted && tx.date?.toLocalDate() == today }
+            actualSpends.filter { tx -> tx.date?.toLocalDate() == today }
                 .fold(BigDecimal.ZERO) { acc, tx -> acc.add(tx.amount) }
         val remainingToday = totalSpentToday
 
@@ -261,9 +262,9 @@ class AnalyticsViewModel @Inject constructor(
 
         return AnalyticsState(
             periodFinished = periodFinished,
-            transactions = transactions,
-            spends = transactions,
-            recurringInPeriod = recurringInPeriod,
+            transactions = actualSpends,
+            spends = actualSpends,
+            recurringInPeriod = (paidRecurring + upcomingRecurring).distinctBy { it.id },
             oneTimeSpends = oneTimeSpends,
             wholeBudget = wholeBudget,
             currencyCode = settings.currencyCode,
@@ -288,7 +289,7 @@ class AnalyticsViewModel @Inject constructor(
         periodStart: LocalDate,
         periodEnd: LocalDate,
         today: LocalDate,
-    ): Pair<List<Transaction>, List<Transaction>> {
+    ): Triple<List<Transaction>, List<Transaction>, List<Transaction>> {
         val oneTimeSpends =
             filteredTransactions.filterNot { it.isDeleted }.filterNot { it.isRecurrent }
 
@@ -296,74 +297,27 @@ class AnalyticsViewModel @Inject constructor(
             filteredTransactions.filterNot { it.isDeleted }.filter { it.isRecurrent }
 
         val recurringParents = (paidRecurringInPeriod + allTransactions.filterNot { it.isDeleted }
-            .filter { it.isRecurrent }).distinctBy { it.id }.also { list ->
-            logcat(RECURRING_TAG) {
-                "---- Recurring debug for period $periodStart → $periodEnd (today=$today) ----"
-            }
-            logcat(RECURRING_TAG) {
-                "raw allTransactions=${allTransactions.size}, " + "filteredTransactions=${filteredTransactions.size}, " + "paidRecurringInPeriod=${paidRecurringInPeriod.size}, " + "recurringParents=${list.size}"
-            }
-            list.forEach { parent ->
-                logcat(RECURRING_TAG) {
-                    "  parent: id=${parent.id} '${parent.comment}' amount=${parent.amount} " + "periodId=${parent.periodId} date=${parent.date} freq=${parent.recurrentFrequency} " + "subDay=${parent.subscriptionDay} endDate=${parent.recurrentEndDate} " + "deleted=${parent.isDeleted}"
-                }
-            }
-        }
+            .filter { it.isRecurrent }).distinctBy { it.id }
 
         val paidCharges = recurringParents.flatMap { parent ->
             getRecurringChargesInPeriod(parent, periodStart, periodEnd, today)
-        }.also { charges ->
-            logcat(RECURRING_TAG) {
-                "  paidCharges (from getRecurringChargesInPeriod): ${charges.size}"
-            }
-            charges.forEach { c ->
-                logcat(RECURRING_TAG) {
-                    "    paid: virtualId=${c.id} '${c.comment}' amount=${c.amount} date=${c.date}"
-                }
-            }
         }
 
         val upcomingCharges = recurringParents.mapNotNull { parent ->
             val date = calculateNextChargeDate(parent, today) ?: parent.date?.toLocalDate()
-                ?.takeIf { it.isAfter(today) } ?: run {
-                logcat(RECURRING_TAG) {
-                    "    no upcoming date for parent id=${parent.id} '${parent.comment}'"
-                }
-                return@mapNotNull null
-            }
+                ?.takeIf { it.isAfter(today) } ?: return@mapNotNull null
+
             if (date.isBefore(periodStart) || date.isAfter(periodEnd)) {
-                logcat(RECURRING_TAG) {
-                    "    upcoming for parent id=${parent.id} '${parent.comment}' = $date " + "is OUTSIDE [$periodStart, $periodEnd], skipped"
-                }
                 return@mapNotNull null
             }
             val chargeId = parent.id * 1_000_000L + date.toEpochDay()
-            logcat(RECURRING_TAG) {
-                "    upcoming for parent id=${parent.id} '${parent.comment}' = $date (chargeId=$chargeId)"
-            }
             parent.copy(
                 date = date.atTime(parent.date?.toLocalTime() ?: LocalTime.MIDNIGHT),
                 id = chargeId,
             )
         }
 
-        // De-duplicate by generated id so we never double-sum the same charge.
-        val recurringInPeriod = (paidCharges + upcomingCharges).distinctBy { it.id }.also { list ->
-            logcat(RECURRING_TAG) {
-                "  recurringInPeriod total: ${list.size}  sum=${list.sumOf { it.amount }}"
-            }
-            list.forEach { c ->
-                logcat(RECURRING_TAG) {
-                    "    final: virtualId=${c.id} '${c.comment}' amount=${c.amount} date=${c.date}"
-                }
-            }
-            logcat(RECURRING_TAG) {
-                "  oneTimeSpends: ${oneTimeSpends.size}  sum=${oneTimeSpends.sumOf { it.amount }}"
-            }
-            logcat(RECURRING_TAG) { "---- end recurring debug ----" }
-        }
-
-        return recurringInPeriod to oneTimeSpends
+        return Triple(paidCharges, upcomingCharges, oneTimeSpends)
     }
 
     private fun filterTransactions(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/sheets/BudgetPeriodSheet.kt
@@ -1016,6 +1016,9 @@ fun EditBudgetContent(
         ) {
             Text(buttonLabel, style = MaterialTheme.typography.labelMediumEmphasized)
         }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
     }
 
     AnimatedVisibility(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -448,7 +448,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -446,7 +446,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -448,7 +448,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -448,8 +448,8 @@
     <string name="split_mode_dialog_title">¿Cómo deberíamos dividir tu presupuesto?</string>
     <string name="split_mode_dialog_description" formatted="false">Elija cómo se calcula la cantidad por período.</string>
     <string name="split_mode_static">Estático</string>
-    <string name="split_mode_static_desc">El presupuesto total se reparte por igual en todos los períodos, independientemente de cuánto gaste.</string>
-    <string name="split_mode_dynamic">Dinámica</string>
+    <string name="split_mode_static_desc">El presupuesto total se reparte por igual en los días, independientemente de cuánto gaste.</string>
+    <string name="split_mode_dynamic">Dinámica (Recomendado)</string>
     <string name="split_mode_dynamic_desc">Recalcula diariamente como gastas. El saldo restante se reparte a lo largo de los días que quedan en el período.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Sin fecha</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -446,7 +446,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -446,7 +446,7 @@
     <string name="split_mode_dialog_description" formatted="false">Scegli come calcolare l\'importo per periodo.</string>
     <string name="split_mode_static">Statico</string>
     <string name="split_mode_static_desc">Il bilancio totale è ripartito equamente in tutti i periodi, indipendentemente da quanto spendi.</string>
-    <string name="split_mode_dynamic">Dinamico</string>
+    <string name="split_mode_dynamic">Dinamico (consigliato)</string>
     <string name="split_mode_dynamic_desc">Ricalcola quotidianamente mentre spendi. Il saldo rimanente è ripartito sui giorni rimasti nel periodo.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Senza data</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -443,7 +443,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -443,7 +443,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -446,7 +446,7 @@
     <string name="split_mode_dialog_description" formatted="false">Escolha como o valor por período é calculado.</string>
     <string name="split_mode_static">Estático</string>
     <string name="split_mode_static_desc">O orçamento total está dividido igualmente em todos os períodos, independentemente do quanto você gasta.</string>
-    <string name="split_mode_dynamic">Dinâmico</string>
+    <string name="split_mode_dynamic">Dinâmico (Recomendado)</string>
     <string name="split_mode_dynamic_desc">Recalcular diariamente conforme você gasta. O saldo restante está repartido pelos dias que ainda restam no período.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Sem data</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -452,7 +452,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -443,7 +443,7 @@
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
     <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
     <!-- Transaction Detail -->
     <string name="without_date">Without date</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,8 +518,8 @@
     <string name="split_mode_dialog_title">How should we split your budget?</string>
     <string name="split_mode_dialog_description" formatted="false">Choose how the per-period amount is calculated.</string>
     <string name="split_mode_static">Static</string>
-    <string name="split_mode_static_desc">Total budget is split equally across all periods, regardless of how much you spend.</string>
-    <string name="split_mode_dynamic">Dynamic</string>
+    <string name="split_mode_static_desc">Total budget is split equally across all days, regardless of how much you spend.</string>
+    <string name="split_mode_dynamic">Dynamic (Recommended)</string>
     <string name="split_mode_dynamic_desc">Recalculates daily as you spend. The remaining balance is spread over the days still left in the period.</string>
 
     <!-- Transaction Detail -->


### PR DESCRIPTION
## Description
In some cases, recurring payments weren't considered on analytics.

## Change strategy
Change and refactor the viewmodel logic to filter or not the recurring expenses inside the current period the user is on.

## Implemented
- Refactor `AnalyticsViewModel` to distinguish between paid and upcoming recurring transactions for more accurate spend tracking.
- Update budget calculations to only include actual (paid) recurring charges in the total spent.
- Clean up debug logging within the recurring transaction processing logic.
- Update string resources to mark "Dynamic" split mode as "Recommended" across multiple locales.
- Clarify "Static" split mode description to specify budget is split across days.
- Add a spacer for better visual padding in `BudgetPeriodSheet`

## Working demo
<img width="600" height="593" alt="image" src="https://github.com/user-attachments/assets/17ff1253-fddf-4e45-b8cf-897684ed0d8f" />

<img width="601" height="447" alt="image" src="https://github.com/user-attachments/assets/7601afc8-0470-4608-bc33-5d4effd34675" />


## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
closes #131 
