### PR TITLE
feat: add setting to toggle visibility of past transactions

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepository.kt
@@ -52,6 +52,8 @@ interface SettingsRepository {
 
     suspend fun setCreditQuickToggleEnabled(enabled: Boolean)
 
+    suspend fun setShowPastTransactions(enabled: Boolean)
+
     suspend fun setCategoryPickerDirectPopupEnabled(enabled: Boolean)
 
     suspend fun setCategoryGridModeEnabled(enabled: Boolean)

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
@@ -41,6 +41,7 @@ const val COLOR_SCHEME_KEY_NAME = "app_color_scheme"
 const val LANGUAGE_KEY_NAME = "language"
 const val DYNAMIC_COLOR_KEY_NAME = "dynamic_color_enabled"
 const val CREDIT_QUICK_TOGGLE_FEATURE_KEY_NAME = "credit_quick_toggle_feature_enabled"
+const val SHOW_PAST_TRANSACTIONS_KEY_NAME = "show_past_transactions"
 const val CATEGORY_PICKER_DIRECT_POPUP_KEY_NAME = "category_picker_direct_popup_enabled"
 const val CATEGORY_GRID_MODE_KEY_NAME = "category_grid_mode_enabled"
 const val RECURRENT_PAYMENTS_VIEW_MODE_KEY_NAME = "recurrent_payments_view_mode"
@@ -79,6 +80,8 @@ private val LANGUAGE = stringPreferencesKey(LANGUAGE_KEY_NAME)
 private val DYNAMIC_COLOR = booleanPreferencesKey(DYNAMIC_COLOR_KEY_NAME)
 private val CREDIT_QUICK_TOGGLE_FEATURE_ENABLED =
     booleanPreferencesKey(CREDIT_QUICK_TOGGLE_FEATURE_KEY_NAME)
+private val SHOW_PAST_TRANSACTIONS =
+    booleanPreferencesKey(SHOW_PAST_TRANSACTIONS_KEY_NAME)
 private val CATEGORY_PICKER_DIRECT_POPUP_ENABLED =
     booleanPreferencesKey(CATEGORY_PICKER_DIRECT_POPUP_KEY_NAME)
 private val CATEGORY_GRID_MODE_ENABLED =
@@ -146,6 +149,7 @@ class SettingsRepositoryImpl @Inject constructor(
                     ?: com.serranoie.app.minus.domain.model.AppColorScheme.BRAND,
                 language = preferences[LANGUAGE] ?: "en",
                 dynamicColorEnabled = preferences[DYNAMIC_COLOR] ?: false,
+                showPastTransactions = preferences[SHOW_PAST_TRANSACTIONS] ?: true,
                 isCreditQuickToggleEnabled = preferences[CREDIT_QUICK_TOGGLE_FEATURE_ENABLED] ?: false,
                 categoryPickerDirectPopupEnabled = preferences[CATEGORY_PICKER_DIRECT_POPUP_ENABLED] ?: false,
                 categoryGridModeEnabled = preferences[CATEGORY_GRID_MODE_ENABLED] ?: false,
@@ -316,6 +320,12 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setCreditQuickToggleEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[CREDIT_QUICK_TOGGLE_FEATURE_ENABLED] = enabled
+        }
+    }
+
+    override suspend fun setShowPastTransactions(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[SHOW_PAST_TRANSACTIONS] = enabled
         }
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/domain/model/UserSettingsModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/UserSettingsModel.kt
@@ -26,6 +26,7 @@ data class UserSettings(
     val firstLaunchTutorialStage: FirstLaunchTutorialStage = FirstLaunchTutorialStage.COMPLETED,
     val analyticsTutorialCompleted: Boolean = false,
     val analyticsSpendsTutorialCompleted: Boolean = false,
+    val showPastTransactions: Boolean = false,
     val periodMappingMode: PeriodMappingMode = PeriodMappingMode.ACTIVE_BUDGET,
     val recurrentPaymentsViewMode: RecurrentPaymentsViewMode = RecurrentPaymentsViewMode.VERTICAL_LIST,
     val budgetSplitViewPeriod: BudgetPeriod? = null,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryMviContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryMviContract.kt
@@ -38,6 +38,7 @@ data class HistoryUiState(
     val currentPeriodStartedAtMillis: Long = 0L,
 
     val isCreditQuickToggleEnabled: Boolean = false,
+    val showPastTransactionsSetting: Boolean = true,
 
     val tags: List<String> = emptyList(),
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryScreen.kt
@@ -51,7 +51,7 @@ enum class RecurrentPaymentsViewMode {
     companion object {
         fun fromName(value: String?): RecurrentPaymentsViewMode = runCatching {
             value?.let(::valueOf)
-        }.getOrNull() ?: HORIZONTAL_LIST
+        }.getOrNull() ?: VERTICAL_LIST
     }
 }
 
@@ -203,7 +203,13 @@ fun History(
                 onMarkAsPaid = { expense ->
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
-                onClick = { expense -> onProcessIntent(HistoryUiIntent.ToggleExpandedTransaction(expense.id)) },
+                onClick = { expense ->
+                    onProcessIntent(
+                        HistoryUiIntent.ToggleExpandedTransaction(
+                            expense.id
+                        )
+                    )
+                },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
                 creditCardCutoffDay = uiState.budgetSettings?.creditCardCutoffDay,
@@ -236,7 +242,13 @@ fun History(
                 onMarkAsPaid = { expense ->
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
-                onClick = { expense -> onProcessIntent(HistoryUiIntent.ToggleExpandedTransaction(expense.id)) },
+                onClick = { expense ->
+                    onProcessIntent(
+                        HistoryUiIntent.ToggleExpandedTransaction(
+                            expense.id
+                        )
+                    )
+                },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
                 creditCardCutoffDay = uiState.budgetSettings?.creditCardCutoffDay,
@@ -258,52 +270,71 @@ fun History(
                 onMarkAsPaid = { expense ->
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
-                onClick = { expense -> onProcessIntent(HistoryUiIntent.ToggleExpandedTransaction(expense.id)) },
+                onClick = { expense ->
+                    onProcessIntent(
+                        HistoryUiIntent.ToggleExpandedTransaction(
+                            expense.id
+                        )
+                    )
+                },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
                 creditCardCutoffDay = uiState.budgetSettings?.creditCardCutoffDay,
             )
 
-            pastPeriodToggleSection(
-                groupedPastTransactions = uiState.groupedPastTransactions,
-                showPastPeriod = uiState.showPastPeriod,
-                onToggleShowPastPeriod = {
-                    onProcessIntent(HistoryUiIntent.TogglePastPeriod(!uiState.showPastPeriod))
-                },
-            )
+            if (uiState.showPastTransactionsSetting) {
+                pastPeriodToggleSection(
+                    groupedPastTransactions = uiState.groupedPastTransactions,
+                    showPastPeriod = uiState.showPastPeriod,
+                    onToggleShowPastPeriod = {
+                        onProcessIntent(HistoryUiIntent.TogglePastPeriod(!uiState.showPastPeriod))
+                    },
+                )
 
-            pastTransactionDateSections(
-                showPastPeriod = uiState.showPastPeriod,
-                groupedPastTransactions = uiState.groupedPastTransactions,
-                expandedDates = uiState.expandedDates,
-                expandedTransactionId = uiState.expandedTransactionId,
-                deletingTransactionIds = uiState.pendingRemovedTransactions.keys,
-                currencyCode = currencyCode,
-                currencyFormat = currencyFormat,
-                readOnly = readOnly,
-                onToggleDate = { date -> onProcessIntent(HistoryUiIntent.ToggleExpandedDate(date)) },
-                onDelete = { expense ->
-                    onQueueDeleteWithUndo(
-                        expense,
-                        resources.getString(
-                            R.string.expense_deleted_format,
-                            expense.comment.ifEmpty { resources.getString(R.string.generic_expense) }
-                        ),
-                    ) {
-                        onCancelPendingDelete()
-                    }
-                    onProcessIntent(HistoryUiIntent.DeleteTransaction(expense))
-                },
-                onEdit = { expense -> onProcessIntent(HistoryUiIntent.SetEditingTransaction(expense)) },
-                onMarkAsPaid = { expense ->
-                    onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
-                },
-                onClick = { expense -> onProcessIntent(HistoryUiIntent.ToggleExpandedTransaction(expense.id)) },
-                sharedTransitionScope = sharedTransitionScope,
-                animatedVisibilityScope = animatedVisibilityScope,
-                creditCardCutoffDay = uiState.budgetSettings?.creditCardCutoffDay,
-            )
-
+                pastTransactionDateSections(
+                    showPastPeriod = uiState.showPastPeriod,
+                    groupedPastTransactions = uiState.groupedPastTransactions,
+                    expandedDates = uiState.expandedDates,
+                    expandedTransactionId = uiState.expandedTransactionId,
+                    deletingTransactionIds = uiState.pendingRemovedTransactions.keys,
+                    currencyCode = currencyCode,
+                    currencyFormat = currencyFormat,
+                    readOnly = readOnly,
+                    onToggleDate = { date -> onProcessIntent(HistoryUiIntent.ToggleExpandedDate(date)) },
+                    onDelete = { expense ->
+                        onQueueDeleteWithUndo(
+                            expense,
+                            resources.getString(
+                                R.string.expense_deleted_format,
+                                expense.comment.ifEmpty { resources.getString(R.string.generic_expense) }
+                            ),
+                        ) {
+                            onCancelPendingDelete()
+                        }
+                        onProcessIntent(HistoryUiIntent.DeleteTransaction(expense))
+                    },
+                    onEdit = { expense ->
+                        onProcessIntent(
+                            HistoryUiIntent.SetEditingTransaction(
+                                expense
+                            )
+                        )
+                    },
+                    onMarkAsPaid = { expense ->
+                        onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
+                    },
+                    onClick = { expense ->
+                        onProcessIntent(
+                            HistoryUiIntent.ToggleExpandedTransaction(
+                                expense.id
+                            )
+                        )
+                    },
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                    creditCardCutoffDay = uiState.budgetSettings?.creditCardCutoffDay,
+                )
+            }
 
             item("spacer-bottom") {
                 Spacer(modifier = Modifier.height(32.dp))

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryViewModel.kt
@@ -223,9 +223,14 @@ class HistoryViewModel @Inject constructor(
             today = today,
         )
 
-        val groupedPast = groupTransactionsByDate(pastPeriodTx)
+        val groupedPast = if (userSettings?.showPastTransactions == false) {
+            emptyMap()
+        } else {
+            groupTransactionsByDate(pastPeriodTx)
+        }
 
-        val creditOwed = transactions.filter { it.isCredit && !it.isDeleted && !it.isCreditPaid }.sumOf { it.amount }
+        val creditOwed = transactions.filter { it.isCredit && !it.isDeleted && !it.isCreditPaid }
+            .sumOf { it.amount }
         val remainingBudget = budgetState?.remainingToday ?: BigDecimal.ZERO
         val debtAdjustedBalance = remainingBudget.subtract(creditOwed)
 
@@ -250,6 +255,7 @@ class HistoryViewModel @Inject constructor(
             creditOwed = creditOwed,
             debtAdjustedBalance = debtAdjustedBalance,
             isCreditQuickToggleEnabled = userSettings?.isCreditQuickToggleEnabled ?: false,
+            showPastTransactionsSetting = userSettings?.showPastTransactions ?: true,
             recurrentPaymentsViewMode = userSettings?.recurrentPaymentsViewMode
                 ?: RecurrentPaymentsViewMode.VERTICAL_LIST,
         )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/Settings.kt
@@ -74,7 +74,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -116,6 +115,7 @@ fun Settings(
     modifier: Modifier = Modifier,
     isCensored: Boolean = false,
     isCreditQuickToggleFeatureEnabled: Boolean,
+    showPastTransactions: Boolean = true,
     recurrentPaymentsViewMode: RecurrentPaymentsViewMode,
     notificationHour: Int,
     notificationMinute: Int,
@@ -125,6 +125,7 @@ fun Settings(
     notificationPermissionGranted: Boolean,
     onCensorModeToggle: () -> Unit = {},
     onCreditQuickToggleFeatureToggle: () -> Unit,
+    onShowPastTransactionsToggle: () -> Unit = {},
     isCategoryPickerDirectPopupEnabled: Boolean = false,
     isCategoryGridModeEnabled: Boolean = false,
     onCategoryPickerDirectPopupFeatureToggle: () -> Unit = {},
@@ -367,6 +368,34 @@ fun Settings(
                                 }
                             }
                         })
+
+                    CustomPaddedListItem(
+                        onClick = onShowPastTransactionsToggle,
+                        position = PaddedListItemPosition.Middle,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.AutoAwesome,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.settings_feature_show_past_transactions_title),
+                                style = MaterialTheme.typography.bodyMediumEmphasized,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(R.string.settings_feature_show_past_transactions_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = showPastTransactions,
+                            onCheckedChange = { onShowPastTransactionsToggle() },
+                        )
+                    }
 
                     PaddedExpandableList(
                         isExpanded = isCategoryFeatureExpanded,
@@ -970,11 +999,14 @@ fun RecurrentPaymentsViewModePickerDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Repeat, contentDescription = null, tint = if (currentMode == RecurrentPaymentsViewMode.HORIZONTAL_LIST) {
+                        imageVector = Icons.Default.Repeat,
+                        contentDescription = null,
+                        tint = if (currentMode == RecurrentPaymentsViewMode.HORIZONTAL_LIST) {
                             MaterialTheme.colorScheme.onPrimaryContainer
                         } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
-                        }, modifier = Modifier.size(24.dp)
+                        },
+                        modifier = Modifier.size(24.dp)
                     )
 
                     Spacer(modifier = Modifier.width(16.dp))
@@ -1031,11 +1063,14 @@ fun RecurrentPaymentsViewModePickerDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Repeat, contentDescription = null, tint = if (currentMode == RecurrentPaymentsViewMode.VERTICAL_LIST) {
+                        imageVector = Icons.Default.Repeat,
+                        contentDescription = null,
+                        tint = if (currentMode == RecurrentPaymentsViewMode.VERTICAL_LIST) {
                             MaterialTheme.colorScheme.onPrimaryContainer
                         } else {
                             MaterialTheme.colorScheme.onSurfaceVariant
-                        }, modifier = Modifier.size(24.dp)
+                        },
+                        modifier = Modifier.size(24.dp)
                     )
 
                     Spacer(modifier = Modifier.width(16.dp))

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsScreen.kt
@@ -60,11 +60,14 @@ fun SettingsScreen(
                     viewModel.consumeEffect()
                     onNavigateToBugReport()
                 }
+
                 is SettingsUiEffect.NavigateBack -> {
                     viewModel.consumeEffect()
                     onNavigateBack()
                 }
-                null -> { /* no-op */ }
+
+                null -> { /* no-op */
+                }
             }
         }
     }
@@ -72,10 +75,12 @@ fun SettingsScreen(
     Settings(
         isCensored = uiState.isCensored,
         isCreditQuickToggleFeatureEnabled = uiState.isCreditQuickToggleEnabled,
+        showPastTransactions = uiState.showPastTransactions,
         isCategoryPickerDirectPopupEnabled = uiState.isCategoryPickerDirectPopupEnabled,
         isCategoryGridModeEnabled = uiState.isCategoryGridModeEnabled,
         onCategoryPickerDirectPopupFeatureToggle = viewModel::onCategoryPickerDirectPopupFeatureToggle,
         onCategoryGridModeToggle = viewModel::onCategoryGridModeToggle,
+        onShowPastTransactionsToggle = viewModel::onShowPastTransactionsToggle,
         recurrentPaymentsViewMode = uiState.recurrentPaymentsViewMode,
         notificationHour = uiState.notificationHour,
         notificationMinute = uiState.notificationMinute,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
@@ -49,6 +49,7 @@ data class SettingsUiState(
     val currentLanguage: String = "English",
     val isMaterialYouEnabled: Boolean = false,
     val isCreditQuickToggleEnabled: Boolean = false,
+    val showPastTransactions: Boolean = true,
     val isCategoryPickerDirectPopupEnabled: Boolean = false,
     val isCategoryGridModeEnabled: Boolean = false,
     val recurrentPaymentsViewMode: RecurrentPaymentsViewMode = RecurrentPaymentsViewMode.VERTICAL_LIST,
@@ -152,6 +153,7 @@ class SettingsViewModel @Inject constructor(
                         currentColorScheme = settings.colorScheme,
                         isMaterialYouEnabled = settings.dynamicColorEnabled,
                         isCreditQuickToggleEnabled = settings.isCreditQuickToggleEnabled,
+                        showPastTransactions = settings.showPastTransactions,
                         isCategoryPickerDirectPopupEnabled = settings.categoryPickerDirectPopupEnabled,
                         isCategoryGridModeEnabled = settings.categoryGridModeEnabled,
                         currentLanguage = settings.language,
@@ -248,6 +250,14 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(isCreditQuickToggleEnabled = newValue) }
         viewModelScope.launch {
             settingsRepository.setCreditQuickToggleEnabled(newValue)
+        }
+    }
+
+    fun onShowPastTransactionsToggle() {
+        val newValue = !_uiState.value.showPastTransactions
+        _uiState.update { it.copy(showPastTransactions = newValue) }
+        viewModelScope.launch {
+            settingsRepository.setShowPastTransactions(newValue)
         }
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/SettingsGroup.kt
@@ -275,9 +275,11 @@ fun SelectablePaddedItem(
         position == PaddedListItemPosition.First -> RoundedCornerShape(
             topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp
         )
+
         position == PaddedListItemPosition.Last -> RoundedCornerShape(
             bottomStart = 16.dp, bottomEnd = 16.dp, topStart = 4.dp, topEnd = 4.dp
         )
+
         else -> RoundedCornerShape(4.dp)
     }
 
@@ -299,7 +301,10 @@ fun SelectablePaddedItem(
         },
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = verticalPadding),
+            modifier = Modifier.padding(
+                horizontal = 16.dp,
+                vertical = verticalPadding
+            ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             leadingIcon?.invoke()
@@ -310,6 +315,7 @@ fun SelectablePaddedItem(
                 Text(
                     text = label,
                     style = MaterialTheme.typography.bodyMediumEmphasized,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
                 if (subtitle != null) {
                     Text(
@@ -355,9 +361,11 @@ fun SelectableInfoPaddedItem(
         position == PaddedListItemPosition.First -> RoundedCornerShape(
             topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp
         )
+
         position == PaddedListItemPosition.Last -> RoundedCornerShape(
             bottomStart = 16.dp, bottomEnd = 16.dp, topStart = 4.dp, topEnd = 4.dp
         )
+
         else -> RoundedCornerShape(4.dp)
     }
 
@@ -853,7 +861,8 @@ fun PaddedExpandableListPreview() {
                             )
                         },
                         expandedContent = {
-                            val items = listOf("Food", "Transport", "Shopping", "Entertainment", "Bills")
+                            val items =
+                                listOf("Food", "Transport", "Shopping", "Entertainment", "Bills")
 
                             items.forEachIndexed { index, item ->
                                 val position = when {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -262,6 +262,8 @@
     <string name="settings_category_picker_direct_popup_description">Open the suggestions popup with all your saved categories as soon as you tap the category field. When off, suggestions only appear after you start typing.</string>
     <string name="settings_category_grid_mode_switch_label">Show as a list (Experimental)</string>
     <string name="settings_category_grid_mode_description">Tap the category tag to open a grid of your saved categories, instead of entering inline edit mode. Also turns off the numpad\'s calculation mode while this is on.</string>
+    <string name="settings_feature_show_past_transactions_title">Show past transactions</string>
+    <string name="settings_feature_show_past_transactions_subtitle">Load transactions from past periods</string>
     <string name="settings_recurrent_payments_view_mode_title">Recurrent payments view mode</string>
     <string name="settings_recurrent_payments_view_mode_subtitle">Change the type of display to show your recurrent payments</string>
     <string name="settings_recurrent_payments_view_mode_dialog_title">Recurrent payments view mode</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -262,6 +262,8 @@
     <string name="settings_category_picker_direct_popup_description">Abrir sugerencias de categorías al momento de dar tap en el campo de categorías. Si está apagado, las sugerencias solo aparecerán al momento que empieces a escribir.</string>
     <string name="settings_category_grid_mode_switch_label">Mostrar como una lista (Experimental)</string>
     <string name="settings_category_grid_mode_description">Al dar tap en la categoría se abrirá una lista con todas las categorías guardadas, en vez de escribirlos directamente. Este ajuste apaga el Numpad al escribir la categoría.</string>
+    <string name="settings_feature_show_past_transactions_title">Mostrar transacciones pasadas</string>
+    <string name="settings_feature_show_past_transactions_subtitle">Cargar transacciones de periodos pasados</string>
     <string name="settings_recurrent_payments_view_mode_title">Modo de visualización de pagos recurrentes</string>
     <string name="settings_recurrent_payments_view_mode_subtitle">Cambia el tipo de visualización para mostrar tus pagos recurrentes</string>
     <string name="settings_recurrent_payments_view_mode_dialog_title">Modo de visualización de pagos recurrentes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,8 @@
     <string name="settings_category_picker_direct_popup_description">Open the suggestions popup with all your saved categories as soon as you tap the category field. When off, suggestions only appear after you start typing.</string>
     <string name="settings_category_grid_mode_switch_label">Show as a list (Experimental)</string>
     <string name="settings_category_grid_mode_description">Tap the category tag to open a grid of your saved categories, instead of entering inline edit mode. Also turns off the numpad\'s calculation mode while this is on.</string>
+    <string name="settings_feature_show_past_transactions_title">Show past transactions</string>
+    <string name="settings_feature_show_past_transactions_subtitle">Load transactions from past periods</string>
     <string name="settings_recurrent_payments_view_mode_title">Recurrent payments view mode</string>
     <string name="settings_recurrent_payments_view_mode_subtitle">Change the type of display to show your recurrent payments</string>
     <string name="settings_recurrent_payments_view_mode_dialog_title">Recurrent payments view mode</string>


### PR DESCRIPTION
## Description
Be able to show or hide past period list of transaction on History.

## Change strategy
Introducing a new user preference to show or hide past transactions within the history screen
## Implemented

- Updating the `SettingsRepository` and `DataStore` to persist the new preference.
- Adding a toggle switch in the Settings screen with localized strings.
- Modifying `HistoryViewModel` and `HistoryScreen` to conditionally filter and display past transaction sections based on the setting.
- Updating the default recurrent payments view mode to vertical list.

## Working demo
https://github.com/user-attachments/assets/7410cb96-7291-4a99-a8cd-8091612e5f47

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
This pr closes #163 