### PR TITLE
fix: refine period end notification scheduling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,10 @@
             android:exported="false" />
 
         <receiver
+            android:name=".presentation.notification.MidnightPeriodTransitionReceiver"
+            android:exported="false" />
+
+        <receiver
             android:name=".presentation.notification.NotificationRescheduleReceiver"
             android:enabled="true"
             android:exported="true">

--- a/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationScheduler.kt
@@ -134,7 +134,7 @@ class NotificationScheduler @Inject constructor(
     ) {
         scope.launch {
             val (hour, minute) = getPeriodEndNotificationTime()
-            schedulePeriodEndNotification(periodEndDate, hour, minute, currentDate)
+            schedulePeriodEndNotification(periodEndDate.plusDays(1), hour, minute, currentDate)
         }
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/notification/PeriodEndAlarmReceiver.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/notification/PeriodEndAlarmReceiver.kt
@@ -38,7 +38,7 @@ class PeriodEndAlarmReceiver : BroadcastReceiver() {
                 val settings = budgetRepository.getBudgetSettingsSync() ?: return@launch
                 val periodEnd = settings.getPeriodEndDate()
                 val today = LocalDate.now()
-                if (today.isBefore(periodEnd)) {
+                if (!today.isAfter(periodEnd)) {
                     return@launch
                 }
                 val transactions = budgetRepository.getTransactions().first()

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
@@ -167,7 +167,10 @@ class AnalyticsViewModel @Inject constructor(
                 if (hasOverlap) return@mapNotNull null
 
                 val virtualId = -(year.toLong() * 100 + month.toLong())
-                val daysInMonth = java.time.temporal.ChronoUnit.DAYS.between(actualStartDate, actualEndDate.plusDays(1))
+                val daysInMonth = java.time.temporal.ChronoUnit.DAYS.between(
+                    actualStartDate,
+                    actualEndDate.plusDays(1)
+                )
 
                 ArchivedBudget(
                     periodId = virtualId,
@@ -298,8 +301,7 @@ class AnalyticsViewModel @Inject constructor(
         val savingsPreferences = userSettings.savingsPreferences
 
         val periodFinishedNaturally =
-            settings.getPeriodEndDate().isBefore(today) || settings.getPeriodEndDate()
-                .isEqual(today)
+            settings.getPeriodEndDate().isBefore(today)
         val periodFinished = periodFinishedNaturally || earlyFinishActive
 
         val displayBudget = displayBudgetState.totalBudget

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/DaysLeftCard.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/date/DaysLeftCard.kt
@@ -46,116 +46,116 @@ import java.util.Date
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DaysLeftCard(
-	modifier: Modifier = Modifier,
-	startDate: Date,
-	finishDate: Date?,
+    modifier: Modifier = Modifier,
+    startDate: Date,
+    finishDate: Date?,
 ) {
-	if (finishDate == null) {
-		Box { }
-		return
-	}
+    if (finishDate == null) {
+        Box { }
+        return
+    }
 
-	val days = countDays(finishDate, startDate)
-	val restDays = countDaysToToday(finishDate)
+    val days = countDays(finishDate, startDate)
+    val restDays = countDaysToToday(finishDate)
 
-	val density = LocalDensity.current
-	val strokeWidthPx = with(density) { 6.dp.toPx() }
+    val density = LocalDensity.current
+    val strokeWidthPx = with(density) { 6.dp.toPx() }
 
-	Box(
-		Modifier
+    Box(
+        Modifier
 			.widthIn(max = 120.dp)
 			.aspectRatio(1f),
-		contentAlignment = Alignment.Center
-	) {
-		CircularWavyProgressIndicator(
-			// Subtract a tiny amount to show animation when completed
-			progress = { 1f - (restDays / days.toFloat()) - 0.01f },
-			modifier = modifier.fillMaxSize(),
-			color = MaterialTheme.colorScheme.primary,
-			trackColor = MaterialTheme.colorScheme.surfaceVariant,
-			amplitude = { 2f },
-			wavelength = 46.dp,
-			stroke = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
-			trackStroke = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
-		)
+        contentAlignment = Alignment.Center
+    ) {
+        CircularWavyProgressIndicator(
+            // Subtract a tiny amount to show animation when completed
+            progress = { 1f - (restDays / days.toFloat()) - 0.01f },
+            modifier = modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            amplitude = { 2f },
+            wavelength = 46.dp,
+            stroke = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
+            trackStroke = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
+        )
 
-		Column(
-			horizontalAlignment = Alignment.CenterHorizontally,
-			verticalArrangement = Arrangement.Center,
-			modifier = Modifier.padding(16.dp)
-		) {
-			Text(
-				text = restDays.toString(),
-				style = MaterialTheme.typography.displayLargeEmphasized.copy(
-					fontSize = MaterialTheme.typography.titleLarge.fontSize,
-					lineHeight = MaterialTheme.typography.titleLarge.fontSize
-				)
-			)
-			Text(
-				text = stringResource(R.string.days_remaining_label),
-				style = MaterialTheme.typography.labelMediumCondensed.copy(lineHeight = 12.sp),
-				textAlign = TextAlign.Center,
-				color = LocalContentColor.current.copy(alpha = 0.6f),
-			)
-			Spacer(modifier = Modifier.height(4.dp))
-		}
-	}
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = restDays.toString(),
+                style = MaterialTheme.typography.displayLargeEmphasized.copy(
+                    fontSize = MaterialTheme.typography.titleLarge.fontSize,
+                    lineHeight = MaterialTheme.typography.titleLarge.fontSize
+                )
+            )
+            Text(
+                text = stringResource(R.string.days_remaining_label),
+                style = MaterialTheme.typography.labelMediumCondensed.copy(lineHeight = 12.sp),
+                textAlign = TextAlign.Center,
+                color = LocalContentColor.current.copy(alpha = 0.6f),
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
 }
 
 @Deprecated("No longer used, using CircularWavyProgressIndicator instead")
 class ArcShape(
-	private val thickness: Dp,
-	private val progress: Float,
+    private val thickness: Dp,
+    private val progress: Float,
 ) : Shape {
-	override fun createOutline(
-		size: Size,
-		layoutDirection: LayoutDirection,
-		density: Density,
-	) = Outline.Generic(Path().apply {
-		val fixedProgress = progress - 0.000001f
-		val thicknessPx = with(density) { thickness.toPx() }
-		val shift = -90f
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ) = Outline.Generic(Path().apply {
+        val fixedProgress = progress - 0.000001f
+        val thicknessPx = with(density) { thickness.toPx() }
+        val shift = -90f
 
-		val wavyPath = Path().apply {
-			arcTo(
-				Rect(offset = Offset.Zero, size = size),
-				shift,
-				-360 * fixedProgress,
-				forceMoveTo = true,
-			)
-			arcTo(
-				Rect(
-					offset = Offset(thicknessPx, thicknessPx),
-					size = Size(
-						width = size.width - thicknessPx * 2,
-						height = size.height - thicknessPx * 2
-					),
-				),
-				-360 * fixedProgress + shift,
-				360 * fixedProgress,
-				forceMoveTo = false,
-			)
-		}
-		val boundsPath = Path().apply {
-			addRect(Rect(offset = Offset.Zero, size = size))
-		}
-		op(wavyPath, boundsPath, PathOperation.Intersect)
-	})
+        val wavyPath = Path().apply {
+            arcTo(
+                Rect(offset = Offset.Zero, size = size),
+                shift,
+                -360 * fixedProgress,
+                forceMoveTo = true,
+            )
+            arcTo(
+                Rect(
+                    offset = Offset(thicknessPx, thicknessPx),
+                    size = Size(
+                        width = size.width - thicknessPx * 2,
+                        height = size.height - thicknessPx * 2
+                    ),
+                ),
+                -360 * fixedProgress + shift,
+                360 * fixedProgress,
+                forceMoveTo = false,
+            )
+        }
+        val boundsPath = Path().apply {
+            addRect(Rect(offset = Offset.Zero, size = size))
+        }
+        op(wavyPath, boundsPath, PathOperation.Intersect)
+    })
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun PreviewDaysLeftCard() {
-	val calendar = Calendar.getInstance()
-	calendar.add(Calendar.DAY_OF_YEAR, -3)
-	val startDate = calendar.time
-	calendar.add(Calendar.DAY_OF_YEAR, 6)
-	val finishDate = calendar.time
+    val calendar = Calendar.getInstance()
+    calendar.add(Calendar.DAY_OF_YEAR, -3)
+    val startDate = calendar.time
+    calendar.add(Calendar.DAY_OF_YEAR, 6)
+    val finishDate = calendar.time
 
-	MinusTheme {
-		DaysLeftCard(
-			startDate = startDate,
-			finishDate = finishDate,
-		)
-	}
+    MinusTheme {
+        DaysLeftCard(
+            startDate = startDate,
+            finishDate = finishDate,
+        )
+    }
 }


### PR DESCRIPTION
## Description
Fix #165

## Change strategy
Render and schedule end period notification a day after the end date to take in consideration the last day too.

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes

<!-- Risks, follow-ups, or anything reviewers should know. -->
