### PR TITLE
feat: reconstruct historical periods and enhance analytics visualization

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -105,6 +105,7 @@ private val STABLE_DEFAULT_DATE = Date(0)
 data class AnalyticsState(
     val periodFinished: Boolean = false,
     val transactions: List<Transaction> = emptyList(),
+    val allTransactions: List<Transaction> = emptyList(),
     val spends: List<Transaction> = emptyList(),
     val recurringInPeriod: List<Transaction> = emptyList(),
     val oneTimeSpends: List<Transaction> = emptyList(),
@@ -490,6 +491,7 @@ fun Analytics(
         ) {
             com.serranoie.app.minus.presentation.ui.analytics.dialogs.PastPeriodsBottomSheet(
                 periods = archivedBudgets,
+                allTransactions = state.allTransactions,
                 onPeriodClick = { archivedBudget ->
                     scope.launch {
                         sheetState.hide()

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
@@ -92,18 +92,22 @@ class AnalyticsViewModel @Inject constructor(
                 val rollover = args[5] as Pair<BigDecimal, Boolean>
 
                 val currentPeriodId = periodBoundary.second
+                val reconstructedArchives = reconstructHistory(transactions, archives, settings)
+                val allArchives = (archives + reconstructedArchives).distinctBy { it.periodId }
+                    .sortedByDescending { it.startDate }
+
                 val updatedState = _uiState.value.copy(
                     isLoading = false,
                     budgetSettings = settings,
                     allTransactions = transactions,
-                    archivedBudgets = archives,
+                    archivedBudgets = allArchives,
                     currentPeriodId = currentPeriodId,
                     userSettings = userSettings,
                     rolloverAmount = rollover.first,
                     rolloverCarryForward = rollover.second,
                     displayState = if (_uiState.value.selectedPeriodId != null && _uiState.value.selectedPeriodId != currentPeriodId) {
                         buildHistoricalDisplayState(
-                            _uiState.value.selectedPeriodId!!, transactions, archives
+                            _uiState.value.selectedPeriodId!!, transactions, allArchives
                         )
                     } else {
                         buildDisplayState(
@@ -120,6 +124,64 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
+    private fun reconstructHistory(
+        allTransactions: List<Transaction>,
+        existingArchives: List<ArchivedBudget>,
+        currentSettings: BudgetSettings?
+    ): List<ArchivedBudget> {
+        if (currentSettings == null) return emptyList()
+
+        val orphaned = allTransactions.filter { it.periodId <= 0L && !it.isDeleted }
+        if (orphaned.isEmpty()) return emptyList()
+
+        val currentPeriodStart = currentSettings.startDate
+        val currentPeriodEnd = currentSettings.getPeriodEndDate()
+        val dailyBudget = currentSettings.calculateDailyBudget()
+
+        return orphaned
+            .filter { tx ->
+                val date = tx.date?.toLocalDate() ?: return@filter false
+                date.isBefore(currentPeriodStart) || date.isAfter(currentPeriodEnd)
+            }
+            .groupBy { tx ->
+                val date = tx.date?.toLocalDate() ?: return@groupBy "0-0"
+                "${date.year}-${date.monthValue}"
+            }
+            .mapNotNull { (key, txs) ->
+                val parts = key.split("-")
+                if (parts.size < 2) return@mapNotNull null
+                val year = parts[0].toInt()
+                val month = parts[1].toInt()
+
+                val actualStartDate = txs.mapNotNull { it.date?.toLocalDate() }.minOrNull()
+                    ?: LocalDate.of(year, month, 1)
+                val actualEndDate = txs.mapNotNull { it.date?.toLocalDate() }.maxOrNull()
+                    ?: actualStartDate.plusMonths(1).minusDays(1)
+
+                val hasOverlap = existingArchives.any { existing ->
+                    val eStart = existing.startDate
+                    val eEnd = existing.endDate
+                    actualStartDate <= eEnd && actualEndDate >= eStart
+                }
+
+                if (hasOverlap) return@mapNotNull null
+
+                val virtualId = -(year.toLong() * 100 + month.toLong())
+                val daysInMonth = java.time.temporal.ChronoUnit.DAYS.between(actualStartDate, actualEndDate.plusDays(1))
+
+                ArchivedBudget(
+                    periodId = virtualId,
+                    totalBudget = dailyBudget.multiply(BigDecimal(daysInMonth)),
+                    spentAmount = txs.sumOf { it.amount },
+                    startDate = actualStartDate,
+                    endDate = actualEndDate,
+                    currencyCode = currentSettings.currencyCode,
+                    periodType = com.serranoie.app.minus.domain.model.BudgetPeriod.MONTHLY,
+                    createdAt = System.currentTimeMillis()
+                )
+            }
+    }
+
     private fun buildHistoricalDisplayState(
         periodId: Long, allTransactions: List<Transaction>, archives: List<ArchivedBudget>
     ): AnalyticsState {
@@ -131,7 +193,15 @@ class AnalyticsViewModel @Inject constructor(
             rolloverAmountFromPref = _uiState.value.rolloverAmount
         )
 
-        val transactions = allTransactions.filter { it.periodId == periodId && !it.isDeleted }
+        val isVirtual = periodId < 0L
+        val transactions = if (isVirtual) {
+            allTransactions.filter { tx ->
+                val date = tx.date?.toLocalDate() ?: return@filter false
+                !date.isBefore(archive.startDate) && !date.isAfter(archive.endDate) && !tx.isDeleted
+            }
+        } else {
+            allTransactions.filter { it.periodId == periodId && !it.isDeleted }
+        }
         val (paidRecurring, upcomingRecurring, oneTimeSpends) = splitRecurringAndOneTime(
             allTransactions = allTransactions,
             filteredTransactions = transactions,
@@ -159,6 +229,7 @@ class AnalyticsViewModel @Inject constructor(
         return AnalyticsState(
             periodFinished = true,
             transactions = actualSpends,
+            allTransactions = allTransactions,
             spends = actualSpends,
             recurringInPeriod = (paidRecurring + upcomingRecurring).distinctBy { it.id },
             oneTimeSpends = oneTimeSpends,
@@ -255,6 +326,7 @@ class AnalyticsViewModel @Inject constructor(
         return AnalyticsState(
             periodFinished = periodFinished,
             transactions = transactions,
+            allTransactions = allTransactions,
             spends = transactions,
             recurringInPeriod = (paidRecurring + upcomingRecurring).distinctBy { it.id },
             oneTimeSpends = oneTimeSpends,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/PastPeriodsBottomSheet.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/dialogs/PastPeriodsBottomSheet.kt
@@ -2,18 +2,28 @@
 
 package com.serranoie.app.minus.presentation.ui.analytics.dialogs
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -23,23 +33,29 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.serranoie.app.minus.R
 import com.serranoie.app.minus.domain.model.ArchivedBudget
 import com.serranoie.app.minus.domain.model.BudgetPeriod
+import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.labelMediumCondensed
+import com.serranoie.app.minus.presentation.util.calcAdaptiveFont
+import com.serranoie.app.minus.presentation.util.combineColors
 import com.serranoie.app.minus.presentation.util.formatCurrencySymbolOnly
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -48,6 +64,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun PastPeriodsBottomSheet(
     periods: List<ArchivedBudget>,
+    allTransactions: List<Transaction> = emptyList(),
     onPeriodClick: (ArchivedBudget) -> Unit,
 ) {
     Column(
@@ -82,7 +99,10 @@ fun PastPeriodsBottomSheet(
             ) {
                 items(periods) { period ->
                     ArchivedPeriodCard(
-                        period = period, onClick = { onPeriodClick(period) })
+                        period = period,
+                        allTransactions = allTransactions,
+                        onClick = { onPeriodClick(period) }
+                    )
                 }
             }
         }
@@ -91,16 +111,37 @@ fun PastPeriodsBottomSheet(
 
 @Composable
 private fun ArchivedPeriodCard(
-    period: ArchivedBudget, onClick: () -> Unit
+    period: ArchivedBudget,
+    allTransactions: List<Transaction>,
+    onClick: () -> Unit
 ) {
+    val isVirtual = period.periodId < 0L
+
+    val periodTransactions = remember(period, allTransactions) {
+        val filteredById =
+            allTransactions.filter { it.periodId == period.periodId && !it.isDeleted && period.periodId > 0 }
+        if (filteredById.isNotEmpty()) {
+            filteredById
+        } else {
+            allTransactions.filter { tx ->
+                val date = tx.date?.toLocalDate() ?: return@filter false
+                !date.isBefore(period.startDate) && !date.isAfter(period.endDate) && !tx.isDeleted
+            }
+        }
+    }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() },
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        )
+            containerColor = combineColors(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.surfaceVariant,
+                t = 0.3f,
+            ),
+        ),
     ) {
         Column(
             modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -130,55 +171,259 @@ private fun ArchivedPeriodCard(
                     }
                 }
 
-                StatusChip(period)
+                if (!isVirtual) {
+                    StatusChip(period)
+                }
             }
 
+            val density = LocalDensity.current
+            val spentFormatted = formatCurrencySymbolOnly(period.spentAmount, period.currencyCode)
+            val budgetFormatted = formatCurrencySymbolOnly(period.totalBudget, period.currencyCode)
+
             Row(
-                modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = stringResource(R.string.past_periods_spent_label),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Text(
-                        text = formatCurrencySymbolOnly(period.spentAmount, period.currencyCode),
-                        style = MaterialTheme.typography.titleLargeEmphasized,
-                        fontWeight = FontWeight.ExtraBold,
-                        color = if (period.isOverBudget) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
-                    )
+                    BoxWithConstraints {
+                        val adaptiveFontSize = calcAdaptiveFont(
+                            height = 100f,
+                            width = with(density) { maxWidth.toPx() },
+                            minFontSize = 14.sp,
+                            maxFontSize = 24.sp,
+                            text = spentFormatted,
+                            style = MaterialTheme.typography.titleLargeEmphasized
+                        )
+                        Text(
+                            text = spentFormatted,
+                            style = MaterialTheme.typography.titleLargeEmphasized.copy(
+                                fontSize = adaptiveFontSize,
+                                fontWeight = FontWeight.ExtraBold
+                            ),
+                            color = if (!isVirtual && period.isOverBudget) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            softWrap = false
+                        )
+                    }
                 }
 
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        text = stringResource(R.string.past_periods_limit_label),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                if (!isVirtual) {
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .width(1.dp)
+                            .height(36.dp)
+                            .background(MaterialTheme.colorScheme.outlineVariant)
                     )
-                    Text(
-                        text = "of ${
-                            formatCurrencySymbolOnly(
-                                period.totalBudget, period.currencyCode
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.budget),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        BoxWithConstraints {
+                            val adaptiveFontSize = calcAdaptiveFont(
+                                height = 100f,
+                                width = with(density) { maxWidth.toPx() },
+                                minFontSize = 14.sp,
+                                maxFontSize = 24.sp,
+                                text = budgetFormatted,
+                                style = MaterialTheme.typography.titleLargeEmphasized
                             )
-                        }",
-                        style = MaterialTheme.typography.titleLargeEmphasized,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                            Text(
+                                text = budgetFormatted,
+                                style = MaterialTheme.typography.titleLargeEmphasized.copy(
+                                    fontSize = adaptiveFontSize
+                                ),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                softWrap = false
+                            )
+                        }
+                    }
                 }
             }
 
-            val progress =
-                (period.spentAmount.toFloat() / period.totalBudget.toFloat()).coerceIn(0f, 1f)
-            LinearWavyProgressIndicator(
-                progress = { progress },
-                modifier = Modifier.fillMaxWidth(),
-                color = if (period.isOverBudget) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            CategoryDistributionBar(
+                transactions = periodTransactions,
+                totalBudget = if (isVirtual) null else period.totalBudget,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
 }
+
+@Composable
+private fun CategoryDistributionBar(
+    transactions: List<Transaction>,
+    totalBudget: BigDecimal?,
+    modifier: Modifier = Modifier
+) {
+    val uncategorizedLabel = stringResource(R.string.categories_chart_uncategorized)
+    val recurrentLabel = stringResource(R.string.tutorial_recurrent_title)
+
+    val data = remember(transactions, totalBudget, uncategorizedLabel, recurrentLabel) {
+        val recurrentTotal = transactions.filter { it.isRecurrent }.sumOf { it.amount }
+        val categoryTotals = transactions
+            .filter { !it.isRecurrent }
+            .groupBy { it.comment.trim().ifEmpty { uncategorizedLabel } }
+            .mapValues { (_, txs) -> txs.sumOf { it.amount } }
+            .toList()
+            .sortedByDescending { it.second }
+            .take(4)
+
+        val totalSpent = transactions.sumOf { it.amount }
+        val base = totalBudget ?: totalSpent.coerceAtLeast(BigDecimal.ONE)
+        val isOverBudget = totalBudget != null && totalSpent > totalBudget
+
+        val segments = mutableListOf<DistributionSegment>()
+
+        // Recurrent first
+        if (recurrentTotal > BigDecimal.ZERO) {
+            segments.add(
+                DistributionSegment(
+                    name = recurrentLabel,
+                    amount = recurrentTotal,
+                    isRecurrent = true
+                )
+            )
+        }
+
+        // Categories
+        categoryTotals.forEach { (name, amount) ->
+            segments.add(
+                DistributionSegment(
+                    name = name,
+                    amount = amount,
+                    isRecurrent = false
+                )
+            )
+        }
+
+        val totalWeight = base.coerceAtLeast(totalSpent).toFloat()
+
+        DistributionData(
+            segments = segments,
+            totalSpent = totalSpent,
+            totalBudget = totalBudget,
+            totalWeight = totalWeight,
+            isOverBudget = isOverBudget
+        )
+    }
+
+    val colors = listOf(
+        Color(0xFF5FC7E7),
+        Color(0xFF75E584),
+        Color(0xFFFFD386),
+        Color(0xFFEF7564),
+        Color(0xFF64B5F6),
+        Color(0xFFAED581),
+        Color(0xFFFFB74D),
+        Color(0xFFBA68C8),
+        Color(0xFF4DB6AC),
+        Color(0xFF9575CD),
+        Color(0xFFF06292),
+    )
+    val recurrentColor = MaterialTheme.colorScheme.outline
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(14.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.65f))
+        ) {
+            Row(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                data.segments.forEachIndexed { index, segment ->
+                    val weight = (segment.amount.toFloat() / data.totalWeight).coerceAtLeast(0.01f)
+                    val color =
+                        if (segment.isRecurrent) recurrentColor else colors.getOrElse(index - if (data.segments.any { it.isRecurrent }) 1 else 0) { MaterialTheme.colorScheme.outlineVariant }
+
+                    Box(
+                        modifier = Modifier
+                            .weight(weight)
+                            .fillMaxHeight()
+                            .clip(CircleShape)
+                            .background(color)
+                            .then(
+                                if (segment.isRecurrent) {
+                                    Modifier.border(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
+                                        CircleShape
+                                    )
+                                } else {
+                                    Modifier
+                                }
+                            )
+                    )
+                }
+
+                if (data.totalBudget != null && data.totalSpent < data.totalBudget) {
+                    val remaining = (data.totalBudget - data.totalSpent).toFloat()
+                    if (remaining > 0) {
+                        Box(
+                            modifier = Modifier
+                                .weight(remaining / data.totalWeight)
+                                .fillMaxHeight()
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                        )
+                    }
+                }
+            }
+        }
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            itemsIndexed(data.segments) { index, segment ->
+                val color =
+                    if (segment.isRecurrent) recurrentColor else colors.getOrElse(index - if (data.segments.any { it.isRecurrent }) 1 else 0) { MaterialTheme.colorScheme.outlineVariant }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = segment.name,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = color,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class DistributionSegment(
+    val name: String,
+    val amount: BigDecimal,
+    val isRecurrent: Boolean
+)
+
+private data class DistributionData(
+    val segments: List<DistributionSegment>,
+    val totalSpent: BigDecimal,
+    val totalBudget: BigDecimal?,
+    val totalWeight: Float,
+    val isOverBudget: Boolean
+)
 
 @Composable
 private fun StatusChip(period: ArchivedBudget) {
@@ -230,38 +475,80 @@ private fun StatusChip(period: ArchivedBudget) {
 @Preview(showBackground = true)
 @Composable
 private fun PastPeriodsBottomSheetPreview() {
+    val today = LocalDate.now()
+    val sampleTransactions = listOf(
+        Transaction(
+            amount = BigDecimal("150.00"),
+            comment = "Netflix",
+            isRecurrent = true,
+            date = today.minusDays(5).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("50.00"),
+            comment = "Food",
+            date = today.minusDays(5).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("20.00"),
+            comment = "Coffee",
+            date = today.minusDays(5).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("100.00"),
+            comment = "Rent",
+            isRecurrent = true,
+            date = today.minusDays(40).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("30.00"),
+            comment = "Gas",
+            date = today.minusDays(70).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("80.00"),
+            comment = "Internet",
+            date = LocalDate.of(2026, 6, 15).atStartOfDay()
+        ),
+        Transaction(
+            amount = BigDecimal("70.00"),
+            comment = "Other",
+            date = LocalDate.of(2026, 6, 20).atStartOfDay()
+        ),
+    )
     val samplePeriods = listOf(
         ArchivedBudget(
             periodId = 1L,
             totalBudget = BigDecimal("1000.00"),
             spentAmount = BigDecimal("850.00"),
-            startDate = LocalDate.now().minusDays(30),
-            endDate = LocalDate.now().minusDays(1),
+            startDate = today.minusDays(30),
+            endDate = today.minusDays(1),
+            currencyCode = "USD",
+            periodType = BudgetPeriod.MONTHLY
+        ), ArchivedBudget(
+            periodId = -202606L,
+            totalBudget = BigDecimal("1000.00"),
+            spentAmount = BigDecimal("150.00"),
+            startDate = LocalDate.of(2026, 6, 1),
+            endDate = LocalDate.of(2026, 6, 30),
             currencyCode = "USD",
             periodType = BudgetPeriod.MONTHLY
         ), ArchivedBudget(
             periodId = 2L,
             totalBudget = BigDecimal("500.00"),
             spentAmount = BigDecimal("600.00"),
-            startDate = LocalDate.now().minusDays(45),
-            endDate = LocalDate.now().minusDays(31),
+            startDate = today.minusDays(45),
+            endDate = today.minusDays(31),
             currencyCode = "USD",
             periodType = BudgetPeriod.BIWEEKLY
-        ), ArchivedBudget(
-            periodId = 3L,
-            totalBudget = BigDecimal("1200.00"),
-            spentAmount = BigDecimal("1200.00"),
-            startDate = LocalDate.now().minusDays(60),
-            endDate = LocalDate.now().minusDays(46),
-            currencyCode = "USD",
-            periodType = BudgetPeriod.MONTHLY
         )
     )
 
     MinusTheme {
         Surface {
             PastPeriodsBottomSheet(
-                periods = samplePeriods, onPeriodClick = {})
+                periods = samplePeriods,
+                allTransactions = sampleTransactions,
+                onPeriodClick = {})
         }
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/CalendarHeatmap.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/CalendarHeatmap.kt
@@ -70,575 +70,577 @@ import java.util.Date
 import java.util.Locale
 
 data class SpendingDay(
-	val date: Date,
-	val spends: List<Transaction>,
-	val budget: BigDecimal,
-	val spending: BigDecimal,
+    val date: Date,
+    val spends: List<Transaction>,
+    val budget: BigDecimal,
+    val spending: BigDecimal,
 )
 
 @Composable
 fun CalendarHeatmap(
-	modifier: Modifier = Modifier,
-	budget: BigDecimal,
-	transactions: List<Transaction>,
-	startDate: Date,
-	finishDate: Date,
-	actualFinishDate: Date? = null,
-	onDayClick: (LocalDate) -> Unit = {},
+    modifier: Modifier = Modifier,
+    budget: BigDecimal,
+    transactions: List<Transaction>,
+    startDate: Date,
+    finishDate: Date,
+    actualFinishDate: Date? = null,
+    onDayClick: (LocalDate) -> Unit = {},
 ) {
-	val context = LocalContext.current
+    val context = LocalContext.current
+    val spendingDays = remember(transactions) {
+        val days: MutableMap<LocalDate, SpendingDay> = mutableMapOf()
+        val groupedByDate = transactions.filter { it.date != null && !it.isDeleted }
+            .groupBy { it.date!!.toLocalDate() }
 
-	val spendingDays = remember(transactions) {
-		val days: MutableMap<LocalDate, SpendingDay> = mutableMapOf()
+        groupedByDate.forEach { (date, txs) ->
+            val totalSpending = txs.sumOf { it.amount }
+            days[date] = SpendingDay(
+                date = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                spends = txs,
+                budget = budget,
+                spending = totalSpending,
+            )
+        }
 
-		// Group transactions by date
-		val groupedByDate = transactions.filter { it.date != null && !it.isDeleted }
-			.groupBy { it.date!!.toLocalDate() }
+        days
+    }
+    val maxSpendsPerDay = remember(spendingDays) {
+        spendingDays.values.maxOfOrNull { it.spends.size }?.coerceAtLeast(1) ?: 1
+    }
 
-		groupedByDate.forEach { (date, txs) ->
-			val totalSpending = txs.sumOf { it.amount }
-			days[date] = SpendingDay(
-				date = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
-				spends = txs,
-				budget = budget,
-				spending = totalSpending,
-			)
-		}
+    val calendarState = remember(startDate, finishDate, actualFinishDate) {
+        CalendarState(
+            context = context,
+            disableBeforeDate = startDate,
+            disableAfterDate = actualFinishDate ?: finishDate,
+        )
+    }
 
-		days
-	}
-	val maxSpendsPerDay = remember(spendingDays) {
-		spendingDays.values.maxOfOrNull { it.spends.size }?.coerceAtLeast(1) ?: 1
-	}
+    Card(
+        modifier = modifier, shape = RoundedCornerShape(22.dp), colors = CardDefaults.cardColors(
+            containerColor = combineColors(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.surfaceVariant,
+                t = 0.3f,
+            ),
+        )
+    ) {
+        Row(Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
+            Icon(
+                modifier = Modifier
+                    .padding(top = 0.5.dp)
+                    .size(14.dp),
+                imageVector = Icons.Rounded.Info,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                modifier = Modifier.basicMarquee(),
+                text = stringResource(R.string.calendar_heatmap_info_text),
+                style = MaterialTheme.typography.labelSmallCondensed.copy(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.8f),
+                    fontWeight = FontWeight.W100,
+                ),
+            )
+        }
+        Layout(
+            modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
+            measurePolicy = verticalGridMeasurePolicy(7),
+            content = {
+                val calendarUiState = calendarState.calendarUiState.value
 
-	val calendarState = remember(startDate, finishDate, actualFinishDate) {
-		CalendarState(
-			context = context,
-			disableBeforeDate = startDate,
-			disableAfterDate = actualFinishDate ?: finishDate,
-		)
-	}
+                calendarState.listMonths.forEach { month ->
+                    MonthHeader(
+                        modifier = Modifier.layoutId("fullWidth"), yearMonth = month.yearMonth
+                    )
 
-	Card(
-		modifier = modifier, shape = RoundedCornerShape(22.dp), colors = CardDefaults.cardColors(
-			containerColor = combineColors(
-				MaterialTheme.colorScheme.surface,
-				MaterialTheme.colorScheme.surfaceVariant,
-				t = 0.3f,
-			),
-		)
-	) {
-		Row(Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
-			Icon(
-				modifier = Modifier
-					.padding(top = 0.5.dp)
-					.size(14.dp),
-				imageVector = Icons.Rounded.Info,
-				tint = MaterialTheme.colorScheme.onSurfaceVariant,
-				contentDescription = null,
-			)
-			Spacer(modifier = Modifier.width(4.dp))
-			Text(
-				modifier = Modifier.basicMarquee(),
-				text = stringResource(R.string.calendar_heatmap_info_text),
-				style = MaterialTheme.typography.labelSmallCondensed.copy(
-					color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.8f),
-					fontWeight = FontWeight.W100,
-				),
-			)
-		}
-		Layout(
-			modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
-			measurePolicy = verticalGridMeasurePolicy(7),
-			content = {
-				val calendarUiState = calendarState.calendarUiState.value
+                    DaysOfWeek(
+                        modifier = Modifier.layoutId("fullWidth")
+                    )
 
-				calendarState.listMonths.forEach { month ->
-					MonthHeader(
-						modifier = Modifier.layoutId("fullWidth"), yearMonth = month.yearMonth
-					)
+                    month.weeks.forEach { week ->
+                        val beginningWeek = week.yearMonth.atDay(1).plusWeeks(week.number.toLong())
+                        val currentDay =
+                            beginningWeek.with(TemporalAdjusters.previousOrSame(getWeek()[0]))
 
-					DaysOfWeek(
-						modifier = Modifier.layoutId("fullWidth")
-					)
+                        if (currentDay.plusDays(6)
+                                .isAfter(calendarUiState.disabledBefore) && currentDay.isBefore(
+                                calendarUiState.disabledAfter!!.plusDays(1)
+                            )
+                        ) {
+                            WeekRow(
+                                modifier = Modifier.layoutId("fullWidth"),
+                                week = week,
+                                calendarUiState = calendarUiState,
+                                spendingDays = spendingDays,
+                                budget = budget,
+                                maxSpendsPerDay = maxSpendsPerDay,
+                                onDayClick = onDayClick,
+                            )
+                        }
+                    }
+                }
+            })
 
-					month.weeks.forEach { week ->
-						val beginningWeek = week.yearMonth.atDay(1).plusWeeks(week.number.toLong())
-						val currentDay =
-							beginningWeek.with(TemporalAdjusters.previousOrSame(getWeek()[0]))
-
-						if (currentDay.plusDays(6)
-								.isAfter(calendarUiState.disabledBefore) && currentDay.isBefore(
-								calendarUiState.disabledAfter!!.plusDays(1)
-							)
-						) {
-							WeekRow(
-								modifier = Modifier.layoutId("fullWidth"),
-								week = week,
-								calendarUiState = calendarUiState,
-								spendingDays = spendingDays,
-								budget = budget,
-								maxSpendsPerDay = maxSpendsPerDay,
-								onDayClick = onDayClick,
-							)
-						}
-					}
-				}
-			})
-
-		Box(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(end = 16.dp, bottom = 12.dp),
-			contentAlignment = Alignment.BottomEnd
-		) {
-			HeatmapLegend()
-		}
-	}
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 16.dp, bottom = 12.dp),
+            contentAlignment = Alignment.BottomEnd
+        ) {
+            HeatmapLegend()
+        }
+    }
 
 }
 
 @Composable
 private fun HeatmapLegend() {
-	Row(
-		verticalAlignment = Alignment.CenterVertically,
-		modifier = Modifier.padding(top = 4.dp)
-	) {
-		Text(
-			text = stringResource(R.string.heatmap_legend_less),
-			style = MaterialTheme.typography.labelSmallCondensed,
-			color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-		)
-		Spacer(modifier = Modifier.width(4.dp))
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(top = 4.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.heatmap_legend_less),
+            style = MaterialTheme.typography.labelSmallCondensed,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+        )
+        Spacer(modifier = Modifier.width(4.dp))
 
-		listOf(0.0f, 0.25f, 0.5f, 0.75f, 1.0f).forEach { ratio ->
-			val color = if (ratio == 0f) Color.Transparent else {
-				val normalizedHeat = ratio.coerceIn(0f, 1.2f)
-				val heatColor = when {
-					normalizedHeat <= 0.5f -> lerp(colorGood, colorNotGood, normalizedHeat / 0.5f)
-					normalizedHeat <= 1.0f -> lerp(colorNotGood, colorBad, (normalizedHeat - 0.5f) / 0.5f)
-					else -> colorBad
-				}
-				val heatAlpha = 0.25f + (normalizedHeat * 0.55f)
-				heatColor.copy(alpha = heatAlpha)
-			}
+        listOf(0.0f, 0.25f, 0.5f, 0.75f, 1.0f).forEach { ratio ->
+            val color = if (ratio == 0f) Color.Transparent else {
+                val normalizedHeat = ratio.coerceIn(0f, 1.2f)
+                val heatColor = when {
+                    normalizedHeat <= 0.5f -> lerp(colorGood, colorNotGood, normalizedHeat / 0.5f)
+                    normalizedHeat <= 1.0f -> lerp(
+                        colorNotGood,
+                        colorBad,
+                        (normalizedHeat - 0.5f) / 0.5f
+                    )
 
-			Box(
-				modifier = Modifier
-					.size(10.dp)
-					.padding(1.dp)
-					.background(color, shape = RoundedCornerShape(2.dp))
-					.border(
-						width = 0.5.dp,
-						color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-						shape = RoundedCornerShape(2.dp)
-					)
-			)
-		}
+                    else -> colorBad
+                }
+                val heatAlpha = 0.25f + (normalizedHeat * 0.55f)
+                heatColor.copy(alpha = heatAlpha)
+            }
 
-		Spacer(modifier = Modifier.width(4.dp))
-		Text(
-			text = stringResource(R.string.heatmap_legend_more),
-			style = MaterialTheme.typography.labelSmallCondensed,
-			color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-		)
-	}
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .padding(1.dp)
+                    .background(color, shape = RoundedCornerShape(2.dp))
+                    .border(
+                        width = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                        shape = RoundedCornerShape(2.dp)
+                    )
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = stringResource(R.string.heatmap_legend_more),
+            style = MaterialTheme.typography.labelSmallCondensed,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+        )
+    }
 }
 
 @Composable
 internal fun MonthHeader(modifier: Modifier = Modifier, yearMonth: YearMonth) {
-	Row(modifier = modifier.height(CELL_SIZE), verticalAlignment = Alignment.Bottom) {
-		Text(
-			modifier = Modifier
-				.padding(start = 8.dp)
-				.weight(1f),
-			text = prettyYearMonth(yearMonth),
-			style = MaterialTheme.typography.titleMediumEmphasized,
-			color = MaterialTheme.colorScheme.onSurface,
-		)
-	}
+    Row(modifier = modifier.height(CELL_SIZE), verticalAlignment = Alignment.Bottom) {
+        Text(
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .weight(1f),
+            text = prettyYearMonth(yearMonth),
+            style = MaterialTheme.typography.titleMediumEmphasized,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }
 
 fun verticalGridMeasurePolicy(columns: Int) = MeasurePolicy { measurables, constraints ->
-	val cellWidth = constraints.maxWidth / columns
-	val cells = emptyList<Int>().toMutableList()
-	var cellsCount = 0
+    val cellWidth = constraints.maxWidth / columns
+    val cells = emptyList<Int>().toMutableList()
+    var cellsCount = 0
 
-	val placeables = measurables.mapIndexed { index, it ->
-		cells.add(if (it.layoutId == "fullWidth") columns else 1)
-		cellsCount += cells[index]
+    val placeables = measurables.mapIndexed { index, it ->
+        cells.add(if (it.layoutId == "fullWidth") columns else 1)
+        cellsCount += cells[index]
 
-		it.measure(
-			constraints.copy(
-				maxWidth = cellWidth * cells[index],
-			)
-		)
-	}
+        it.measure(
+            constraints.copy(
+                maxWidth = cellWidth * cells[index],
+            )
+        )
+    }
 
 
-	layout(
-		constraints.maxWidth,
-		((cellsCount + columns - 1) / columns) * CELL_SIZE.roundToPx(),
-	) {
-		var cellsOffset = 0
+    layout(
+        constraints.maxWidth,
+        ((cellsCount + columns - 1) / columns) * CELL_SIZE.roundToPx(),
+    ) {
+        var cellsOffset = 0
 
-		placeables.forEachIndexed { index, it ->
-			val cellIndex = (cells.getOrNull(index - 1) ?: 0) + cellsOffset
+        placeables.forEachIndexed { index, it ->
+            val cellIndex = (cells.getOrNull(index - 1) ?: 0) + cellsOffset
 
-			cellsOffset = cellIndex
-			it.place(
-				cellWidth * (cellIndex % columns), CELL_SIZE.roundToPx() * (cellIndex / columns), 0f
-			)
-		}
-	}
+            cellsOffset = cellIndex
+            it.place(
+                cellWidth * (cellIndex % columns), CELL_SIZE.roundToPx() * (cellIndex / columns), 0f
+            )
+        }
+    }
 }
 
 
 @Composable
 internal fun DaysOfWeek(modifier: Modifier = Modifier) {
-	val week = getWeek()
+    val week = getWeek()
 
-	Row(modifier = modifier) {
-		for (day in week) {
-			DayOfWeekHeading(
-				day = prettyWeekDay(day), modifier = Modifier.weight(1f)
-			)
-		}
-	}
+    Row(modifier = modifier) {
+        for (day in week) {
+            DayOfWeekHeading(
+                day = prettyWeekDay(day), modifier = Modifier.weight(1f)
+            )
+        }
+    }
 }
 
 
 data class Week(
-	val number: Int, val yearMonth: YearMonth
+    val number: Int, val yearMonth: YearMonth
 )
 
 @Composable
 fun WeekRow(
-	modifier: Modifier = Modifier,
-	week: Week,
-	calendarUiState: CalendarUiState,
-	spendingDays: Map<LocalDate, SpendingDay>,
-	budget: BigDecimal,
-	maxSpendsPerDay: Int,
-	onDayClick: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier,
+    week: Week,
+    calendarUiState: CalendarUiState,
+    spendingDays: Map<LocalDate, SpendingDay>,
+    budget: BigDecimal,
+    maxSpendsPerDay: Int,
+    onDayClick: (LocalDate) -> Unit,
 ) {
-	val beginningWeek = week.yearMonth.atDay(1).plusWeeks(week.number.toLong())
-	var currentDay = beginningWeek.with(TemporalAdjusters.previousOrSame(getWeek()[0]))
+    val beginningWeek = week.yearMonth.atDay(1).plusWeeks(week.number.toLong())
+    var currentDay = beginningWeek.with(TemporalAdjusters.previousOrSame(getWeek()[0]))
 
-	Box(modifier.fillMaxWidth()) {
-		Row {
-			for (i in 0..6) {
-				if (currentDay.month == week.yearMonth.month) {
-					val spendingDay = spendingDays[currentDay]
-					val dayBudget = spendingDay?.budget ?: budget
-					val daySpending = spendingDay?.spending ?: BigDecimal.ZERO
-					val amountRatio = if (dayBudget > BigDecimal.ZERO) {
-						(daySpending.toFloat() / dayBudget.toFloat()).coerceAtLeast(0f)
-					} else 0f
-					val daySpendsCount = spendingDay?.spends?.size ?: 0
-					val countRatio = if (maxSpendsPerDay > 0) {
-						(daySpendsCount.toFloat() / maxSpendsPerDay.toFloat()).coerceIn(0f, 1f)
-					} else 0f
-					val heatIntensity = (amountRatio * 0.6f + countRatio * 0.4f).coerceIn(0f, 1.4f)
+    Box(modifier.fillMaxWidth()) {
+        Row {
+            for (i in 0..6) {
+                if (currentDay.month == week.yearMonth.month) {
+                    val spendingDay = spendingDays[currentDay]
+                    val dayBudget = spendingDay?.budget ?: budget
+                    val daySpending = spendingDay?.spending ?: BigDecimal.ZERO
+                    val amountRatio = if (dayBudget > BigDecimal.ZERO) {
+                        (daySpending.toFloat() / dayBudget.toFloat()).coerceAtLeast(0f)
+                    } else 0f
+                    val daySpendsCount = spendingDay?.spends?.size ?: 0
+                    val countRatio = if (maxSpendsPerDay > 0) {
+                        (daySpendsCount.toFloat() / maxSpendsPerDay.toFloat()).coerceIn(0f, 1f)
+                    } else 0f
+                    val heatIntensity = (amountRatio * 0.6f + countRatio * 0.4f).coerceIn(0f, 1.4f)
 
-					DayCell(
-						modifier = Modifier.weight(1f),
-						calendarState = calendarUiState,
-						day = currentDay,
-						onDayClicked = onDayClick,
-						spendingRatio = heatIntensity,
-						hasSpending = spendingDay != null,
-					)
-				} else {
-					Box(
-						modifier = Modifier
-							.size(CELL_SIZE)
-							.weight(1f)
-					)
-				}
-				currentDay = currentDay.plusDays(1)
-			}
-		}
-	}
+                    DayCell(
+                        modifier = Modifier.weight(1f),
+                        calendarState = calendarUiState,
+                        day = currentDay,
+                        onDayClicked = onDayClick,
+                        spendingRatio = heatIntensity,
+                        hasSpending = spendingDay != null,
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(CELL_SIZE)
+                            .weight(1f)
+                    )
+                }
+                currentDay = currentDay.plusDays(1)
+            }
+        }
+    }
 }
 
 @Composable
 internal fun DayOfWeekHeading(day: String, modifier: Modifier = Modifier) {
-	Box(
-		modifier = modifier
-			.height(CELL_SIZE)
-			.widthIn(min = CELL_SIZE)
-			.fillMaxWidth()
-			.background(Color.Transparent), contentAlignment = Alignment.Center
-	) {
-		Text(
-			modifier = Modifier
-				.fillMaxSize()
-				.wrapContentHeight(Alignment.CenterVertically),
-			textAlign = TextAlign.Center,
-			text = day,
-			style = MaterialTheme.typography.labelSmallEmphasized,
-			color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5F),
-		)
-	}
+    Box(
+        modifier = modifier
+            .height(CELL_SIZE)
+            .widthIn(min = CELL_SIZE)
+            .fillMaxWidth()
+            .background(Color.Transparent), contentAlignment = Alignment.Center
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentHeight(Alignment.CenterVertically),
+            textAlign = TextAlign.Center,
+            text = day,
+            style = MaterialTheme.typography.labelSmallEmphasized,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5F),
+        )
+    }
 }
 
 @Composable
 private fun DayContainer(
-	modifier: Modifier = Modifier,
-	current: Boolean = false,
-	disabled: Boolean = false,
-	onSelect: () -> Unit = { },
-	content: @Composable () -> Unit
+    modifier: Modifier = Modifier,
+    current: Boolean = false,
+    disabled: Boolean = false,
+    onSelect: () -> Unit = { },
+    content: @Composable () -> Unit
 ) {
-	Box(
-		modifier = modifier
-			.height(CELL_SIZE)
-			.widthIn(min = CELL_SIZE)
-			.fillMaxWidth()
-			.background(Color.Transparent)
-			.clickable(
-				onClick = { onSelect() },
-				enabled = !disabled,
-				role = Role.Button,
-				interactionSource = remember { MutableInteractionSource() },
-				indication = ripple(
-					bounded = false,
-					radius = CELL_SIZE / 2,
-				)
-			), contentAlignment = Alignment.Center
-	) {
-		if (current) {
-			Box(
-				modifier = modifier
-					.height(CELL_SIZE - 8.dp)
-					.width(CELL_SIZE - 8.dp)
-					.background(
-						color = MaterialTheme.colorScheme.primaryContainer,
-						shape = CircleShape,
-					)
-			) {
-				content()
-			}
-		} else {
-			content()
-		}
-	}
+    Box(
+        modifier = modifier
+            .height(CELL_SIZE)
+            .widthIn(min = CELL_SIZE)
+            .fillMaxWidth()
+            .background(Color.Transparent)
+            .clickable(
+                onClick = { onSelect() },
+                enabled = !disabled,
+                role = Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(
+                    bounded = false,
+                    radius = CELL_SIZE / 2,
+                )
+            ), contentAlignment = Alignment.Center
+    ) {
+        if (current) {
+            Box(
+                modifier = modifier
+                    .height(CELL_SIZE - 8.dp)
+                    .width(CELL_SIZE - 8.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = CircleShape,
+                    )
+            ) {
+                content()
+            }
+        } else {
+            content()
+        }
+    }
 }
 
 @Composable
 internal fun Day(
-	day: LocalDate,
-	calendarState: CalendarUiState,
-	onDayClicked: (LocalDate) -> Unit,
-	modifier: Modifier = Modifier
+    day: LocalDate,
+    calendarState: CalendarUiState,
+    onDayClicked: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-	val disabled =
-		calendarState.disabledBefore?.let { day.isBefore(it) } == true || calendarState.disabledAfter?.let {
-			day.isAfter(it)
-		} == true
-	val selected = !disabled
-	val current = day == LocalDate.now()
+    val disabled =
+        calendarState.disabledBefore?.let { day.isBefore(it) } == true || calendarState.disabledAfter?.let {
+            day.isAfter(it)
+        } == true
+    val selected = !disabled
+    val current = day == LocalDate.now()
 
-	DayContainer(
-		modifier = modifier,
-		current = current,
-		disabled = disabled,
-		onSelect = { onDayClicked(day) },
-	) {
+    DayContainer(
+        modifier = modifier,
+        current = current,
+        disabled = disabled,
+        onSelect = { onDayClicked(day) },
+    ) {
 
-		Text(
-			modifier = Modifier
-				.fillMaxSize()
-				.wrapContentSize(Alignment.Center),
-			text = day.dayOfMonth.toString(),
-			style = MaterialTheme.typography.bodyMedium,
-			color = when (true) {
-				current -> MaterialTheme.colorScheme.onPrimaryContainer
-				selected -> MaterialTheme.colorScheme.onPrimary
-				else -> MaterialTheme.colorScheme.onSurface.copy(alpha = if (disabled) 0.3F else 1F)
-			},
-		)
-	}
+        Text(
+            modifier = Modifier
+                .fillMaxSize()
+                .wrapContentSize(Alignment.Center),
+            text = day.dayOfMonth.toString(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = when (true) {
+                current -> MaterialTheme.colorScheme.onPrimaryContainer
+                selected -> MaterialTheme.colorScheme.onPrimary
+                else -> MaterialTheme.colorScheme.onSurface.copy(alpha = if (disabled) 0.3F else 1F)
+            },
+        )
+    }
 }
 
 @Composable
 internal fun DayCell(
-	day: LocalDate,
-	calendarState: CalendarUiState,
-	onDayClicked: (LocalDate) -> Unit,
-	spendingRatio: Float,
-	hasSpending: Boolean,
-	modifier: Modifier = Modifier
+    day: LocalDate,
+    calendarState: CalendarUiState,
+    onDayClicked: (LocalDate) -> Unit,
+    spendingRatio: Float,
+    hasSpending: Boolean,
+    modifier: Modifier = Modifier
 ) {
-	val disabled =
-		calendarState.disabledBefore?.let { day.isBefore(it) } == true || calendarState.disabledAfter?.let {
-			day.isAfter(it)
-		} == true
-	val current = day == LocalDate.now()
+    val disabled =
+        calendarState.disabledBefore?.let { day.isBefore(it) } == true || calendarState.disabledAfter?.let {
+            day.isAfter(it)
+        } == true
+    val current = day == LocalDate.now()
 
-	val normalizedHeat = spendingRatio.coerceIn(0f, 1.2f)
-	val heatColor = when {
-		normalizedHeat <= 0.5f -> lerp(colorGood, colorNotGood, normalizedHeat / 0.5f)
-		normalizedHeat <= 1.0f -> lerp(colorNotGood, colorBad, (normalizedHeat - 0.5f) / 0.5f)
-		else -> colorBad
-	}
-	val heatAlpha = when {
-		normalizedHeat <= 0f -> 0f
-		normalizedHeat <= 1f -> 0.25f + (normalizedHeat * 0.55f)
-		else -> 0.85f
-	}
-	val backgroundColor = when {
-		disabled || !hasSpending -> Color.Transparent
-		else -> heatColor.copy(alpha = heatAlpha)
-	}
+    val normalizedHeat = spendingRatio.coerceIn(0f, 1.2f)
+    val heatColor = when {
+        normalizedHeat <= 0.5f -> lerp(colorGood, colorNotGood, normalizedHeat / 0.5f)
+        normalizedHeat <= 1.0f -> lerp(colorNotGood, colorBad, (normalizedHeat - 0.5f) / 0.5f)
+        else -> colorBad
+    }
+    val heatAlpha = when {
+        normalizedHeat <= 0f -> 0f
+        normalizedHeat <= 1f -> 0.25f + (normalizedHeat * 0.55f)
+        else -> 0.85f
+    }
+    val backgroundColor = when {
+        disabled || !hasSpending -> Color.Transparent
+        else -> heatColor.copy(alpha = heatAlpha)
+    }
 
-	Box(
-		modifier = modifier
-			.size(CELL_SIZE)
-			.padding(2.dp)
-			.background(
-				color = backgroundColor, shape = RoundedCornerShape(8.dp)
-			)
-			.clickable(
-				onClick = { onDayClicked(day) },
-				enabled = !disabled,
-			)
-			.border(
-				width = if (current) 2.dp else 1.dp,
-				color = if (current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
-				shape = RoundedCornerShape(4.dp)
-			), contentAlignment = Alignment.Center
-	) {
-		Text(
-			text = day.dayOfMonth.toString(),
-			style = MaterialTheme.typography.bodyMediumCondensed,
-			color = when {
-				disabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-				hasSpending && spendingRatio > 1.0f -> MaterialTheme.colorScheme.onError
-				hasSpending -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
-				else -> MaterialTheme.colorScheme.onSurface
-			},
-		)
-	}
+    Box(
+        modifier = modifier
+            .size(CELL_SIZE)
+            .padding(2.dp)
+            .background(
+                color = backgroundColor, shape = RoundedCornerShape(8.dp)
+            )
+            .clickable(
+                onClick = { onDayClicked(day) },
+                enabled = !disabled,
+            )
+            .border(
+                width = if (current) 2.dp else 1.dp,
+                color = if (current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(4.dp)
+            ), contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = day.dayOfMonth.toString(),
+            style = MaterialTheme.typography.bodyMediumCondensed,
+            color = when {
+                disabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                hasSpending && spendingRatio > 1.0f -> MaterialTheme.colorScheme.onError
+                hasSpending -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
+                else -> MaterialTheme.colorScheme.onSurface
+            },
+        )
+    }
 }
 
 internal val CELL_SIZE = 32.dp
 
 data class CalendarUiState(
-	val disabledBefore: LocalDate? = null,
-	val disabledAfter: LocalDate? = null,
+    val disabledBefore: LocalDate? = null,
+    val disabledAfter: LocalDate? = null,
 )
 
 data class Month(
-	val yearMonth: YearMonth, val weeks: List<Week>
+    val yearMonth: YearMonth, val weeks: List<Week>
 )
 
 class CalendarState(
-	context: Context,
-	disableBeforeDate: Date,
-	disableAfterDate: Date,
+    context: Context,
+    disableBeforeDate: Date,
+    disableAfterDate: Date,
 ) {
-	val calendarUiState = mutableStateOf(
-		CalendarUiState(
-			disabledBefore = disableBeforeDate.toLocalDate(),
-			disabledAfter = disableAfterDate.toLocalDate(),
-		)
-	)
+    val calendarUiState = mutableStateOf(
+        CalendarUiState(
+            disabledBefore = disableBeforeDate.toLocalDate(),
+            disabledAfter = disableAfterDate.toLocalDate(),
+        )
+    )
 
-	val listMonths: List<Month> = generateMonths(disableBeforeDate, disableAfterDate)
+    val listMonths: List<Month> = generateMonths(disableBeforeDate, disableAfterDate)
 
-	private fun generateMonths(startDate: Date, endDate: Date): List<Month> {
-		val start = startDate.toLocalDate()
-		val end = endDate.toLocalDate()
-		val months = mutableListOf<Month>()
+    private fun generateMonths(startDate: Date, endDate: Date): List<Month> {
+        val start = startDate.toLocalDate()
+        val end = endDate.toLocalDate()
+        val months = mutableListOf<Month>()
 
-		var current = YearMonth.from(start)
-		val endMonth = YearMonth.from(end)
+        var current = YearMonth.from(start)
+        val endMonth = YearMonth.from(end)
 
-		while (!current.isAfter(endMonth)) {
-			val weeks = mutableListOf<Week>()
-			val firstDayOfMonth = current.atDay(1)
-			val lastDayOfMonth = current.atEndOfMonth()
+        while (!current.isAfter(endMonth)) {
+            val weeks = mutableListOf<Week>()
+            val firstDayOfMonth = current.atDay(1)
+            val lastDayOfMonth = current.atEndOfMonth()
 
-			// Calculate week numbers in this month
-			var currentWeekDay = firstDayOfMonth
-			while (!currentWeekDay.isAfter(lastDayOfMonth)) {
-				val weekNumber = currentWeekDay.get(
-					WeekFields.of(Locale.getDefault()).weekOfMonth()
-				) - 1
-				if (weekNumber >= 0 && weeks.none { it.number == weekNumber && it.yearMonth == current }) {
-					weeks.add(Week(weekNumber, current))
-				}
-				currentWeekDay = currentWeekDay.plusDays(7)
-			}
+            // Calculate week numbers in this month
+            var currentWeekDay = firstDayOfMonth
+            while (!currentWeekDay.isAfter(lastDayOfMonth)) {
+                val weekNumber = currentWeekDay.get(
+                    WeekFields.of(Locale.getDefault()).weekOfMonth()
+                ) - 1
+                if (weekNumber >= 0 && weeks.none { it.number == weekNumber && it.yearMonth == current }) {
+                    weeks.add(Week(weekNumber, current))
+                }
+                currentWeekDay = currentWeekDay.plusDays(7)
+            }
 
-			months.add(Month(current, weeks.sortedBy { it.number }))
-			current = current.plusMonths(1)
-		}
+            months.add(Month(current, weeks.sortedBy { it.number }))
+            current = current.plusMonths(1)
+        }
 
-		return months
-	}
+        return months
+    }
 
-	fun isDisabledDay(day: LocalDate): Boolean {
-		val state = calendarUiState.value
-		return state.disabledBefore?.let { day.isBefore(it) } == true || state.disabledAfter?.let {
-			day.isAfter(
-				it
-			)
-		} == true
-	}
+    fun isDisabledDay(day: LocalDate): Boolean {
+        val state = calendarUiState.value
+        return state.disabledBefore?.let { day.isBefore(it) } == true || state.disabledAfter?.let {
+            day.isAfter(
+                it
+            )
+        } == true
+    }
 
-	fun isCurrentDay(day: LocalDate): Boolean {
-		return day == LocalDate.now()
-	}
+    fun isCurrentDay(day: LocalDate): Boolean {
+        return day == LocalDate.now()
+    }
 
-	fun isDateInSelectedPeriod(day: LocalDate): Boolean {
-		return !isDisabledDay(day)
-	}
+    fun isDateInSelectedPeriod(day: LocalDate): Boolean {
+        return !isDisabledDay(day)
+    }
 }
 
 @Preview(name = "Calendar Heatmap - Full 2 Weeks", widthDp = 420)
 @Preview(
-	name = "Calendar Heatmap - Full 2 Weeks Dark Mode",
-	widthDp = 420,
-	showSystemUi = false,
-	uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
+    name = "Calendar Heatmap - Full 2 Weeks Dark Mode",
+    widthDp = 420,
+    showSystemUi = false,
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL
 )
 @Composable
 private fun PreviewCalendarHeatmap() {
-	val start = LocalDate.now().minusDays(13)
-	val mockTransactions = buildList {
-		val countByDay = listOf(0, 1, 2, 3, 1, 4, 6, 8, 5, 2, 7, 3, 1, 4)
-		val amountByDay = listOf(0, 12, 18, 26, 10, 45, 70, 130, 60, 22, 105, 35, 14, 52)
+    val start = LocalDate.now().minusDays(13)
+    val mockTransactions = buildList {
+        val countByDay = listOf(0, 1, 2, 3, 1, 4, 6, 8, 5, 2, 7, 3, 1, 4)
+        val amountByDay = listOf(0, 12, 18, 26, 10, 45, 70, 130, 60, 22, 105, 35, 14, 52)
 
-		countByDay.forEachIndexed { index, count ->
-			repeat(count) { txIndex ->
-				val dayAmount = amountByDay[index]
-				val splitAmount = if (count > 0) {
-					BigDecimal(dayAmount).divide(
-						BigDecimal(count), 2, java.math.RoundingMode.HALF_UP
-					)
-				} else {
-					BigDecimal.ZERO
-				}
-				add(
-					Transaction(
-						amount = splitAmount,
-						date = start.plusDays(index.toLong()).atTime(8 + (txIndex % 10), 0),
-						comment = "Mock #$index-$txIndex",
-					)
-				)
-			}
-		}
-	}
+        countByDay.forEachIndexed { index, count ->
+            repeat(count) { txIndex ->
+                val dayAmount = amountByDay[index]
+                val splitAmount = if (count > 0) {
+                    BigDecimal(dayAmount).divide(
+                        BigDecimal(count), 2, java.math.RoundingMode.HALF_UP
+                    )
+                } else {
+                    BigDecimal.ZERO
+                }
+                add(
+                    Transaction(
+                        amount = splitAmount,
+                        date = start.plusDays(index.toLong()).atTime(8 + (txIndex % 10), 0),
+                        comment = "Mock #$index-$txIndex",
+                    )
+                )
+            }
+        }
+    }
 
-	MinusTheme {
-		CalendarHeatmap(
-			budget = BigDecimal(200),
-			transactions = mockTransactions,
-			startDate = start.toDate(),
-			finishDate = start.plusDays(13).toDate(),
-		)
-	}
+    MinusTheme {
+        CalendarHeatmap(
+            budget = BigDecimal(200),
+            transactions = mockTransactions,
+            startDate = start.toDate(),
+            finishDate = start.plusDays(13).toDate(),
+        )
+    }
 }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBox.kt
@@ -18,16 +18,20 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -48,10 +52,12 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
+import com.serranoie.app.minus.R
 import com.serranoie.app.minus.presentation.ui.theme.bodyMediumCondensed
 import com.serranoie.app.minus.presentation.ui.theme.titleMediumCondensed
 import kotlinx.coroutines.delay
@@ -105,6 +111,7 @@ fun TutorialBox(
                 isVirtual = isVirtual,
                 tutorialTarget = tutorialTarget,
                 onTap = { state.advance() },
+                onSkip = { state.skipAll() }
             )
         }
     }
@@ -116,7 +123,7 @@ fun TutorialBox(
             !isVirtual &&
             state.currentBounds == null
         ) {
-            delay(1000.milliseconds)
+            delay(400.milliseconds)
             if (state.currentBounds == null) {
                 logcat(TUTORIAL_LOG_TAG) {
                     "TutorialBox: current target $currentIndex " +
@@ -194,6 +201,7 @@ private fun TutorialOverlay(
     isVirtual: Boolean,
     tutorialTarget: @Composable (Int) -> Unit,
     onTap: () -> Unit,
+    onSkip: () -> Unit,
 ) {
     if (!isVirtual && bounds.isEmpty) return
 
@@ -205,9 +213,9 @@ private fun TutorialOverlay(
     val paddingPx = with(density) { 4.dp.toPx() }
     val cornerRadiusPx = with(density) { 12.dp.toPx() }
     val tooltipGapPx = with(density) { 20.dp.toPx() }
-    val tooltipMaxWidthPx = with(density) { 260.dp.toPx() }
+    val tooltipMaxWidthPx = with(density) { 280.dp.toPx() }
     val tooltipMaxWidth = with(density) { tooltipMaxWidthPx.toDp() }
-    val tooltipMinHeightEstimate = with(density) { 160.dp.toPx() }
+    val tooltipMinHeightEstimate = with(density) { 180.dp.toPx() }
 
     val infiniteTransition = rememberInfiniteTransition(label = "TutorialPulse")
     val pulseScale by infiniteTransition.animateFloat(
@@ -345,8 +353,21 @@ private fun TutorialOverlay(
                 .widthIn(max = tooltipMaxWidth)
                 .padding(horizontal = 16.dp),
         ) {
-            Box(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(16.dp)) {
                 tutorialTarget(index)
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onSkip) {
+                        Text(
+                            text = stringResource(R.string.skip_tutorial),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/tutorial/TutorialBoxState.kt
@@ -2,6 +2,7 @@ package com.serranoie.app.minus.presentation.ui.tutorial
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -85,6 +86,12 @@ class TutorialBoxState {
         }
     }
 
+    fun skipAll() {
+        isCompleted = true
+        visitedIndices.addAll(registrationOrder)
+        logcat(TUTORIAL_LOG_TAG) { "skipAll: tutorial marked as completed" }
+    }
+
     fun resetForReplay() {
         isCompleted = false
         currentIndexState.value = if (registrationOrder.isEmpty()) -1 else registrationOrder.first()
@@ -105,11 +112,31 @@ internal val GatedIndices: Set<Int> = setOf(3, 4, 7, 8)
 fun rememberTutorialBoxState(
     order: List<Int> = DefaultWalkOrder,
     virtual: Set<Int> = VirtualIndices,
-): TutorialBoxState = remember(order) {
-    TutorialBoxState().also {
-        it.registrationOrder.addAll(order)
-        virtual.forEach { idx -> it.targetBounds[idx] = Rect.Zero }
+): TutorialBoxState {
+    val state = remember { TutorialBoxState() }
+
+    LaunchedEffect(order) {
+        val currentOrder = state.registrationOrder.toList()
+        if (currentOrder != order) {
+            state.registrationOrder.clear()
+            state.registrationOrder.addAll(order)
+
+            // If we were at -1 or our current index is no longer in the order, reset to first
+            if (state.currentIndexState.value == -1 || state.currentIndexState.value !in order) {
+                state.currentIndexState.value = order.firstOrNull() ?: -1
+            }
+        }
     }
+
+    LaunchedEffect(virtual) {
+        virtual.forEach { idx ->
+            if (idx !in state.targetBounds) {
+                state.targetBounds[idx] = Rect.Zero
+            }
+        }
+    }
+
+    return state
 }
 
 fun Modifier.markForTutorial(

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -550,4 +550,5 @@
     <string name="analytics_tutorial_credit_desc">Pulsa sobre la estrella para ver todas las transacciones realizadas con ella, marcarlas como pagadas o ajusta la fecha límite de facturación para evitar intereses.</string>
     <string name="analytics_tutorial_history_title">Historial de Transacciones</string>
     <string name="analytics_tutorial_history_desc">Haz tap aquí para ver la lista completa de gastos en este periodo.</string>
+    <string name="skip_tutorial">Omitir</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -643,4 +643,5 @@
     <string name="analytics_tutorial_credit_desc">Tap the credit card to view all CC transactions, mark them as paid, or adjust your billing cutoff date to avoid interest.</string>
     <string name="analytics_tutorial_history_title">Transaction History</string>
     <string name="analytics_tutorial_history_desc">Tap here to see a list of all your expenses for this period.</string>
+    <string name="skip_tutorial">Skip</string>
 </resources>


### PR DESCRIPTION
## Description
Enhance and be able to see past "legacy" periods on analytics if the user came from an older version of the app.

## Change strategy
Inside the logic to filter and show the list of past periods on Analytics, now since it didn't have the info to split each budget period, now as a fallback we group per month a period if any to quickly view a "fake" period on the list with all the categories used.

Once the app finished a period completely and saved it correctly the app should render the item with all its info:

<img width="471" height="435" alt="image" src="https://github.com/user-attachments/assets/94199df3-7f4c-4fe7-a8bf-e25e3de038c8" />
  

## Implemented

- Implement `reconstructHistory` in `AnalyticsViewModel` to generate virtual archives from legacy periods.
- Enhance `PastPeriodsBottomSheet` with a new `CategoryDistributionBar` to visualize spending by category and recurrence.
- Add a "Skip" option to the tutorial and refine tooltip appearance and timing.

## Working demo
https://github.com/user-attachments/assets/40bec2b6-448d-47cf-8105-3d3ca8d644da

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes