### PR TITLE
feat: implement clickable calendar heatmap

### DIFF
--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/SplitModeE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/budget/SplitModeE2ETest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth
+import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetSplitMode
@@ -290,7 +291,8 @@ class SplitModeE2ETest {
 
         composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG)
             .assertIsDisplayed()
-        composeTestRule.onAllNodesWithText("Static").onLast().assertIsDisplayed()
+        val staticLabel = composeTestRule.activity.getString(R.string.split_mode_static)
+        composeTestRule.onAllNodesWithText(staticLabel, substring = true).onLast().assertIsDisplayed()
     }
 
     @Test
@@ -302,7 +304,8 @@ class SplitModeE2ETest {
 
         composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG)
             .assertIsDisplayed()
-        composeTestRule.onAllNodesWithText("Dynamic").onLast().assertIsDisplayed()
+        val dynamicLabel = composeTestRule.activity.getString(R.string.split_mode_dynamic)
+        composeTestRule.onAllNodesWithText(dynamicLabel, substring = true).onLast().assertIsDisplayed()
     }
 
     @Test
@@ -327,13 +330,14 @@ class SplitModeE2ETest {
         composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG).performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onAllNodesWithText("Dynamic").onLast().performClick()
+        val dynamicLabel = composeTestRule.activity.getString(R.string.split_mode_dynamic)
+        composeTestRule.onAllNodesWithText(dynamicLabel, substring = true).onLast().performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onAllNodesWithText("How should we split your budget?")
+        composeTestRule.onAllNodesWithText("How should we split your budget?", substring = true)
             .onLast()
             .assertIsNotDisplayed()
-        composeTestRule.onAllNodesWithText("Dynamic").onLast().assertIsDisplayed()
+        composeTestRule.onAllNodesWithText(dynamicLabel, substring = true).onLast().assertIsDisplayed()
     }
 
     @Test
@@ -347,7 +351,8 @@ class SplitModeE2ETest {
 
         composeTestRule.onNodeWithTag(BUDGET_PERIOD_SPLIT_MODE_ROW_TAG).performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onAllNodesWithText("Dynamic").onLast().performClick()
+        val dynamicLabel = composeTestRule.activity.getString(R.string.split_mode_dynamic)
+        composeTestRule.onAllNodesWithText(dynamicLabel, substring = true).onLast().performClick()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithTag(BUDGET_PERIOD_APPLY_BUTTON_TAG).performClick()

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/history/HistoryScreenE2ETest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/e2e/history/HistoryScreenE2ETest.kt
@@ -7,16 +7,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.test.waitUntilDoesNotExist
 import com.google.common.truth.Truth
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.BudgetPeriod
@@ -79,22 +83,26 @@ class HistoryScreenE2ETest {
     )
 
     private fun sampleTransactions(): List<Transaction> = listOf(
-        Transaction.create(
+        Transaction(
+            id = 1L,
             amount = BigDecimal("45.50"),
             comment = "Groceries",
             date = LocalDateTime.now().minusHours(2),
         ),
-        Transaction.create(
+        Transaction(
+            id = 2L,
             amount = BigDecimal("12.00"),
             comment = "Coffee",
             date = LocalDateTime.now().minusHours(5),
         ),
-        Transaction.create(
+        Transaction(
+            id = 3L,
             amount = BigDecimal("85.00"),
             comment = "Gas",
             date = LocalDateTime.now().minusDays(1),
         ),
-        Transaction.create(
+        Transaction(
+            id = 4L,
             amount = BigDecimal("30.00"),
             comment = "Lunch",
             date = LocalDateTime.now().minusDays(2),
@@ -118,7 +126,8 @@ class HistoryScreenE2ETest {
 
     private fun sampleUpcomingRecurrentItems(): List<UpcomingRecurrentItem> = listOf(
         UpcomingRecurrentItem(
-            transaction = Transaction.create(
+            transaction = Transaction(
+                id = 5L,
                 amount = BigDecimal("15.00"),
                 comment = "Netflix",
                 date = LocalDateTime.now().minusDays(10),
@@ -283,6 +292,7 @@ class HistoryScreenE2ETest {
         composeTestRule.onAllNodesWithText("Coffee").onLast().assertIsDisplayed()
     }
 
+    @OptIn(ExperimentalTestApi::class)
     @Test
     fun when_tapping_transaction_then_deleting_from_dialog_removes_it_from_list() {
         val transactions = sampleTransactions()
@@ -327,12 +337,12 @@ class HistoryScreenE2ETest {
         }
 
         composeTestRule.onNodeWithText("Coffee").performClick()
+        composeTestRule.waitForIdle()
 
-        val deleteLabel = composeTestRule.activity.getString(R.string.delete)
-        composeTestRule.onNodeWithText(deleteLabel).performClick()
+        composeTestRule.onNodeWithTag("ExpenseItem_DeleteButton_2").performClick()
 
-        composeTestRule.mainClock.advanceTimeBy(500)
-        composeTestRule.onAllNodesWithText("Coffee").assertCountEquals(0)
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilDoesNotExist(hasText("Coffee"), timeoutMillis = 2000L)
     }
 
     @Test
@@ -375,14 +385,14 @@ class HistoryScreenE2ETest {
             }
 
         composeTestRule.onNodeWithText("Coffee").performClick()
+        composeTestRule.waitForIdle()
 
-        val editLabel = composeTestRule.activity.getString(R.string.edit)
-        composeTestRule.onNodeWithText(editLabel).performClick()
+        composeTestRule.onNodeWithTag("ExpenseItem_EditButton_2").performClick()
 
-        composeTestRule.mainClock.advanceTimeBy(500)
+        composeTestRule.waitForIdle()
 
         val editTitle = composeTestRule.activity.getString(R.string.edit_expense_title)
-        composeTestRule.onNodeWithText(editTitle).assertIsDisplayed()
+        composeTestRule.onNodeWithText(editTitle, substring = true).assertIsDisplayed()
         composeTestRule.onAllNodesWithText("Coffee").onLast().assertIsDisplayed()
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -67,6 +68,8 @@ import com.serranoie.app.minus.presentation.ui.theme.component.date.CalendarHeat
 import com.serranoie.app.minus.presentation.util.Utils.strongHapticFeedback
 import com.serranoie.app.minus.presentation.util.Utils.weakHapticFeedback
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Date
 
 data class AnalyticsState(
@@ -115,9 +118,12 @@ fun Analytics(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var selectedCategory by remember { mutableStateOf<CategoryAnalyticsState?>(null) }
+    var selectedDayData by remember { mutableStateOf<CategoryAnalyticsState?>(null) }
 
     val navigationBarHeight =
         LocalWindowInsets.current.calculateBottomPadding().coerceAtLeast(16.dp)
+
+    val locale = LocalConfiguration.current.locales[0]
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -176,6 +182,18 @@ fun Analytics(
                         selectedCategory =
                             state.toCategoryAnalyticsState(categoryName, categorySpends)
                         view.weakHapticFeedback()
+                    },
+                    onDayClick = { date ->
+                        val daySpends = state.spends.filter { it.date?.toLocalDate() == date }
+                        val formatter = DateTimeFormatter.ofPattern(
+                            "dd MMMM",
+                            locale
+                        )
+                        selectedDayData = state.toCategoryAnalyticsState(
+                            categoryName = date.format(formatter),
+                            categorySpends = daySpends
+                        ).copy(isDayView = true)
+                        view.weakHapticFeedback()
                     }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
@@ -216,12 +234,16 @@ fun Analytics(
         }
     }
 
-    if (selectedCategory != null) {
+    if (selectedCategory != null || selectedDayData != null) {
         ModalBottomSheet(
-            onDismissRequest = { selectedCategory = null },
+            onDismissRequest = {
+                selectedCategory = null
+                selectedDayData = null
+            },
             sheetState = sheetState,
         ) {
-            CategoryAnalytics(state = selectedCategory!!)
+            val displayState = selectedCategory ?: selectedDayData!!
+            CategoryAnalytics(state = displayState)
         }
     }
 
@@ -266,6 +288,7 @@ private fun AnalyticsResponsiveLayout(
     onShowHistory: () -> Unit,
     onShowCreditDetails: () -> Unit,
     onCategoryClick: (String, List<Transaction>) -> Unit,
+    onDayClick: (LocalDate) -> Unit,
 ) {
     if (useTabletLayout) {
         AnalyticsTabletLayout(
@@ -273,6 +296,7 @@ private fun AnalyticsResponsiveLayout(
             onShowHistory = onShowHistory,
             onShowCreditDetails = onShowCreditDetails,
             onCategoryClick = onCategoryClick,
+            onDayClick = onDayClick,
         )
     } else {
         AnalyticsCompactLayout(
@@ -280,6 +304,7 @@ private fun AnalyticsResponsiveLayout(
             onShowHistory = onShowHistory,
             onShowCreditDetails = onShowCreditDetails,
             onCategoryClick = onCategoryClick,
+            onDayClick = onDayClick,
         )
     }
 }
@@ -290,6 +315,7 @@ private fun AnalyticsCompactLayout(
     onShowHistory: () -> Unit,
     onShowCreditDetails: () -> Unit,
     onCategoryClick: (String, List<Transaction>) -> Unit,
+    onDayClick: (LocalDate) -> Unit,
 ) {
     Column {
         Row(
@@ -303,6 +329,7 @@ private fun AnalyticsCompactLayout(
                     budget = state.wholeBudget,
                     startDate = state.startPeriodDate,
                     finishDate = state.finishPeriodDate,
+                    onDayClick = onDayClick,
                     modifier = Modifier
                         .weight(1f)
                         .wrapContentHeight(),
@@ -408,6 +435,7 @@ private fun AnalyticsTabletLayout(
     onShowHistory: () -> Unit,
     onShowCreditDetails: () -> Unit,
     onCategoryClick: (String, List<Transaction>) -> Unit,
+    onDayClick: (LocalDate) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -431,6 +459,7 @@ private fun AnalyticsTabletLayout(
                         budget = state.wholeBudget,
                         startDate = state.startPeriodDate,
                         finishDate = state.finishPeriodDate,
+                        onDayClick = onDayClick,
                         modifier = Modifier
                             .fillMaxWidth()
                             .fillMaxHeight(),

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
@@ -56,6 +56,7 @@ data class CategoryAnalyticsState(
     val categorySpends: List<Transaction> = emptyList(),
     val currencyCode: String = "USD",
     val creditCardCutoffDay: Int? = null,
+    val isDayView: Boolean = false,
 )
 
 @Composable
@@ -223,7 +224,11 @@ fun CategoryAnalytics(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = stringResource(R.string.category_no_expenses),
+                    text = if (state.isDayView) {
+                        stringResource(R.string.day_no_expenses)
+                    } else {
+                        stringResource(R.string.category_no_expenses)
+                    },
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/CategoryAnalytics.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,9 +34,11 @@ import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.LocalWindowInsets
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.presentation.ui.theme.component.PaddedListItem
 import com.serranoie.app.minus.presentation.ui.theme.component.PaddedListItemPosition
 import com.serranoie.app.minus.presentation.ui.theme.component.budget.AverageSpendCard
 import com.serranoie.app.minus.presentation.ui.theme.component.charts.DetailedChart
+import com.serranoie.app.minus.presentation.ui.theme.component.date.DayTotalItem
 import com.serranoie.app.minus.presentation.ui.theme.component.date.HistoryDateDivider
 import com.serranoie.app.minus.presentation.ui.theme.component.expense.ExpenseItem
 import com.serranoie.app.minus.presentation.ui.theme.labelMediumCondensed
@@ -94,7 +98,7 @@ fun CategoryAnalytics(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        if (state.categorySpends.size >= 2) {
+        if (state.categorySpends.size >= 2 && !state.isDayView) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -151,7 +155,7 @@ fun CategoryAnalytics(
             Spacer(modifier = Modifier.height(12.dp))
         }
 
-        if (state.categorySpends.size > 1) {
+        if (state.categorySpends.size > 1 && !state.isDayView) {
             AverageSpendCard(
                 spends = state.categorySpends,
                 startDate = state.startPeriodDate,
@@ -191,22 +195,22 @@ fun CategoryAnalytics(
                             sharedTransitionScope = null,
                             animatedVisibilityScope = null,
                             creditCardCutoffDay = state.creditCardCutoffDay,
+                            containerColor = MaterialTheme.colorScheme.surfaceContainer,
                         )
+
+                        if (index < transactions.size - 1) {
+                            Spacer(modifier = Modifier.height(2.dp))
+                        }
                     }
 
                     val dayTotal = transactions.sumOf { it.amount }
-                    Box(
+                    DayTotalItem(
+                        total = dayTotal,
+                        currencyFormat = currencyFormat,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 4.dp)
-                    ) {
-                        Text(
-                            text = "Total: ${currencyFormat.format(dayTotal)}",
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.align(Alignment.CenterEnd)
-                        )
-                    }
+                    )
 
                     Spacer(modifier = Modifier.height(8.dp))
                 }
@@ -216,21 +220,21 @@ fun CategoryAnalytics(
         }
 
         if (state.categorySpends.isEmpty()) {
+            val emptyMessage = if (state.isDayView) {
+                stringResource(R.string.day_no_expenses)
+            } else {
+                stringResource(R.string.category_no_expenses)
+            }
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .height(200.dp),
-                contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = if (state.isDayView) {
-                        stringResource(R.string.day_no_expenses)
-                    } else {
-                        stringResource(R.string.category_no_expenses)
-                    },
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                PaddedListItem(
+                    title = emptyMessage,
+                    icon = Icons.Default.Info,
+                    onClick = {},
+                    position = PaddedListItemPosition.Single
                 )
             }
         }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/CalendarHeatmap.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/CalendarHeatmap.kt
@@ -85,6 +85,7 @@ fun CalendarHeatmap(
 	startDate: Date,
 	finishDate: Date,
 	actualFinishDate: Date? = null,
+	onDayClick: (LocalDate) -> Unit = {},
 ) {
 	val context = LocalContext.current
 
@@ -115,7 +116,7 @@ fun CalendarHeatmap(
 		CalendarState(
 			context = context,
 			disableBeforeDate = startDate,
-			disableAfterDate = (actualFinishDate ?: finishDate).coerceAtMost(Date()),
+			disableAfterDate = actualFinishDate ?: finishDate,
 		)
 	}
 
@@ -179,13 +180,70 @@ fun CalendarHeatmap(
 								spendingDays = spendingDays,
 								budget = budget,
 								maxSpendsPerDay = maxSpendsPerDay,
+								onDayClick = onDayClick,
 							)
 						}
 					}
 				}
 			})
+
+		Box(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(end = 16.dp, bottom = 12.dp),
+			contentAlignment = Alignment.BottomEnd
+		) {
+			HeatmapLegend()
+		}
 	}
 
+}
+
+@Composable
+private fun HeatmapLegend() {
+	Row(
+		verticalAlignment = Alignment.CenterVertically,
+		modifier = Modifier.padding(top = 4.dp)
+	) {
+		Text(
+			text = stringResource(R.string.heatmap_legend_less),
+			style = MaterialTheme.typography.labelSmallCondensed,
+			color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+		)
+		Spacer(modifier = Modifier.width(4.dp))
+
+		listOf(0.0f, 0.25f, 0.5f, 0.75f, 1.0f).forEach { ratio ->
+			val color = if (ratio == 0f) Color.Transparent else {
+				val normalizedHeat = ratio.coerceIn(0f, 1.2f)
+				val heatColor = when {
+					normalizedHeat <= 0.5f -> lerp(colorGood, colorNotGood, normalizedHeat / 0.5f)
+					normalizedHeat <= 1.0f -> lerp(colorNotGood, colorBad, (normalizedHeat - 0.5f) / 0.5f)
+					else -> colorBad
+				}
+				val heatAlpha = 0.25f + (normalizedHeat * 0.55f)
+				heatColor.copy(alpha = heatAlpha)
+			}
+
+			Box(
+				modifier = Modifier
+					.size(10.dp)
+					.padding(1.dp)
+					.background(color, shape = RoundedCornerShape(2.dp))
+					.border(
+						width = 0.5.dp,
+						color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+						shape = RoundedCornerShape(2.dp)
+					)
+			)
+		}
+
+		Spacer(modifier = Modifier.width(4.dp))
+		Text(
+			text = stringResource(R.string.heatmap_legend_more),
+			style = MaterialTheme.typography.labelSmallCondensed,
+			color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+		)
+	}
 }
 
 @Composable
@@ -263,6 +321,7 @@ fun WeekRow(
 	spendingDays: Map<LocalDate, SpendingDay>,
 	budget: BigDecimal,
 	maxSpendsPerDay: Int,
+	onDayClick: (LocalDate) -> Unit,
 ) {
 	val beginningWeek = week.yearMonth.atDay(1).plusWeeks(week.number.toLong())
 	var currentDay = beginningWeek.with(TemporalAdjusters.previousOrSame(getWeek()[0]))
@@ -287,7 +346,7 @@ fun WeekRow(
 						modifier = Modifier.weight(1f),
 						calendarState = calendarUiState,
 						day = currentDay,
-						onDayClicked = {},
+						onDayClicked = onDayClick,
 						spendingRatio = heatIntensity,
 						hasSpending = spendingDay != null,
 					)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
@@ -69,6 +69,7 @@ fun ExpenseItem(
     readOnly: Boolean = false,
     disableAnimations: Boolean = false,
     modifier: Modifier = Modifier,
+    containerColor: Color = Color.Transparent,
     customShape: androidx.compose.ui.graphics.Shape? = null,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
@@ -82,7 +83,7 @@ fun ExpenseItem(
         CustomPaddedListItem(
             onClick = onClick,
             position = position,
-            background = Color.Transparent,
+            background = containerColor,
             contentColor = MaterialTheme.colorScheme.onSurface,
             customShape = customShape
         ) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItemExpandedContent.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItemExpandedContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -206,7 +207,7 @@ fun ExpenseItemExpandedContent(
                     contentColor = MaterialTheme.colorScheme.primary,
                 ),
                 onClick = onEdit,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).testTag("ExpenseItem_EditButton_${transaction.id}"),
             ) {
                 Text(stringResource(R.string.edit), style = MaterialTheme.typography.labelSmallEmphasized)
             }
@@ -214,7 +215,7 @@ fun ExpenseItemExpandedContent(
             if (!readOnly) {
                 Button(
                     onClick = onDelete,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).testTag("ExpenseItem_DeleteButton_${transaction.id}"),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.error,
                         contentColor = MaterialTheme.colorScheme.onError,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -348,8 +348,11 @@
     <string name="categories_chart_empty_title">No podemos dividir los gastos sin categoría</string>
     <string name="categories_chart_empty_subtitle">Agregue categorías para ver el gráfico</string>
     <string name="category_no_expenses">No hay gastos en esta categoría</string>
+    <string name="day_no_expenses">No hay gastos este día, aún…</string>
     <!-- Calendar Heatmap -->
     <string name="calendar_heatmap_info_text">Este gráfico muestra el dinero gastado por cada día del período</string>
+    <string name="heatmap_legend_less">Menos</string>
+    <string name="heatmap_legend_more">Más</string>
     <!-- No Transactions -->
     <string name="no_transactions_title">No hay gastos registrados</string>
     <string name="no_transactions_subtitle">Agregue un gasto para comenzar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,9 +403,12 @@
     <string name="categories_chart_empty_title">We can\'t split your expenses</string>
     <string name="categories_chart_empty_subtitle">Save expenses with a category to split them</string>
     <string name="category_no_expenses">No expenses in this category</string>
+    <string name="day_no_expenses">No expenses on this day, yet…</string>
 
     <!-- Calendar Heatmap -->
     <string name="calendar_heatmap_info_text">This chart shows money spent for each day in the period</string>
+    <string name="heatmap_legend_less">Less</string>
+    <string name="heatmap_legend_more">More</string>
 
     <!-- No Transactions -->
     <string name="no_transactions_title">No recorded expenses</string>


### PR DESCRIPTION
## Description
Be able to implement a tap per day on the calendar heath map

## Change strategy
Be able to tap on a specific day to see all expenses recorded on that selected date. Also render the full weeks of the period on the calendar instead of waiting the days to pass to show them on anayltics.

## Implemented

- Sheet to render the same graph on the per-category analytics.
- Render multiple weeks on the calendar

## Working demo

https://github.com/user-attachments/assets/7bdc4e52-504f-4c7e-bfae-b0711ff8d0e9



## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
closes #132 
