### PR TITLE
feat: include budget split mode & period ID on CSV export

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/data/csv/CsvModels.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/CsvModels.kt
@@ -17,7 +17,8 @@ data class CsvTransactionRow(
     val endDate: LocalDate?,
     val subscriptionDay: Int?,
     val isCredit: Boolean,
-    val isCreditPaid: Boolean
+    val isCreditPaid: Boolean,
+    val periodId: Long
 )
 
 data class CsvBackupMetadata(
@@ -44,6 +45,7 @@ fun CsvTransactionRow.toDomainTransaction(): Transaction {
         amount = amount,
         comment = comment,
         date = date,
+        periodId = periodId,
         isDeleted = false,
         isRecurrent = isRecurrent,
         recurrentFrequency = frequency,

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/CsvModels.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/CsvModels.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.data.csv
 
+import com.serranoie.app.minus.domain.model.ArchivedBudget
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
@@ -30,6 +31,7 @@ data class CsvBackupMetadata(
 data class CsvImportPayload(
     val rows: List<CsvTransactionRow>,
     val metadata: CsvBackupMetadata?,
+    val archivedBudgets: List<ArchivedBudget>,
     val errors: List<String>,
 )
 

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvContract.kt
@@ -14,8 +14,10 @@ object MinusCsvContract {
     const val COL_IS_CREDIT = "is_credit"
     const val COL_IS_CREDIT_PAID = "is_credit_paid"
     const val COL_PERIOD_ID = "period_id"
+    const val COL_CREATED_AT = "created_at"
 
     const val MARKER_META = "__META__"
+    const val MARKER_ARCHIVED = "__ARCHIVED__"
 
     const val COL_BUDGET_TOTAL = "budget_total"
     const val COL_BUDGET_PERIOD = "budget_period"
@@ -43,6 +45,7 @@ object MinusCsvContract {
         COL_IS_CREDIT,
         COL_IS_CREDIT_PAID,
         COL_PERIOD_ID,
+        COL_CREATED_AT,
         COL_BUDGET_TOTAL,
         COL_BUDGET_PERIOD,
         COL_BUDGET_START_DATE,

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvContract.kt
@@ -13,6 +13,9 @@ object MinusCsvContract {
     const val COL_ID = "id"
     const val COL_IS_CREDIT = "is_credit"
     const val COL_IS_CREDIT_PAID = "is_credit_paid"
+    const val COL_PERIOD_ID = "period_id"
+
+    const val MARKER_META = "__META__"
 
     const val COL_BUDGET_TOTAL = "budget_total"
     const val COL_BUDGET_PERIOD = "budget_period"
@@ -26,6 +29,7 @@ object MinusCsvContract {
     const val COL_CURRENT_PERIOD_STARTED_AT = "current_period_started_at_millis"
     const val COL_CURRENT_PERIOD_ID = "current_period_id"
     const val COL_CREDIT_CARD_CUTOFF_DAY = "credit_card_cutoff_day"
+    const val COL_SPLIT_MODE = "split_mode"
 
     val HEADERS = arrayOf(
         COL_DATE,
@@ -38,6 +42,7 @@ object MinusCsvContract {
         COL_ID,
         COL_IS_CREDIT,
         COL_IS_CREDIT_PAID,
+        COL_PERIOD_ID,
         COL_BUDGET_TOTAL,
         COL_BUDGET_PERIOD,
         COL_BUDGET_START_DATE,
@@ -50,5 +55,6 @@ object MinusCsvContract {
         COL_CURRENT_PERIOD_STARTED_AT,
         COL_CURRENT_PERIOD_ID,
         COL_CREDIT_CARD_CUTOFF_DAY,
+        COL_SPLIT_MODE,
     )
 }

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvExporter.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvExporter.kt
@@ -27,7 +27,7 @@ class MinusCsvExporter {
                 metadata?.let { meta ->
                     val s = meta.budgetSettings
                     printer.printRecord(
-                        "__META__",
+                        MinusCsvContract.MARKER_META,
                         "",
                         "",
                         "",
@@ -49,6 +49,7 @@ class MinusCsvExporter {
                         meta.currentPeriodStartedAtMillis.toString(),
                         meta.currentPeriodId.toString(),
                         s.creditCardCutoffDay?.toString().orEmpty(),
+                        s.splitMode.name,
                     )
                 }
 
@@ -69,6 +70,7 @@ class MinusCsvExporter {
                         tx.id.toString(),
                         if (tx.isCredit) "1" else "0",
                         if (tx.isCreditPaid) "1" else "0",
+                        tx.periodId.toString(),
                         "",
                         "",
                         "",

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvExporter.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvExporter.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.data.csv
 
+import com.serranoie.app.minus.domain.model.ArchivedBudget
 import com.serranoie.app.minus.domain.model.Transaction
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
@@ -15,6 +16,7 @@ class MinusCsvExporter {
 
     fun export(
         transactions: List<Transaction>,
+        archivedBudgets: List<ArchivedBudget>,
         metadata: CsvBackupMetadata?,
         outputStream: OutputStream,
     ) {
@@ -28,6 +30,8 @@ class MinusCsvExporter {
                     val s = meta.budgetSettings
                     printer.printRecord(
                         MinusCsvContract.MARKER_META,
+                        "",
+                        "",
                         "",
                         "",
                         "",
@@ -53,6 +57,36 @@ class MinusCsvExporter {
                     )
                 }
 
+                archivedBudgets.forEach { archive ->
+                    printer.printRecord(
+                        MinusCsvContract.MARKER_ARCHIVED,
+                        archive.spentAmount.toPlainString(),
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        archive.periodId.toString(),
+                        archive.createdAt.toString(),
+                        archive.totalBudget.toPlainString(),
+                        archive.periodType.name,
+                        archive.startDate.format(dateFormatter),
+                        archive.endDate.format(dateFormatter),
+                        archive.currencyCode,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                    )
+                }
+
                 transactions.forEach { tx ->
                     val txDate = tx.date ?: return@forEach
                     val frequency = tx.recurrentFrequency?.name.orEmpty()
@@ -71,7 +105,7 @@ class MinusCsvExporter {
                         if (tx.isCredit) "1" else "0",
                         if (tx.isCreditPaid) "1" else "0",
                         tx.periodId.toString(),
-                        "",
+                        tx.createdAt.toString(),
                         "",
                         "",
                         "",

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvParser.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvParser.kt
@@ -2,6 +2,7 @@ package com.serranoie.app.minus.data.csv
 
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.RemainingBudgetStrategy
 import org.apache.commons.csv.CSVFormat
@@ -36,7 +37,7 @@ class MinusCsvParser {
                 val raw = record.toMap()
 
                 val dateRaw = raw.valueOf(MinusCsvContract.COL_DATE)
-                if (dateRaw == "__META__") {
+                if (dateRaw == MinusCsvContract.MARKER_META) {
                     runCatching { parseMetadata(raw) }
                         .onSuccess { parsedMeta -> metadata = parsedMeta }
                         .onFailure { throwable -> errors.add("Line $lineNo metadata discarded: ${throwable.message}") }
@@ -59,7 +60,11 @@ class MinusCsvParser {
             }
         }
 
-        return CsvImportPayload(rows = rows, metadata = metadata, errors = errors)
+        return CsvImportPayload(
+            rows = rows,
+            metadata = metadata,
+            errors = errors
+        )
     }
 
     private fun parseRecord(raw: Map<String, String>): CsvTransactionRow {
@@ -89,6 +94,11 @@ class MinusCsvParser {
         val isCredit = raw.valueOf(MinusCsvContract.COL_IS_CREDIT).trim() == "1"
         val isCreditPaid = raw.valueOf(MinusCsvContract.COL_IS_CREDIT_PAID).trim() == "1"
 
+        val periodId = raw.valueOf(MinusCsvContract.COL_PERIOD_ID)
+            .toLongOrNull()
+            ?.coerceAtLeast(0L)
+            ?: 0L
+
         return CsvTransactionRow(
             id = id,
             date = date,
@@ -100,6 +110,7 @@ class MinusCsvParser {
             subscriptionDay = subDay,
             isCredit = isCredit,
             isCreditPaid = isCreditPaid,
+            periodId = periodId,
         )
     }
 
@@ -133,6 +144,16 @@ class MinusCsvParser {
             ?.coerceAtLeast(0L)
             ?: 0L
 
+        val splitMode = raw.valueOf(MinusCsvContract.COL_SPLIT_MODE)
+            .takeIf { it.isNotBlank() }
+            ?.let {
+                try {
+                    BudgetSplitMode.valueOf(it)
+                } catch (_: Exception) {
+                    BudgetSplitMode.STATIC
+                }
+            } ?: BudgetSplitMode.STATIC
+
         return CsvBackupMetadata(
             budgetSettings = BudgetSettings(
                 totalBudget = totalBudget,
@@ -147,6 +168,7 @@ class MinusCsvParser {
                 creditCardCutoffDay = raw.valueOf(MinusCsvContract.COL_CREDIT_CARD_CUTOFF_DAY)
                     .toIntOrNull()
                     ?.takeIf { it in 1..31 },
+                splitMode = splitMode,
             ),
             currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
             currentPeriodId = currentPeriodId,

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvParser.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvParser.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.data.csv
 
+import com.serranoie.app.minus.domain.model.ArchivedBudget
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetSplitMode
@@ -22,6 +23,7 @@ class MinusCsvParser {
     fun parse(inputStream: InputStream): CsvImportPayload {
         val errors = mutableListOf<String>()
         val rows = mutableListOf<CsvTransactionRow>()
+        val archivedBudgets = mutableListOf<ArchivedBudget>()
         var metadata: CsvBackupMetadata? = null
 
         val format = CSVFormat.DEFAULT.builder()
@@ -44,6 +46,13 @@ class MinusCsvParser {
                     return@forEachIndexed
                 }
 
+                if (dateRaw == MinusCsvContract.MARKER_ARCHIVED) {
+                    runCatching { parseArchivedBudget(raw) }
+                        .onSuccess { archivedBudgets.add(it) }
+                        .onFailure { throwable -> errors.add("Line $lineNo archived budget discarded: ${throwable.message}") }
+                    return@forEachIndexed
+                }
+
                 runCatching {
                     val row = parseRecord(raw)
                     if (row.amount <= BigDecimal.ZERO) {
@@ -63,6 +72,7 @@ class MinusCsvParser {
         return CsvImportPayload(
             rows = rows,
             metadata = metadata,
+            archivedBudgets = archivedBudgets,
             errors = errors
         )
     }
@@ -111,6 +121,29 @@ class MinusCsvParser {
             isCredit = isCredit,
             isCreditPaid = isCreditPaid,
             periodId = periodId,
+        )
+    }
+
+    private fun parseArchivedBudget(raw: Map<String, String>): ArchivedBudget {
+        val spentAmount = raw.valueOf(MinusCsvContract.COL_AMOUNT).toBigDecimal()
+        val periodId = raw.valueOf(MinusCsvContract.COL_PERIOD_ID).toLong()
+        val createdAt = raw.valueOf(MinusCsvContract.COL_CREATED_AT)
+            .toLongOrNull() ?: System.currentTimeMillis()
+        val totalBudget = raw.valueOf(MinusCsvContract.COL_BUDGET_TOTAL).toBigDecimal()
+        val periodType = BudgetPeriod.valueOf(raw.valueOf(MinusCsvContract.COL_BUDGET_PERIOD))
+        val startDate = LocalDate.parse(raw.valueOf(MinusCsvContract.COL_BUDGET_START_DATE), dateFormatter)
+        val endDate = LocalDate.parse(raw.valueOf(MinusCsvContract.COL_BUDGET_END_DATE), dateFormatter)
+        val currencyCode = raw.valueOf(MinusCsvContract.COL_CURRENCY_CODE).ifBlank { "USD" }
+
+        return ArchivedBudget(
+            periodId = periodId,
+            totalBudget = totalBudget,
+            spentAmount = spentAmount,
+            startDate = startDate,
+            endDate = endDate,
+            currencyCode = currencyCode,
+            periodType = periodType,
+            createdAt = createdAt
         )
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvService.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/csv/MinusCsvService.kt
@@ -36,6 +36,7 @@ class MinusCsvService @Inject constructor(
 
     suspend fun exportAllTransactions(outputStream: OutputStream) {
         val transactions = repository.getTransactions().first()
+        val archivedBudgets = repository.getArchivedBudgets().first()
         val settings = repository.getBudgetSettingsSync()
         val userSettings = settingsRepository.getSettings()
         val metadata = settings?.let {
@@ -45,7 +46,7 @@ class MinusCsvService @Inject constructor(
                 currentPeriodId = userSettings.currentPeriodId,
             )
         }
-        exporter.export(transactions, metadata, outputStream)
+        exporter.export(transactions, archivedBudgets, metadata, outputStream)
     }
 
     suspend fun importTransactions(inputStream: InputStream): CsvImportResult {
@@ -60,6 +61,10 @@ class MinusCsvService @Inject constructor(
         }
 
         fresh.forEach { repository.addTransaction(it.copy(id = 0L)) }
+
+        if (payload.archivedBudgets.isNotEmpty()) {
+            repository.upsertArchivedBudgets(payload.archivedBudgets)
+        }
 
         payload.metadata?.let { metadata ->
             repository.saveBudgetSettings(metadata.budgetSettings)

--- a/app/src/main/java/com/serranoie/app/minus/data/local/dao/ArchivedBudgetDao.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/dao/ArchivedBudgetDao.kt
@@ -13,6 +13,9 @@ interface ArchivedBudgetDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(archivedBudget: ArchivedBudgetEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(archivedBudgets: List<ArchivedBudgetEntity>)
+
     @Query("SELECT * FROM archived_budgets ORDER BY startDate DESC")
     fun getAllArchivedBudgets(): Flow<List<ArchivedBudgetEntity>>
 

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepository.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepository.kt
@@ -67,6 +67,8 @@ interface BudgetRepository {
 
     fun getArchivedBudgets(): Flow<List<ArchivedBudget>>
 
+    suspend fun upsertArchivedBudgets(archivedBudgets: List<ArchivedBudget>)
+
     suspend fun archiveCurrentPeriod(
         periodId: Long,
         settings: BudgetSettings,

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
@@ -188,6 +188,17 @@ class BudgetRepositoryImpl @Inject constructor(
         createdAt = this.createdAt
     )
 
+    private fun ArchivedBudget.toEntity(): ArchivedBudgetEntity = ArchivedBudgetEntity(
+        periodId = periodId,
+        totalBudget = totalBudget.toPlainString(),
+        spentAmount = spentAmount.toPlainString(),
+        startDate = startDate.toEpochDay() * 86400000,
+        endDate = endDate.toEpochDay() * 86400000,
+        currencyCode = currencyCode,
+        periodType = periodType.name,
+        createdAt = createdAt
+    )
+
     override fun getTransactions(): Flow<List<Transaction>> {
         return transactionDao.getAllTransactions()
             .map { entities -> entities.map { it.toDomain() } }
@@ -368,6 +379,11 @@ class BudgetRepositoryImpl @Inject constructor(
         return archivedBudgetDao.getAllArchivedBudgets().map { entities ->
             entities.map { it.toDomain() }
         }
+    }
+
+    override suspend fun upsertArchivedBudgets(archivedBudgets: List<ArchivedBudget>) {
+        val entities = archivedBudgets.map { it.toEntity() }
+        archivedBudgetDao.insertAll(entities)
     }
 
     override suspend fun archiveCurrentPeriod(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetPeriodManager.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetPeriodManager.kt
@@ -13,135 +13,135 @@ import java.time.ZoneId
 import javax.inject.Inject
 
 data class PeriodBoundaryResult(
-	val periodStartMillis: Long,
-	val periodId: Long,
+    val periodStartMillis: Long,
+    val periodId: Long,
 )
 
 class BudgetPeriodManager @Inject constructor(
-	private val budgetRepository: BudgetRepository,
-	private val settingsRepository: SettingsRepository,
-	private val timeProvider: TimeProvider,
-	private val notificationScheduler: NotificationScheduler,
+    private val budgetRepository: BudgetRepository,
+    private val settingsRepository: SettingsRepository,
+    private val timeProvider: TimeProvider,
+    private val notificationScheduler: NotificationScheduler,
 ) {
 
-	suspend fun updatePeriodEndNotificationTime(hour: Int, minute: Int) {
-		settingsRepository.setNotificationTime(hour, minute)
-		budgetRepository.getBudgetSettingsSync()?.let { settings ->
-			notificationScheduler.schedulePeriodEndNotification(settings.getPeriodEndDate())
-		}
-	}
+    suspend fun updatePeriodEndNotificationTime(hour: Int, minute: Int) {
+        settingsRepository.setNotificationTime(hour, minute)
+        budgetRepository.getBudgetSettingsSync()?.let { settings ->
+            notificationScheduler.schedulePeriodEndNotification(settings.getPeriodEndDate())
+        }
+    }
 
-	suspend fun updateRecurrentNotificationTime(hour: Int, minute: Int) {
-		settingsRepository.setRecurrentNotificationTime(hour, minute)
-		notificationScheduler.rescheduleRecurrentExpenseNotifications()
-	}
+    suspend fun updateRecurrentNotificationTime(hour: Int, minute: Int) {
+        settingsRepository.setRecurrentNotificationTime(hour, minute)
+        notificationScheduler.rescheduleRecurrentExpenseNotifications()
+    }
 
-	suspend fun finishBudgetEarly() {
-		val settings = budgetRepository.getBudgetSettingsSync() ?: return
-		val originalEndDate = settings.getPeriodEndDate()
-		val now = LocalDate.now()
+    suspend fun finishBudgetEarly() {
+        val settings = budgetRepository.getBudgetSettingsSync() ?: return
+        val originalEndDate = settings.getPeriodEndDate()
+        val now = LocalDate.now()
 
-		settingsRepository.setEarlyFinishActive(
-			active = true,
-			actualDate = now.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-			originalEndDate = originalEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
-				.toEpochMilli()
-		)
-	}
+        settingsRepository.setEarlyFinishActive(
+            active = true,
+            actualDate = now.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            originalEndDate = originalEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                .toEpochMilli()
+        )
+    }
 
-	suspend fun clearEarlyFinishState() {
-		settingsRepository.clearEarlyFinish()
-	}
+    suspend fun clearEarlyFinishState() {
+        settingsRepository.clearEarlyFinish()
+    }
 
-	suspend fun persistBudgetSettings(
-		settings: BudgetSettings,
-		forceNewPeriodBoundary: Boolean,
-	): PeriodBoundaryResult {
-		val userSettings = settingsRepository.getSettings()
-		val (pendingRolloverAmount, pendingRolloverStrategy) = settingsRepository.getPendingRollover()
+    suspend fun persistBudgetSettings(
+        settings: BudgetSettings,
+        forceNewPeriodBoundary: Boolean,
+    ): PeriodBoundaryResult {
+        val userSettings = settingsRepository.getSettings()
+        val (pendingRolloverAmount, pendingRolloverStrategy) = settingsRepository.getPendingRollover()
 
-		val shouldApplyPendingRollover =
-			forceNewPeriodBoundary && pendingRolloverAmount > BigDecimal.ZERO
-		val appliedRolloverAmount =
-			if (shouldApplyPendingRollover) pendingRolloverAmount else BigDecimal.ZERO
-		val appliedCarryForward =
-			shouldApplyPendingRollover && pendingRolloverStrategy == RemainingBudgetStrategy.ADD_TO_FIRST_DAY
+        val shouldApplyPendingRollover =
+            forceNewPeriodBoundary && pendingRolloverAmount > BigDecimal.ZERO
+        val appliedRolloverAmount =
+            if (shouldApplyPendingRollover) pendingRolloverAmount else BigDecimal.ZERO
+        val appliedCarryForward =
+            shouldApplyPendingRollover && pendingRolloverStrategy == RemainingBudgetStrategy.ADD_TO_FIRST_DAY
 
-		val effectiveSettings = if (shouldApplyPendingRollover && pendingRolloverStrategy != null) {
-			when (pendingRolloverStrategy) {
-				RemainingBudgetStrategy.SPLIT_EQUALLY -> settings.copy(
-					totalBudget = settings.totalBudget.add(pendingRolloverAmount),
-					rollOverCarryForward = false,
-					rollOverLimit = pendingRolloverAmount,
-				)
+        val effectiveSettings = if (shouldApplyPendingRollover && pendingRolloverStrategy != null) {
+            when (pendingRolloverStrategy) {
+                RemainingBudgetStrategy.SPLIT_EQUALLY -> settings.copy(
+                    totalBudget = settings.totalBudget.add(pendingRolloverAmount),
+                    rollOverCarryForward = false,
+                    rollOverLimit = pendingRolloverAmount,
+                )
 
-				RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> settings.copy(
-					rollOverCarryForward = true,
-					rollOverLimit = pendingRolloverAmount,
-				)
+                RemainingBudgetStrategy.ADD_TO_FIRST_DAY -> settings.copy(
+                    rollOverCarryForward = true,
+                    rollOverLimit = pendingRolloverAmount,
+                )
 
-				RemainingBudgetStrategy.ASK_ALWAYS -> settings
-			}
-		} else {
-			settings
-		}
+                RemainingBudgetStrategy.ASK_ALWAYS -> settings
+            }
+        } else {
+            settings
+        }
 
-		clearEarlyFinishState()
-		val previousSettings = budgetRepository.getBudgetSettingsSync()
-		val previousPeriodId = userSettings.currentPeriodId
+        clearEarlyFinishState()
+        val previousSettings = budgetRepository.getBudgetSettingsSync()
+        val previousPeriodId = userSettings.currentPeriodId
 
-		if (forceNewPeriodBoundary && previousSettings != null && previousPeriodId != 0L) {
-			archivePeriod(previousPeriodId, previousSettings)
-		}
+        if (forceNewPeriodBoundary && previousSettings != null && previousPeriodId != 0L) {
+            archivePeriod(previousPeriodId, previousSettings)
+        }
 
-		budgetRepository.saveBudgetSettings(effectiveSettings)
+        budgetRepository.saveBudgetSettings(effectiveSettings)
 
-		val shouldCreateNewPeriodBoundary =
-			forceNewPeriodBoundary || previousSettings == null || previousSettings.startDate != effectiveSettings.startDate
+        val shouldCreateNewPeriodBoundary =
+            forceNewPeriodBoundary || previousSettings == null || previousSettings.startDate != effectiveSettings.startDate
 
-		val periodStartMillis = if (shouldCreateNewPeriodBoundary) {
-			timeProvider.nowEpochMillis()
-		} else {
-			val existingStart = userSettings.currentPeriodStartedAt
-			if (existingStart != 0L) existingStart
-			else effectiveSettings.startDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
-				.toEpochMilli()
-		}
-		val periodId = if (shouldCreateNewPeriodBoundary) {
-			periodStartMillis
-		} else {
-			val existingId = userSettings.currentPeriodId
-			if (existingId != 0L) existingId else periodStartMillis
-		}
+        val periodStartMillis = if (shouldCreateNewPeriodBoundary) {
+            timeProvider.nowEpochMillis()
+        } else {
+            val existingStart = userSettings.currentPeriodStartedAt
+            if (existingStart != 0L) existingStart
+            else effectiveSettings.startDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                .toEpochMilli()
+        }
+        val periodId = if (shouldCreateNewPeriodBoundary) {
+            periodStartMillis
+        } else {
+            val existingId = userSettings.currentPeriodId
+            if (existingId != 0L) existingId else periodStartMillis
+        }
 
-		val periodEndDate = effectiveSettings.getPeriodEndDate()
-		val millis = periodEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val periodEndDate = effectiveSettings.getPeriodEndDate()
+        val millis = periodEndDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
-		settingsRepository.setBudgetEndDate(millis)
-		settingsRepository.setCurrentPeriod(periodId, periodStartMillis)
-		settingsRepository.setCurrentPeriodRollover(appliedRolloverAmount, appliedCarryForward)
+        settingsRepository.setBudgetEndDate(millis)
+        settingsRepository.setCurrentPeriod(periodId, periodStartMillis)
+        settingsRepository.setCurrentPeriodRollover(appliedRolloverAmount, appliedCarryForward)
 
-		if (shouldApplyPendingRollover) {
-			settingsRepository.clearPendingRollover()
-		}
-		if (shouldCreateNewPeriodBoundary) {
-			settingsRepository.clearLastPeriodSnapshot()
-		}
+        if (shouldApplyPendingRollover) {
+            settingsRepository.clearPendingRollover()
+        }
+        if (shouldCreateNewPeriodBoundary) {
+            settingsRepository.clearLastPeriodSnapshot()
+        }
 
-		if (shouldCreateNewPeriodBoundary) {
-			budgetRepository.assignQueuedTransactionsToPeriod(periodId)
-		}
+        if (shouldCreateNewPeriodBoundary) {
+            budgetRepository.assignQueuedTransactionsToPeriod(periodId)
+        }
 
-		notificationScheduler.schedulePeriodEndNotification(periodEndDate)
-		return PeriodBoundaryResult(periodStartMillis = periodStartMillis, periodId = periodId)
-	}
+        notificationScheduler.schedulePeriodEndNotification(periodEndDate)
+        return PeriodBoundaryResult(periodStartMillis = periodStartMillis, periodId = periodId)
+    }
 
-	private suspend fun archivePeriod(periodId: Long, settings: BudgetSettings) {
-		val transactions = budgetRepository.getTransactions().firstOrNull() ?: emptyList()
-		val periodTransactions = transactions.filter {
-			it.periodId == periodId && !it.isDeleted
-		}
-		val totalSpent = periodTransactions.sumOf { it.amount }
-		budgetRepository.archiveCurrentPeriod(periodId, settings, totalSpent)
-	}
+    private suspend fun archivePeriod(periodId: Long, settings: BudgetSettings) {
+        val transactions = budgetRepository.getTransactions().firstOrNull() ?: emptyList()
+        val periodTransactions = transactions.filter {
+            it.periodId == periodId && !it.isDeleted
+        }
+        val totalSpent = periodTransactions.sumOf { it.amount }
+        budgetRepository.archiveCurrentPeriod(periodId, settings, totalSpent)
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -85,6 +85,7 @@ import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.SupportedCurrency
+import com.serranoie.app.minus.domain.model.SymbolPosition
 import com.serranoie.app.minus.presentation.ui.budget.BudgetUiState
 import com.serranoie.app.minus.presentation.ui.editor.calculation.evaluateCalculation
 import com.serranoie.app.minus.presentation.ui.editor.category.CategoryToolbar
@@ -549,7 +550,6 @@ private fun EditingContent(
     modifier: Modifier = Modifier
 ) {
     val currencyFormat = symbolOnlyCurrencyFormat(currencyCode)
-    val currencySymbol = SupportedCurrency.findByCode(currencyCode)?.symbol ?: "$"
 
     val hasExpressionOperators = remember(input) { input.any { it in "+-×÷" } }
 
@@ -567,44 +567,130 @@ private fun EditingContent(
     val symbolStyle = MaterialTheme.typography.titleSmallCondensed.toSpanStyle()
     val annotatedDisplayContent =
         remember(input, currencyCode, hasExpressionOperators, symbolStyle) {
+            val supportedCurrency = SupportedCurrency.findByCode(currencyCode)
+            val currencySymbol = supportedCurrency?.symbol ?: "$"
+            val isSymbolAtEnd = supportedCurrency?.symbolPosition == SymbolPosition.END
+
             if (hasExpressionOperators) {
-                val content = "$currencySymbol$input"
+                val leadingSign =
+                    if (input.startsWith("+") || input.startsWith("-")) input[0].toString() else ""
+                val remaining = if (leadingSign.isNotEmpty()) input.substring(1) else input
+                val hasInnerOperators = remaining.any { it in "+-×÷" }
+
+                val useLeadingSignOrder = leadingSign.isNotEmpty() && !hasInnerOperators
+
+                val formattedRemaining = if (useLeadingSignOrder) {
+                    val value = remaining.toBigDecimalOrNull() ?: BigDecimal.ZERO
+                    val formatted = currencyFormat.format(value)
+                    formatted.replace(currencySymbol, "").trim()
+                } else {
+                    remaining
+                }
+
                 if (currencySymbol.length > 2) {
                     AnnotatedString.Builder().apply {
-                        pushStyle(
-                            symbolStyle.copy(
-                                fontSize = 86.sp * 0.6f,
-                                fontWeight = FontWeight.Bold,
-                                baselineShift = BaselineShift(0f)
-                            )
-                        )
-                        append(currencySymbol)
-                        pop()
-                        pushStyle(SpanStyle(fontWeight = FontWeight.Light))
-                        append(input)
-                        pop()
+                        if (useLeadingSignOrder) {
+                            append(leadingSign)
+                            if (isSymbolAtEnd) {
+                                pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                                append(formattedRemaining)
+                                pop()
+                                pushStyle(
+                                    symbolStyle.copy(
+                                        fontSize = 86.sp * 0.6f,
+                                        fontWeight = FontWeight.Bold,
+                                        baselineShift = BaselineShift(0f)
+                                    )
+                                )
+                                append(currencySymbol)
+                                pop()
+                            } else {
+                                pushStyle(
+                                    symbolStyle.copy(
+                                        fontSize = 86.sp * 0.6f,
+                                        fontWeight = FontWeight.Bold,
+                                        baselineShift = BaselineShift(0f)
+                                    )
+                                )
+                                append(currencySymbol)
+                                pop()
+                                pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                                append(formattedRemaining)
+                                pop()
+                            }
+                        } else {
+                            if (isSymbolAtEnd) {
+                                pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                                append(input)
+                                pop()
+                                pushStyle(
+                                    symbolStyle.copy(
+                                        fontSize = 86.sp * 0.6f,
+                                        fontWeight = FontWeight.Bold,
+                                        baselineShift = BaselineShift(0f)
+                                    )
+                                )
+                                append(currencySymbol)
+                                pop()
+                            } else {
+                                pushStyle(
+                                    symbolStyle.copy(
+                                        fontSize = 86.sp * 0.6f,
+                                        fontWeight = FontWeight.Bold,
+                                        baselineShift = BaselineShift(0f)
+                                    )
+                                )
+                                append(currencySymbol)
+                                pop()
+                                pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                                append(input)
+                                pop()
+                            }
+                        }
                     }.toAnnotatedString()
                 } else {
+                    val content = if (useLeadingSignOrder) {
+                        if (isSymbolAtEnd) "$leadingSign$formattedRemaining$currencySymbol"
+                        else "$leadingSign$currencySymbol$formattedRemaining"
+                    } else {
+                        if (isSymbolAtEnd) "$input$currencySymbol"
+                        else "$currencySymbol$input"
+                    }
                     AnnotatedString(content)
                 }
             } else {
                 val value = input.toBigDecimalOrNull() ?: BigDecimal.ZERO
                 val formatted = currencyFormat.format(value)
-                if (currencySymbol.length > 2 && formatted.startsWith(currencySymbol)) {
-                    val amount = formatted.removePrefix(currencySymbol).trim()
+                if (currencySymbol.length > 2 && formatted.contains(currencySymbol)) {
+                    val amount = formatted.replace(currencySymbol, "").trim()
                     AnnotatedString.Builder().apply {
-                        pushStyle(
-                            symbolStyle.copy(
-                                fontSize = 86.sp * 0.6f,
-                                fontWeight = FontWeight.Bold,
-                                baselineShift = BaselineShift(0f)
+                        if (formatted.startsWith(currencySymbol)) {
+                            pushStyle(
+                                symbolStyle.copy(
+                                    fontSize = 86.sp * 0.6f,
+                                    fontWeight = FontWeight.Bold,
+                                    baselineShift = BaselineShift(0f)
+                                )
                             )
-                        )
-                        append(currencySymbol)
-                        pop()
-                        pushStyle(SpanStyle(fontWeight = FontWeight.Light))
-                        append(amount)
-                        pop()
+                            append(currencySymbol)
+                            pop()
+                            pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                            append(amount)
+                            pop()
+                        } else {
+                            pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                            append(amount)
+                            pop()
+                            pushStyle(
+                                symbolStyle.copy(
+                                    fontSize = 86.sp * 0.6f,
+                                    fontWeight = FontWeight.Bold,
+                                    baselineShift = BaselineShift(0f)
+                                )
+                            )
+                            append(currencySymbol)
+                            pop()
+                        }
                     }.toAnnotatedString()
                 } else {
                     AnnotatedString(formatted)
@@ -612,26 +698,54 @@ private fun EditingContent(
             }
         }
 
-    val annotatedCalculationResult = remember(calculationResult, currencyCode, symbolStyle) {
-        if (calculationResult == null) return@remember null
-        val content = "= $currencySymbol$calculationResult"
+    val annotatedCalculationResult = remember(calculationResult, currencyCode, symbolStyle, input) {
+        val isSimpleSignEntry = (input.startsWith("+") || input.startsWith("-")) &&
+                input.substring(1).none { it in "+-×÷" }
+
+        if (calculationResult == null || isSimpleSignEntry) return@remember null
+        val supportedCurrency = SupportedCurrency.findByCode(currencyCode)
+        val currencySymbol = supportedCurrency?.symbol ?: "$"
+        val isSymbolAtEnd = supportedCurrency?.symbolPosition == SymbolPosition.END
+
+        val isNegative = calculationResult.startsWith("-")
+        val sign = if (isNegative) "-" else ""
+        val absValue = if (isNegative) calculationResult.substring(1) else calculationResult
+
         if (currencySymbol.length > 2) {
             AnnotatedString.Builder().apply {
                 append("= ")
-                pushStyle(
-                    symbolStyle.copy(
-                        fontSize = 36.sp * 0.6f,
-                        fontWeight = FontWeight.Bold,
-                        baselineShift = BaselineShift(0f)
+                append(sign)
+                if (isSymbolAtEnd) {
+                    pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                    append(absValue)
+                    pop()
+                    pushStyle(
+                        symbolStyle.copy(
+                            fontSize = 36.sp * 0.6f,
+                            fontWeight = FontWeight.Bold,
+                            baselineShift = BaselineShift(0f)
+                        )
                     )
-                )
-                append(currencySymbol)
-                pop()
-                pushStyle(SpanStyle(fontWeight = FontWeight.Light))
-                append(calculationResult)
-                pop()
+                    append(currencySymbol)
+                    pop()
+                } else {
+                    pushStyle(
+                        symbolStyle.copy(
+                            fontSize = 36.sp * 0.6f,
+                            fontWeight = FontWeight.Bold,
+                            baselineShift = BaselineShift(0f)
+                        )
+                    )
+                    append(currencySymbol)
+                    pop()
+                    pushStyle(SpanStyle(fontWeight = FontWeight.Light))
+                    append(absValue)
+                    pop()
+                }
             }.toAnnotatedString()
         } else {
+            val content = if (isSymbolAtEnd) "= $sign$absValue$currencySymbol"
+            else "= $sign$currencySymbol$absValue"
             AnnotatedString(content)
         }
     }

--- a/app/src/test/java/com/serranoie/app/minus/data/csv/MinusCsvParserTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/data/csv/MinusCsvParserTest.kt
@@ -1,9 +1,11 @@
 package com.serranoie.app.minus.data.csv
 
+import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.math.BigDecimal
 import java.nio.charset.StandardCharsets
 
 class MinusCsvParserTest {
@@ -13,29 +15,44 @@ class MinusCsvParserTest {
     @Test
     fun parse_validRows_returnsRows() {
         val csv = """
-            date,amount,comment,is_recurrent,frequency,end_date,sub_day,id
-            2026-03-10 09:30,10.50,Coffee,0,,, ,1
-            2026-03-11 10:00,25.00,Netflix,1,MONTHLY,2026-12-31,15,2
+            date,amount,comment,is_recurrent,frequency,end_date,sub_day,id,is_credit,is_credit_paid,period_id,budget_total,budget_period,budget_start_date,budget_end_date,currency_code,days_in_period,rollover_enabled,rollover_carry_forward,remaining_budget_strategy,current_period_started_at_millis,current_period_id,credit_card_cutoff_day,split_mode
+            2026-03-10 09:30,10.50,Coffee,0,,,,1,0,0,7,,,,,,,,,,,,
+            2026-03-11 10:00,25.00,Netflix,1,MONTHLY,2026-12-31,15,2,0,0,7,,,,,,,,,,,,
         """.trimIndent()
 
-        val (rows, errors) = parser.parse(ByteArrayInputStream(csv.toByteArray(StandardCharsets.UTF_8)))
+        val payload = parser.parse(ByteArrayInputStream(csv.toByteArray(StandardCharsets.UTF_8)))
+        val rows = payload.rows
 
         assertEquals(2, rows.size)
-//        assertTrue(errors.isEmpty())
         assertEquals("Coffee", rows[0].comment)
         assertEquals(1L, rows[0].id)
+        assertEquals(7L, rows[0].periodId)
     }
 
     @Test
     fun parse_invalidAmount_discardsRow() {
         val csv = """
-            date,amount,comment,is_recurrent,frequency,end_date,sub_day,id
-            2026-03-10 09:30,0.00,Invalid,0,,, ,1
+            date,amount,comment,is_recurrent,frequency,end_date,sub_day,id,is_credit,is_credit_paid,period_id,budget_total,budget_period,budget_start_date,budget_end_date,currency_code,days_in_period,rollover_enabled,rollover_carry_forward,remaining_budget_strategy,current_period_started_at_millis,current_period_id,credit_card_cutoff_day,split_mode
+            2026-03-10 09:30,0.00,Invalid,0,,,,1,0,0,7,,,,,,,,,,,,
         """.trimIndent()
 
-        val (rows, errors) = parser.parse(ByteArrayInputStream(csv.toByteArray(StandardCharsets.UTF_8)))
+        val payload = parser.parse(ByteArrayInputStream(csv.toByteArray(StandardCharsets.UTF_8)))
+        val rows = payload.rows
 
         assertTrue(rows.isEmpty())
-//        assertEquals(1, errors.size)
+    }
+
+    @Test
+    fun parse_metadata_with_split_mode_returnsCorrectSettings() {
+        val csv = """
+            date,amount,comment,is_recurrent,frequency,end_date,sub_day,id,is_credit,is_credit_paid,budget_total,budget_period,budget_start_date,budget_end_date,currency_code,days_in_period,rollover_enabled,rollover_carry_forward,remaining_budget_strategy,current_period_started_at_millis,current_period_id,credit_card_cutoff_day,split_mode
+            __META__,,,,,,,,,,1000.00,MONTHLY,2026-01-01,2026-01-31,USD,31,0,0,ASK_ALWAYS,1710000000000,101,3,DYNAMIC
+        """.trimIndent()
+
+        val payload = parser.parse(ByteArrayInputStream(csv.toByteArray(StandardCharsets.UTF_8)))
+        
+        val meta = payload.metadata
+        assertEquals(BigDecimal("1000.00"), meta?.budgetSettings?.totalBudget)
+        assertEquals(BudgetSplitMode.DYNAMIC, meta?.budgetSettings?.splitMode)
     }
 }


### PR DESCRIPTION
## Description
When generating an export file, current and past periods didn't have the separator/ID to match what period was in.

## Change strategy
Integrated period_id and split_mode into the CSV export file to match and split what transaction were made on each period.

## Working demo
_CSV file with added columns/data_
<img width="708" height="93" alt="image" src="https://github.com/user-attachments/assets/69886286-72dd-45f6-944e-986ae802bc5b" />


## Testing
- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
Shouldn't affect users with ongoing periods or modify existing data.
