### PR TITLE
feat: mark as paid for recurring payments

### DIFF
--- a/app/schemas/com.serranoie.app.minus.data.local.AppDatabase/14.json
+++ b/app/schemas/com.serranoie.app.minus.data.local.AppDatabase/14.json
@@ -1,0 +1,388 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "de2703ad7578646ac9398cf87c263bdc",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `comment` TEXT NOT NULL, `date` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `clientGeneratedId` TEXT, `periodId` INTEGER NOT NULL, `isRecurrent` INTEGER NOT NULL, `recurrentFrequency` TEXT, `recurrentEndDate` INTEGER, `subscriptionDay` INTEGER, `categoryId` INTEGER, `isCredit` INTEGER NOT NULL, `isCreditPaid` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientGeneratedId",
+            "columnName": "clientGeneratedId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodId",
+            "columnName": "periodId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRecurrent",
+            "columnName": "isRecurrent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recurrentFrequency",
+            "columnName": "recurrentFrequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recurrentEndDate",
+            "columnName": "recurrentEndDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subscriptionDay",
+            "columnName": "subscriptionDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCredit",
+            "columnName": "isCredit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCreditPaid",
+            "columnName": "isCreditPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_clientGeneratedId",
+            "unique": true,
+            "columnNames": [
+              "clientGeneratedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_clientGeneratedId` ON `${TABLE_NAME}` (`clientGeneratedId`)"
+          },
+          {
+            "name": "index_transactions_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transactions_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `totalBudget` TEXT NOT NULL, `period` TEXT NOT NULL, `startDate` INTEGER NOT NULL, `endDate` INTEGER, `currencyCode` TEXT NOT NULL, `daysInPeriod` INTEGER NOT NULL, `rollOverEnabled` INTEGER NOT NULL, `rollOverCarryForward` INTEGER NOT NULL, `rollOverLimit` TEXT, `remainingBudgetStrategy` TEXT NOT NULL, `creditCardCutoffDay` INTEGER, `splitMode` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBudget",
+            "columnName": "totalBudget",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysInPeriod",
+            "columnName": "daysInPeriod",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverEnabled",
+            "columnName": "rollOverEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverCarryForward",
+            "columnName": "rollOverCarryForward",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverLimit",
+            "columnName": "rollOverLimit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remainingBudgetStrategy",
+            "columnName": "remainingBudgetStrategy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditCardCutoffDay",
+            "columnName": "creditCardCutoffDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "splitMode",
+            "columnName": "splitMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isHidden` INTEGER NOT NULL, `usageCount` INTEGER NOT NULL, `lastUsedAt` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHidden",
+            "columnName": "isHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usageCount",
+            "columnName": "usageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_category_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_category_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "queued_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `comment` TEXT NOT NULL, `date` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `categoryId` INTEGER, `isCredit` INTEGER NOT NULL, `isCreditPaid` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCredit",
+            "columnName": "isCredit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCreditPaid",
+            "columnName": "isCreditPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "archived_budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`periodId` INTEGER NOT NULL, `totalBudget` TEXT NOT NULL, `spentAmount` TEXT NOT NULL, `startDate` INTEGER NOT NULL, `endDate` INTEGER NOT NULL, `currencyCode` TEXT NOT NULL, `periodType` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`periodId`))",
+        "fields": [
+          {
+            "fieldPath": "periodId",
+            "columnName": "periodId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBudget",
+            "columnName": "totalBudget",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spentAmount",
+            "columnName": "spentAmount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "periodType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "periodId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'de2703ad7578646ac9398cf87c263bdc')"
+    ]
+  }
+}

--- a/app/schemas/com.serranoie.app.minus.data.local.AppDatabase/15.json
+++ b/app/schemas/com.serranoie.app.minus.data.local.AppDatabase/15.json
@@ -1,0 +1,419 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "cc49768d05a5390c47174575a3147b86",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `comment` TEXT NOT NULL, `date` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `clientGeneratedId` TEXT, `periodId` INTEGER NOT NULL, `isRecurrent` INTEGER NOT NULL, `recurrentFrequency` TEXT, `recurrentEndDate` INTEGER, `subscriptionDay` INTEGER, `categoryId` INTEGER, `isCredit` INTEGER NOT NULL, `isCreditPaid` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientGeneratedId",
+            "columnName": "clientGeneratedId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodId",
+            "columnName": "periodId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRecurrent",
+            "columnName": "isRecurrent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recurrentFrequency",
+            "columnName": "recurrentFrequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recurrentEndDate",
+            "columnName": "recurrentEndDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subscriptionDay",
+            "columnName": "subscriptionDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCredit",
+            "columnName": "isCredit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCreditPaid",
+            "columnName": "isCreditPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_clientGeneratedId",
+            "unique": true,
+            "columnNames": [
+              "clientGeneratedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transactions_clientGeneratedId` ON `${TABLE_NAME}` (`clientGeneratedId`)"
+          },
+          {
+            "name": "index_transactions_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transactions_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "budget_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `totalBudget` TEXT NOT NULL, `period` TEXT NOT NULL, `startDate` INTEGER NOT NULL, `endDate` INTEGER, `currencyCode` TEXT NOT NULL, `daysInPeriod` INTEGER NOT NULL, `rollOverEnabled` INTEGER NOT NULL, `rollOverCarryForward` INTEGER NOT NULL, `rollOverLimit` TEXT, `remainingBudgetStrategy` TEXT NOT NULL, `creditCardCutoffDay` INTEGER, `splitMode` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBudget",
+            "columnName": "totalBudget",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysInPeriod",
+            "columnName": "daysInPeriod",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverEnabled",
+            "columnName": "rollOverEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverCarryForward",
+            "columnName": "rollOverCarryForward",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rollOverLimit",
+            "columnName": "rollOverLimit",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remainingBudgetStrategy",
+            "columnName": "remainingBudgetStrategy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditCardCutoffDay",
+            "columnName": "creditCardCutoffDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "splitMode",
+            "columnName": "splitMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `isHidden` INTEGER NOT NULL, `usageCount` INTEGER NOT NULL, `lastUsedAt` INTEGER, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHidden",
+            "columnName": "isHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usageCount",
+            "columnName": "usageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_category_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_category_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "queued_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` TEXT NOT NULL, `comment` TEXT NOT NULL, `date` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `categoryId` INTEGER, `isCredit` INTEGER NOT NULL, `isCreditPaid` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCredit",
+            "columnName": "isCredit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCreditPaid",
+            "columnName": "isCreditPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "archived_budgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`periodId` INTEGER NOT NULL, `totalBudget` TEXT NOT NULL, `spentAmount` TEXT NOT NULL, `startDate` INTEGER NOT NULL, `endDate` INTEGER NOT NULL, `currencyCode` TEXT NOT NULL, `periodType` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`periodId`))",
+        "fields": [
+          {
+            "fieldPath": "periodId",
+            "columnName": "periodId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBudget",
+            "columnName": "totalBudget",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spentAmount",
+            "columnName": "spentAmount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currencyCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodType",
+            "columnName": "periodType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "periodId"
+          ]
+        }
+      },
+      {
+        "tableName": "paid_recurrent_occurrences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transactionId` INTEGER NOT NULL, `occurrenceDateEpochDay` INTEGER NOT NULL, `paidAt` INTEGER NOT NULL, PRIMARY KEY(`transactionId`, `occurrenceDateEpochDay`))",
+        "fields": [
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transactionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurrenceDateEpochDay",
+            "columnName": "occurrenceDateEpochDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paidAt",
+            "columnName": "paidAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transactionId",
+            "occurrenceDateEpochDay"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cc49768d05a5390c47174575a3147b86')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImplTest.kt
@@ -47,6 +47,7 @@ class BudgetRepositoryImplTest {
             archivedBudgetDao = database.archivedBudgetDao(),
             categoryDao = database.categoryDao(),
             queuedTransactionDao = database.queuedTransactionDao(),
+            paidRecurrentOccurrenceDao = database.paidRecurrentOccurrenceDao(),
             budgetCalculator = BudgetCalculator(),
         )
     }

--- a/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/budget/MarkRecurrentOccurrencePaidIntegrationTest.kt
+++ b/app/src/androidTest/java/com/serranoie/app/minus/presentation/ui/budget/MarkRecurrentOccurrencePaidIntegrationTest.kt
@@ -1,0 +1,139 @@
+package com.serranoie.app.minus.presentation.ui.budget
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.data.local.AppDatabase
+import com.serranoie.app.minus.data.repository.BudgetRepositoryImpl
+import com.serranoie.app.minus.domain.calculator.BudgetCalculator
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.domain.usecase.AddTransactionUseCase
+import com.serranoie.app.minus.domain.usecase.DeleteTransactionUseCase
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@RunWith(AndroidJUnit4::class)
+class MarkRecurrentOccurrencePaidIntegrationTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var repository: BudgetRepositoryImpl
+    private lateinit var handler: BudgetTransactionHandler
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = BudgetRepositoryImpl(
+            appDatabase = database,
+            transactionDao = database.transactionDao(),
+            settingsDao = database.budgetSettingsDao(),
+            archivedBudgetDao = database.archivedBudgetDao(),
+            categoryDao = database.categoryDao(),
+            queuedTransactionDao = database.queuedTransactionDao(),
+            paidRecurrentOccurrenceDao = database.paidRecurrentOccurrenceDao(),
+            budgetCalculator = BudgetCalculator(),
+        )
+        handler = BudgetTransactionHandler(
+            budgetRepository = repository,
+            addTransactionUseCase = AddTransactionUseCase(repository),
+            deleteTransactionUseCase = DeleteTransactionUseCase(repository),
+            budgetExpressionEvaluator = BudgetExpressionEvaluator(),
+            notificationScheduler = mockk(relaxed = true),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun markingAFutureOccurrencePaidRecordsItAsHandledAndMaterializesARealTransactionDatedToday() = runBlocking {
+        val fixedStartDate = LocalDate.of(2026, 1, 15)
+        val scheduledDate = LocalDate.of(2026, 6, 15)
+
+        val template = Transaction.create(
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = fixedStartDate.atStartOfDay(),
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 15,
+        )
+        repository.addTransaction(template)
+        val savedTemplate = repository.getTransactions().first().single { it.comment == "Netflix" }
+
+        val tappedOccurrence = savedTemplate.copy(date = scheduledDate.atStartOfDay())
+        val result = handler.markRecurrentOccurrencePaid(tappedOccurrence, activePeriodId = 99L)
+        assertThat(result.isSuccess).isTrue()
+
+        val paidDates = repository.getPaidOccurrenceDatesFor(savedTemplate.id)
+        assertThat(paidDates).containsExactly(scheduledDate)
+
+        val allTransactions = repository.getTransactions().first()
+        val materialized = allTransactions.single { it.id != savedTemplate.id }
+        val today = LocalDate.now()
+
+        assertThat(materialized.comment).isEqualTo("Netflix")
+        assertThat(materialized.date?.toLocalDate()).isEqualTo(today)
+        assertThat(materialized.date?.toLocalDate()).isNotEqualTo(scheduledDate)
+        assertThat(materialized.amount).isEqualTo(BigDecimal("15.00"))
+        assertThat(materialized.isRecurrent).isFalse()
+        assertThat(materialized.sourceTransactionId).isNull()
+        assertThat(materialized.periodId).isEqualTo(99L)
+
+        val templateAfter = repository.getTransactionById(savedTemplate.id)
+        assertThat(templateAfter?.isRecurrent).isTrue()
+        assertThat(templateAfter?.date?.toLocalDate()).isEqualTo(fixedStartDate)
+    }
+
+    @Test
+    fun markingOneSeriesOccurrencePaidDoesNotTouchAnUnrelatedRecurringSeries() = runBlocking {
+        val fixedStartDate = LocalDate.of(2026, 1, 15)
+        val scheduledDate = LocalDate.of(2026, 6, 15)
+
+        val netflix = Transaction.create(
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = fixedStartDate.atStartOfDay(),
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 15,
+        )
+        val spotify = Transaction.create(
+            amount = BigDecimal("9.99"),
+            comment = "Spotify",
+            date = fixedStartDate.atStartOfDay(),
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 20,
+        )
+        repository.addTransaction(netflix)
+        repository.addTransaction(spotify)
+        val savedNetflix = repository.getTransactions().first().single { it.comment == "Netflix" }
+        val savedSpotify = repository.getTransactions().first().single { it.comment == "Spotify" }
+
+        val tappedOccurrence = savedNetflix.copy(date = scheduledDate.atStartOfDay())
+        handler.markRecurrentOccurrencePaid(tappedOccurrence, activePeriodId = 1L)
+
+        assertThat(repository.getPaidOccurrenceDatesFor(savedNetflix.id)).containsExactly(scheduledDate)
+        assertThat(repository.getPaidOccurrenceDatesFor(savedSpotify.id)).isEmpty()
+
+        val allTransactions = repository.getTransactions().first()
+        assertThat(allTransactions.none { it.comment == "Spotify" && it.id != savedSpotify.id }).isTrue()
+
+        val spotifyAfter = repository.getTransactionById(savedSpotify.id)
+        assertThat(spotifyAfter?.isRecurrent).isTrue()
+    }
+}

--- a/app/src/main/java/com/serranoie/app/minus/data/di/DatabaseModule.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import com.serranoie.app.minus.data.local.AppDatabaseMigrations
 import com.serranoie.app.minus.data.local.dao.ArchivedBudgetDao
 import com.serranoie.app.minus.data.local.dao.BudgetSettingsDao
 import com.serranoie.app.minus.data.local.dao.CategoryDao
+import com.serranoie.app.minus.data.local.dao.PaidRecurrentOccurrenceDao
 import com.serranoie.app.minus.data.local.dao.QueuedTransactionDao
 import com.serranoie.app.minus.data.local.dao.TransactionDao
 import dagger.Module
@@ -37,6 +38,7 @@ object DatabaseModule {
             .addMigrations(AppDatabaseMigrations.MIGRATION_11_12)
             .addMigrations(AppDatabaseMigrations.MIGRATION_12_13)
             .addMigrations(AppDatabaseMigrations.MIGRATION_13_14)
+            .addMigrations(AppDatabaseMigrations.MIGRATION_14_15)
             .build()
     }
 
@@ -63,5 +65,10 @@ object DatabaseModule {
     @Provides
     fun provideQueuedTransactionDao(database: AppDatabase): QueuedTransactionDao {
         return database.queuedTransactionDao()
+    }
+
+    @Provides
+    fun providePaidRecurrentOccurrenceDao(database: AppDatabase): PaidRecurrentOccurrenceDao {
+        return database.paidRecurrentOccurrenceDao()
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabase.kt
@@ -5,11 +5,13 @@ import androidx.room.RoomDatabase
 import com.serranoie.app.minus.data.local.dao.ArchivedBudgetDao
 import com.serranoie.app.minus.data.local.dao.BudgetSettingsDao
 import com.serranoie.app.minus.data.local.dao.CategoryDao
+import com.serranoie.app.minus.data.local.dao.PaidRecurrentOccurrenceDao
 import com.serranoie.app.minus.data.local.dao.QueuedTransactionDao
 import com.serranoie.app.minus.data.local.dao.TransactionDao
 import com.serranoie.app.minus.data.local.entity.ArchivedBudgetEntity
 import com.serranoie.app.minus.data.local.entity.BudgetSettingsEntity
 import com.serranoie.app.minus.data.local.entity.CategoryEntity
+import com.serranoie.app.minus.data.local.entity.PaidRecurrentOccurrenceEntity
 import com.serranoie.app.minus.data.local.entity.QueuedTransactionEntity
 import com.serranoie.app.minus.data.local.entity.TransactionEntity
 
@@ -19,9 +21,10 @@ import com.serranoie.app.minus.data.local.entity.TransactionEntity
         BudgetSettingsEntity::class,
         CategoryEntity::class,
         QueuedTransactionEntity::class,
-        ArchivedBudgetEntity::class
+        ArchivedBudgetEntity::class,
+        PaidRecurrentOccurrenceEntity::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -35,6 +38,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
 
     abstract fun queuedTransactionDao(): QueuedTransactionDao
+
+    abstract fun paidRecurrentOccurrenceDao(): PaidRecurrentOccurrenceDao
 
     companion object {
         const val DATABASE_NAME = "minus_budget.db"

--- a/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/AppDatabaseMigrations.kt
@@ -78,11 +78,22 @@ object AppDatabaseMigrations {
 
     val MIGRATION_13_14: Migration = object : Migration(13, 14) {
         override fun migrate(db: SupportSQLiteDatabase) {
-            // rollOverLimit was a domain-only field on BudgetSettings that was
-            // never persisted -- it round-tripped to null on every save/reload,
-            // silently dropping the "crossed out previous total" rollover display
-            // as soon as anything re-read budget_settings from disk.
             db.execSQL("ALTER TABLE budget_settings ADD COLUMN rollOverLimit TEXT")
+        }
+    }
+
+    val MIGRATION_14_15: Migration = object : Migration(14, 15) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `paid_recurrent_occurrences` (
+                    `transactionId` INTEGER NOT NULL,
+                    `occurrenceDateEpochDay` INTEGER NOT NULL,
+                    `paidAt` INTEGER NOT NULL,
+                    PRIMARY KEY(`transactionId`, `occurrenceDateEpochDay`)
+                )
+                """.trimIndent()
+            )
         }
     }
 }

--- a/app/src/main/java/com/serranoie/app/minus/data/local/dao/PaidRecurrentOccurrenceDao.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/dao/PaidRecurrentOccurrenceDao.kt
@@ -1,0 +1,24 @@
+package com.serranoie.app.minus.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.serranoie.app.minus.data.local.entity.PaidRecurrentOccurrenceEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PaidRecurrentOccurrenceDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun markPaid(entity: PaidRecurrentOccurrenceEntity)
+
+    @Query("SELECT * FROM paid_recurrent_occurrences")
+    fun getAllPaidOccurrences(): Flow<List<PaidRecurrentOccurrenceEntity>>
+
+    @Query("SELECT occurrenceDateEpochDay FROM paid_recurrent_occurrences WHERE transactionId = :transactionId")
+    suspend fun getPaidOccurrenceDatesFor(transactionId: Long): List<Long>
+
+    @Query("DELETE FROM paid_recurrent_occurrences WHERE transactionId = :transactionId")
+    suspend fun deleteAllForTransaction(transactionId: Long)
+}

--- a/app/src/main/java/com/serranoie/app/minus/data/local/entity/PaidRecurrentOccurrenceEntity.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/local/entity/PaidRecurrentOccurrenceEntity.kt
@@ -1,0 +1,13 @@
+package com.serranoie.app.minus.data.local.entity
+
+import androidx.room.Entity
+
+@Entity(
+    tableName = "paid_recurrent_occurrences",
+    primaryKeys = ["transactionId", "occurrenceDateEpochDay"],
+)
+data class PaidRecurrentOccurrenceEntity(
+    val transactionId: Long,
+    val occurrenceDateEpochDay: Long,
+    val paidAt: Long = System.currentTimeMillis(),
+)

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepository.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepository.kt
@@ -3,6 +3,7 @@ package com.serranoie.app.minus.data.repository
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.Category
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.model.ArchivedBudget
 import kotlinx.coroutines.flow.Flow
@@ -64,6 +65,12 @@ interface BudgetRepository {
     suspend fun markAllCreditTransactionsAsPaid()
 
     suspend fun markTransactionAsPaid(transactionId: Long)
+
+    fun getPaidRecurrentOccurrences(): Flow<Set<PaidRecurrentOccurrence>>
+
+    suspend fun markRecurrentOccurrencePaid(transactionId: Long, occurrenceDate: LocalDate)
+
+    suspend fun getPaidOccurrenceDatesFor(transactionId: Long): Set<LocalDate>
 
     fun getArchivedBudgets(): Flow<List<ArchivedBudget>>
 

--- a/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/BudgetRepositoryImpl.kt
@@ -5,11 +5,13 @@ import com.serranoie.app.minus.data.local.AppDatabase
 import com.serranoie.app.minus.data.local.dao.ArchivedBudgetDao
 import com.serranoie.app.minus.data.local.dao.BudgetSettingsDao
 import com.serranoie.app.minus.data.local.dao.CategoryDao
+import com.serranoie.app.minus.data.local.dao.PaidRecurrentOccurrenceDao
 import com.serranoie.app.minus.data.local.dao.QueuedTransactionDao
 import com.serranoie.app.minus.data.local.dao.TransactionDao
 import com.serranoie.app.minus.data.local.entity.ArchivedBudgetEntity
 import com.serranoie.app.minus.data.local.entity.BudgetSettingsEntity
 import com.serranoie.app.minus.data.local.entity.CategoryEntity
+import com.serranoie.app.minus.data.local.entity.PaidRecurrentOccurrenceEntity
 import com.serranoie.app.minus.data.local.entity.QueuedTransactionEntity
 import com.serranoie.app.minus.data.local.entity.TransactionEntity
 import com.serranoie.app.minus.domain.calculator.BudgetCalculator
@@ -19,6 +21,7 @@ import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.BudgetState
 import com.serranoie.app.minus.domain.model.Category
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.RemainingBudgetStrategy
 import com.serranoie.app.minus.domain.model.Transaction
@@ -40,6 +43,7 @@ class BudgetRepositoryImpl @Inject constructor(
     private val archivedBudgetDao: ArchivedBudgetDao,
     private val categoryDao: CategoryDao,
     private val queuedTransactionDao: QueuedTransactionDao,
+    private val paidRecurrentOccurrenceDao: PaidRecurrentOccurrenceDao,
     private val budgetCalculator: BudgetCalculator
 ) : BudgetRepository {
     private fun TransactionEntity.toDomain(): Transaction = Transaction(
@@ -270,6 +274,7 @@ class BudgetRepositoryImpl @Inject constructor(
 
     override suspend fun deleteTransaction(transaction: Transaction) {
         transactionDao.delete(transaction.toEntity())
+        paidRecurrentOccurrenceDao.deleteAllForTransaction(transaction.id)
     }
 
     override fun getSpentForDate(date: LocalDate): Flow<BigDecimal> {
@@ -375,6 +380,32 @@ class BudgetRepositoryImpl @Inject constructor(
 
     override suspend fun markTransactionAsPaid(transactionId: Long) {
         transactionDao.markTransactionAsPaid(transactionId)
+    }
+
+    override fun getPaidRecurrentOccurrences(): Flow<Set<PaidRecurrentOccurrence>> {
+        return paidRecurrentOccurrenceDao.getAllPaidOccurrences().map { entities ->
+            entities.map {
+                PaidRecurrentOccurrence(
+                    transactionId = it.transactionId,
+                    occurrenceDate = LocalDate.ofEpochDay(it.occurrenceDateEpochDay),
+                )
+            }.toSet()
+        }
+    }
+
+    override suspend fun markRecurrentOccurrencePaid(transactionId: Long, occurrenceDate: LocalDate) {
+        paidRecurrentOccurrenceDao.markPaid(
+            PaidRecurrentOccurrenceEntity(
+                transactionId = transactionId,
+                occurrenceDateEpochDay = occurrenceDate.toEpochDay(),
+            )
+        )
+    }
+
+    override suspend fun getPaidOccurrenceDatesFor(transactionId: Long): Set<LocalDate> {
+        return paidRecurrentOccurrenceDao.getPaidOccurrenceDatesFor(transactionId)
+            .map { LocalDate.ofEpochDay(it) }
+            .toSet()
     }
 
     override fun getArchivedBudgets(): Flow<List<ArchivedBudget>> {

--- a/app/src/main/java/com/serranoie/app/minus/domain/calculator/RecurringExpenseCalculator.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/calculator/RecurringExpenseCalculator.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.domain.calculator
 
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import java.math.BigDecimal
@@ -9,10 +10,15 @@ import javax.inject.Inject
 
 class RecurringExpenseCalculator @Inject constructor() {
 
-    fun calculateRecurringDueToday(transactions: List<Transaction>, today: LocalDate): BigDecimal {
+    fun calculateRecurringDueToday(
+        transactions: List<Transaction>,
+        today: LocalDate,
+        paidOccurrences: Set<PaidRecurrentOccurrence> = emptySet(),
+    ): BigDecimal {
         val recurrentTransactions = transactions.filter { it.isRecurrent && !it.isDeleted }
         return recurrentTransactions.filter { transaction ->
-            isRecurringDueToday(transaction, today)
+            isRecurringDueToday(transaction, today) &&
+                !paidOccurrences.contains(PaidRecurrentOccurrence(transaction.id, today))
         }.sumOf { it.amount }
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/domain/model/TransactionModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/TransactionModel.kt
@@ -1,6 +1,7 @@
 package com.serranoie.app.minus.domain.model
 
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class Transaction(
@@ -60,3 +61,8 @@ enum class RecurrentFrequency {
     BIWEEKLY,
     MONTHLY
 }
+
+data class PaidRecurrentOccurrence(
+    val transactionId: Long,
+    val occurrenceDate: LocalDate,
+)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/notification/NotificationScheduler.kt
@@ -50,6 +50,7 @@ class NotificationScheduler @Inject constructor(
         private const val MIDNIGHT_ALARM_REQUEST_CODE = 5002
         const val ACTION_MIDNIGHT_PERIOD_CHECK =
             "com.serranoie.app.minus.action.MIDNIGHT_PERIOD_CHECK"
+        private const val MAX_OCCURRENCE_LOOKUP_ITERATIONS = 500
     }
 
     private val workManager by lazy { WorkManager.getInstance(context) }
@@ -231,7 +232,7 @@ class NotificationScheduler @Inject constructor(
         logcat { "Cancelled recurrent notification work: workName=$workName transactionId=${transaction.id}" }
     }
 
-    private fun scheduleRecurrentExpenseNotification(
+    private suspend fun scheduleRecurrentExpenseNotification(
         transaction: Transaction,
         notificationTime: Pair<Int, Int>,
     ) {
@@ -240,8 +241,11 @@ class NotificationScheduler @Inject constructor(
             return
         }
 
+        val stableId = transaction.sourceTransactionId ?: transaction.id
+        val paidDates = budgetRepository.getPaidOccurrenceDatesFor(stableId)
+
         val nextRunDateTime =
-            nextOccurrenceDateTime(transaction, LocalDateTime.now(), notificationTime) ?: run {
+            nextOccurrenceDateTime(transaction, LocalDateTime.now(), notificationTime, paidDates) ?: run {
                 cancelRecurrentExpenseNotification(transaction)
                 logcat { "No future recurrent notification to schedule for transactionId=${transaction.id}" }
                 return
@@ -288,39 +292,51 @@ class NotificationScheduler @Inject constructor(
         transaction: Transaction,
         now: LocalDateTime,
         notificationTime: Pair<Int, Int>,
+        paidDates: Set<LocalDate> = emptySet(),
     ): LocalDateTime? {
         val startDate = transaction.date?.toLocalDate() ?: return null
         val frequency = transaction.recurrentFrequency ?: return null
         val endDate = transaction.recurrentEndDate?.toLocalDate()
+        val billingDay = transaction.subscriptionDay ?: startDate.dayOfMonth
+
+        fun advance(from: LocalDate): LocalDate = when (frequency) {
+            RecurrentFrequency.WEEKLY -> from.plusWeeks(1)
+            RecurrentFrequency.BIWEEKLY -> from.plusWeeks(2)
+            RecurrentFrequency.MONTHLY -> nextMonthlyOccurrence(
+                startDate = startDate,
+                today = from.plusDays(1),
+                subscriptionDay = billingDay,
+            )
+        }
+
         var occurrenceDate = when (frequency) {
             RecurrentFrequency.WEEKLY -> nextSteppedOccurrence(startDate, now.toLocalDate(), 7)
             RecurrentFrequency.BIWEEKLY -> nextSteppedOccurrence(startDate, now.toLocalDate(), 14)
             RecurrentFrequency.MONTHLY -> nextMonthlyOccurrence(
                 startDate = startDate,
                 today = now.toLocalDate(),
-                subscriptionDay = transaction.subscriptionDay ?: startDate.dayOfMonth,
+                subscriptionDay = billingDay,
             )
         }
         var triggerDateTime = LocalDateTime.of(
             occurrenceDate,
             LocalTime.of(notificationTime.first, notificationTime.second)
         )
-        if (!triggerDateTime.isAfter(now)) {
-            occurrenceDate = when (frequency) {
-                RecurrentFrequency.WEEKLY -> occurrenceDate.plusWeeks(1)
-                RecurrentFrequency.BIWEEKLY -> occurrenceDate.plusWeeks(2)
-                RecurrentFrequency.MONTHLY -> nextMonthlyOccurrence(
-                    startDate = startDate,
-                    today = occurrenceDate.plusDays(1),
-                    subscriptionDay = transaction.subscriptionDay ?: startDate.dayOfMonth,
-                )
-            }
+
+        var iterations = 0
+        while ((!triggerDateTime.isAfter(now) || paidDates.contains(occurrenceDate)) &&
+            iterations < MAX_OCCURRENCE_LOOKUP_ITERATIONS
+        ) {
+            occurrenceDate = advance(occurrenceDate)
             triggerDateTime = LocalDateTime.of(
                 occurrenceDate,
                 LocalTime.of(notificationTime.first, notificationTime.second)
             )
+            iterations++
         }
+
         if (endDate != null && occurrenceDate.isAfter(endDate)) return null
+        if (paidDates.contains(occurrenceDate)) return null
         return triggerDateTime
     }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/notification/RecurrentExpenseNotificationWorker.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/notification/RecurrentExpenseNotificationWorker.kt
@@ -86,6 +86,7 @@ class RecurrentExpenseNotificationWorker(
                     today = today,
                     notificationHelper = notificationHelper,
                     settingsRepository = settingsRepository,
+                    budgetRepository = budgetRepository,
                 )
                 notificationScheduler.scheduleRecurrentExpenseNotification(transaction)
                 return Result.success()
@@ -157,10 +158,18 @@ class RecurrentExpenseNotificationWorker(
         today: LocalDate,
         notificationHelper: NotificationHelper,
         settingsRepository: SettingsRepository,
+        budgetRepository: BudgetRepository,
     ) {
         val frequency = transaction.recurrentFrequency ?: return
         if (!isDueToday(transaction, today, frequency)) {
             logcat { "Recurrent notification worker fired but transaction is not due today: transactionId=${transaction.id} today=$today" }
+            return
+        }
+
+        val stableId = transaction.sourceTransactionId ?: transaction.id
+        val paidDates = budgetRepository.getPaidOccurrenceDatesFor(stableId)
+        if (paidDates.contains(today)) {
+            logcat { "Recurrent notification worker fired but today's occurrence is already marked paid: transactionId=${transaction.id} today=$today" }
             return
         }
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculator.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculator.kt
@@ -5,6 +5,7 @@ import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetSplitMode
 import com.serranoie.app.minus.domain.model.BudgetState
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.ui.editor.sheets.split.computeDynamicAllocations
 import com.serranoie.app.minus.presentation.ui.editor.sheets.split.splitBudget
@@ -44,6 +45,7 @@ class BudgetStateCalculator @Inject constructor(
         settings: BudgetSettings,
         transactions: List<Transaction>,
         currentDate: LocalDate,
+        paidOccurrences: Set<PaidRecurrentOccurrence> = emptySet(),
     ): BudgetState {
         val periodEnd = settings.getPeriodEndDate()
         val daysRemaining = ChronoUnit.DAYS.between(currentDate, periodEnd).toInt() + 1
@@ -100,7 +102,9 @@ class BudgetStateCalculator @Inject constructor(
         val regularSpentToday = todayTransactions.filter { it.amount > BigDecimal.ZERO }.sumOf { it.amount }
         val incomeToday = todayTransactions.filter { it.amount < BigDecimal.ZERO }.sumOf { it.amount }.abs()
 
-        val recurringDueToday = recurringExpenseCalculator.calculateRecurringDueToday(transactions, currentDate)
+        val recurringDueToday = recurringExpenseCalculator.calculateRecurringDueToday(
+            transactions, currentDate, paidOccurrences
+        )
         val spentToday = regularSpentToday.add(recurringDueToday)
 
         val totalSpentThisWeek = calculateSpentInSubPeriod(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculator.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculator.kt
@@ -51,7 +51,7 @@ class BudgetStateCalculator @Inject constructor(
         val daysRemaining = ChronoUnit.DAYS.between(currentDate, periodEnd).toInt() + 1
         val originalTotalDays = ChronoUnit.DAYS.between(settings.startDate, periodEnd).toInt() + 1
 
-        val activeTransactions = transactions.filter { !it.isDeleted }
+        val activeTransactions = transactions.filter { !it.isDeleted && !it.isRecurrent }
         val totalExpensesInPeriod = activeTransactions.filter { it.amount > BigDecimal.ZERO }.sumOf { it.amount }
         val totalIncomeInPeriod = activeTransactions.filter { it.amount < BigDecimal.ZERO }.sumOf { it.amount }.abs()
 
@@ -202,7 +202,7 @@ class BudgetStateCalculator @Inject constructor(
         val blockStart = budgetStart.plusDays(currentBlockIndex * blockDays)
         val blockEnd = blockStart.plusDays(blockDays.toLong() - 1)
 
-        return transactions.filter { !it.isDeleted }
+        return transactions.filter { !it.isDeleted && !it.isRecurrent }
             .filter {
                 val txDate = it.date?.toLocalDate()
                 txDate != null && !txDate.isBefore(blockStart) && !txDate.isAfter(blockEnd)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandler.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandler.kt
@@ -195,6 +195,32 @@ class BudgetTransactionHandler @Inject constructor(
         }
     }
 
+    suspend fun markRecurrentOccurrencePaid(transaction: Transaction, activePeriodId: Long): Result<Unit> {
+        return runCatching {
+            val realId = transaction.sourceTransactionId ?: transaction.id
+            val occurrenceDate = transaction.date?.toLocalDate() ?: LocalDate.now()
+            budgetRepository.markRecurrentOccurrencePaid(realId, occurrenceDate)
+            val template = budgetRepository.getTransactionById(realId) ?: return@runCatching
+
+            val categoryId: Long? = if (template.comment.isNotBlank()) {
+                budgetRepository.findOrCreateCategory(template.comment.trim()).id
+            } else {
+                null
+            }
+            val paidTransaction = Transaction.create(
+                amount = template.amount,
+                comment = template.comment,
+                date = LocalDateTime.now(),
+                periodId = activePeriodId,
+                categoryId = categoryId,
+                isCredit = template.isCredit,
+            )
+            addTransactionUseCase(paidTransaction)
+
+            notificationScheduler.scheduleRecurrentExpenseNotification(template)
+        }
+    }
+
     suspend fun restoreTransaction(transaction: Transaction): Result<Unit> {
         return runCatching {
             addTransactionUseCase(transaction)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModel.kt
@@ -8,6 +8,7 @@ import com.serranoie.app.minus.data.repository.BudgetRepository
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.Category
 import com.serranoie.app.minus.domain.model.CreditCard
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.model.calculatePaymentDueDate
@@ -112,7 +113,8 @@ class BudgetViewModel @Inject constructor(
         numpadController.isCalculation,
         numpadController.dragProgress,
         editorStateController.state,
-        budgetRepository.getActiveCategories()
+        budgetRepository.getActiveCategories(),
+        budgetRepository.getPaidRecurrentOccurrences()
     ) { params ->
         val settings = params[0] as BudgetSettings?
         val transactions = params[1] as List<Transaction>
@@ -124,6 +126,8 @@ class BudgetViewModel @Inject constructor(
         val dragProgress = params[7] as Float
         val editorState = params[8] as EditorLocalState
         val categories = params[9] as List<Category>
+        @Suppress("UNCHECKED_CAST")
+        val paidOccurrences = params[10] as Set<PaidRecurrentOccurrence>
 
         val settingsWithRollover = settings?.copy(
             rollOverLimit = if (rolloverAmount > BigDecimal.ZERO) rolloverAmount else null,
@@ -137,7 +141,7 @@ class BudgetViewModel @Inject constructor(
                 currentPeriodId = currentPeriodId,
                 currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
             )
-            budgetStateCalculator.calculateBudgetState(s, periodTransactions, LocalDate.now())
+            budgetStateCalculator.calculateBudgetState(s, periodTransactions, LocalDate.now(), paidOccurrences)
         }
 
         val creditOwed = transactions.filter { it.isCredit && !it.isDeleted && !it.isCreditPaid }.sumOf { it.amount }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryCalculations.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryCalculations.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.presentation.ui.history
 
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.ui.theme.component.expense.UpcomingRecurrentItem
@@ -49,6 +50,7 @@ internal fun buildUpcomingRecurrentItems(
     budgetStartDate: LocalDate,
     budgetEndDate: LocalDate,
     today: LocalDate,
+    paidOccurrences: Set<PaidRecurrentOccurrence> = emptySet(),
 ): Pair<List<UpcomingRecurrentItem>, List<UpcomingRecurrentItem>> {
     val recurrentTransactions = transactions.filter { it.isRecurrent }
 
@@ -58,7 +60,9 @@ internal fun buildUpcomingRecurrentItems(
             date.isAfter(today)
         }
         nextDate?.let { date ->
-            if (!date.isBefore(budgetStartDate) && !date.isAfter(budgetEndDate)) {
+            if (!date.isBefore(budgetStartDate) && !date.isAfter(budgetEndDate) &&
+                !paidOccurrences.contains(PaidRecurrentOccurrence(transaction.id, date))
+            ) {
                 UpcomingRecurrentItem(
                     transaction = transaction,
                     nextChargeDate = date,
@@ -72,7 +76,9 @@ internal fun buildUpcomingRecurrentItems(
 
     val futureOutOfPeriod = recurrentTransactions.mapNotNull { transaction ->
         calculateNextChargeDate(transaction, today)?.let { nextDate ->
-            if (nextDate.isAfter(budgetEndDate)) {
+            if (nextDate.isAfter(budgetEndDate) &&
+                !paidOccurrences.contains(PaidRecurrentOccurrence(transaction.id, nextDate))
+            ) {
                 UpcomingRecurrentItem(
                     transaction = transaction,
                     nextChargeDate = nextDate,
@@ -94,11 +100,12 @@ internal fun buildGroupedCurrentTransactions(
     budgetStartDate: LocalDate,
     budgetEndDate: LocalDate,
     today: LocalDate,
+    paidOccurrences: Set<PaidRecurrentOccurrence> = emptySet(),
 ): Map<LocalDate?, List<Transaction>> {
     val regularTransactions = currentPeriodTransactions.filterNot { it.isRecurrent }
     val recurrentCharges = displayTransactions.filter { it.isRecurrent && !it.isDeleted }
         .flatMap { transaction ->
-            getRecurringChargesInPeriod(transaction, budgetStartDate, budgetEndDate, today)
+            getRecurringChargesInPeriod(transaction, budgetStartDate, budgetEndDate, today, paidOccurrences)
         }
 
     return groupTransactionsByDate(regularTransactions + recurrentCharges)
@@ -161,6 +168,7 @@ internal fun getRecurringChargesInPeriod(
     periodStart: LocalDate,
     periodEnd: LocalDate,
     today: LocalDate,
+    paidOccurrences: Set<PaidRecurrentOccurrence> = emptySet(),
 ): List<Transaction> {
     val frequency = transaction.recurrentFrequency ?: return emptyList()
     val originalDateTime = transaction.date ?: return emptyList()
@@ -172,9 +180,9 @@ internal fun getRecurringChargesInPeriod(
     var chargeDate = startDate
 
     while (!chargeDate.isAfter(subscriptionEnd)) {
-        if (!chargeDate.isBefore(periodStart) && !chargeDate.isAfter(periodEnd) && !chargeDate.isAfter(
-                today
-            )
+        if (!chargeDate.isBefore(periodStart) && !chargeDate.isAfter(periodEnd) &&
+            !chargeDate.isAfter(today) &&
+            !paidOccurrences.contains(PaidRecurrentOccurrence(transaction.id, chargeDate))
         ) {
             virtualTransactions.add(
                 transaction.copy(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryMviContract.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryMviContract.kt
@@ -21,6 +21,7 @@ sealed interface HistoryUiIntent {
     data class DeleteTransaction(val transaction: Transaction) : HistoryUiIntent
     data class SaveEditedTransaction(val transaction: Transaction) : HistoryUiIntent
     data class ConfirmDeleteRecurrent(val transaction: Transaction) : HistoryUiIntent
+    data class MarkTransactionAsPaid(val transaction: Transaction) : HistoryUiIntent
 
     data class SetLockSwipeable(val locked: Boolean) : HistoryUiIntent
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryScreen.kt
@@ -202,6 +202,7 @@ fun History(
                 },
                 onEdit = { expense -> onProcessIntent(HistoryUiIntent.SetEditingTransaction(expense)) },
                 onMarkAsPaid = { expense ->
+                    onProcessIntent(HistoryUiIntent.MarkTransactionAsPaid(expense))
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
                 onClick = { expense ->
@@ -241,6 +242,7 @@ fun History(
                 },
                 onEdit = { expense -> onProcessIntent(HistoryUiIntent.SetEditingTransaction(expense)) },
                 onMarkAsPaid = { expense ->
+                    onProcessIntent(HistoryUiIntent.MarkTransactionAsPaid(expense))
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
                 onClick = { expense ->
@@ -269,6 +271,7 @@ fun History(
                 onDelete = { expense -> onProcessIntent(HistoryUiIntent.SetRecurrentToDelete(expense)) },
                 onEdit = { expense -> onProcessIntent(HistoryUiIntent.SetRecurrentToEdit(expense)) },
                 onMarkAsPaid = { expense ->
+                    onProcessIntent(HistoryUiIntent.MarkTransactionAsPaid(expense))
                     onShowInfoSnackbar(resources.getString(R.string.mark_as_paid_success))
                 },
                 onClick = { expense ->

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/HistoryViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.serranoie.app.minus.data.repository.SettingsRepository
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.Category
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.model.UserSettings
+import com.serranoie.app.minus.domain.usecase.GetCurrentPeriodIdUseCase
 import com.serranoie.app.minus.domain.usecase.ObserveCurrentPeriodBoundaryUseCase
 import com.serranoie.app.minus.domain.usecase.PersistBudgetSettingsUseCase
 import com.serranoie.app.minus.presentation.ui.budget.BudgetStateCalculator
@@ -35,6 +37,7 @@ class HistoryViewModel @Inject constructor(
     private val budgetStateCalculator: BudgetStateCalculator,
     private val observeCurrentPeriodBoundaryUseCase: ObserveCurrentPeriodBoundaryUseCase,
     private val persistBudgetSettingsUseCase: PersistBudgetSettingsUseCase,
+    private val getCurrentPeriodIdUseCase: GetCurrentPeriodIdUseCase,
 ) : ViewModel() {
 
     private val _expandedDates = MutableStateFlow(emptySet<LocalDate>())
@@ -90,6 +93,7 @@ class HistoryViewModel @Inject constructor(
         observeCurrentPeriodBoundaryUseCase(),
         settingsRepository.observeSettings(),
         budgetTransactionHandler.budgetRepository.getActiveCategories(),
+        budgetTransactionHandler.budgetRepository.getPaidRecurrentOccurrences(),
         uiInputs
     ) { array ->
         val transactions = array[0] as List<Transaction>
@@ -99,7 +103,9 @@ class HistoryViewModel @Inject constructor(
         val userSettings = array[3] as UserSettings?
         @Suppress("UNCHECKED_CAST")
         val categories = array[4] as List<Category>
-        val inputs = array[5] as UIInputs
+        @Suppress("UNCHECKED_CAST")
+        val paidOccurrences = array[5] as Set<PaidRecurrentOccurrence>
+        val inputs = array[6] as UIInputs
 
         calculateHistoryUiState(
             transactions = transactions,
@@ -108,6 +114,7 @@ class HistoryViewModel @Inject constructor(
             currentPeriodId = periodBoundary.second,
             userSettings = userSettings,
             categories = categories,
+            paidOccurrences = paidOccurrences,
             inputs = inputs
         )
     }.stateIn(
@@ -137,6 +144,7 @@ class HistoryViewModel @Inject constructor(
             is HistoryUiIntent.DeleteTransaction -> deleteTransaction(intent.transaction)
             is HistoryUiIntent.SaveEditedTransaction -> saveEditedTransaction(intent.transaction)
             is HistoryUiIntent.ConfirmDeleteRecurrent -> confirmDeleteRecurrent(intent.transaction)
+            is HistoryUiIntent.MarkTransactionAsPaid -> markTransactionAsPaid(intent.transaction)
             is HistoryUiIntent.SetLockSwipeable -> _lockSwipeable.value = intent.locked
             is HistoryUiIntent.ToggleExpandedTransaction -> toggleExpandedTransaction(intent.transactionId)
             is HistoryUiIntent.UpdateCreditCutoffDay -> updateCreditCutoffDay(intent.day)
@@ -190,6 +198,17 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
+    private fun markTransactionAsPaid(transaction: Transaction) {
+        viewModelScope.launch {
+            val activePeriodId = getCurrentPeriodIdUseCase().takeIf { it > 0L }
+                ?: uiState.value.currentPeriodId
+            val result = budgetTransactionHandler.markRecurrentOccurrencePaid(transaction, activePeriodId)
+            if (result.isFailure) {
+                _effects.emit(HistoryUiEffect.ShowSnackbar("Could not mark transaction as paid"))
+            }
+        }
+    }
+
     private fun toggleExpandedDate(date: LocalDate) {
         _expandedDates.update { expanded ->
             val currentExpanded = if (expanded.isEmpty()) {
@@ -208,6 +227,7 @@ class HistoryViewModel @Inject constructor(
         currentPeriodId: Long,
         userSettings: UserSettings?,
         categories: List<Category>,
+        paidOccurrences: Set<PaidRecurrentOccurrence>,
         inputs: UIInputs
     ): HistoryUiState {
         val displayTx = buildDisplayTransactions(transactions, inputs.pendingRemovedTransactions)
@@ -233,7 +253,7 @@ class HistoryViewModel @Inject constructor(
                 currentPeriodId = currentPeriodId,
                 currentPeriodStartedAtMillis = currentPeriodStartedAtMillis,
             )
-            budgetStateCalculator.calculateBudgetState(s, periodTransactions, today)
+            budgetStateCalculator.calculateBudgetState(s, periodTransactions, today, paidOccurrences)
         }
 
         val (upcomingInPeriod, futureOutOfPeriod) = buildUpcomingRecurrentItems(
@@ -241,6 +261,7 @@ class HistoryViewModel @Inject constructor(
             budgetStartDate = startDate,
             budgetEndDate = endDate,
             today = today,
+            paidOccurrences = paidOccurrences,
         )
 
         val groupedCurrent = buildGroupedCurrentTransactions(
@@ -249,6 +270,7 @@ class HistoryViewModel @Inject constructor(
             budgetStartDate = startDate,
             budgetEndDate = endDate,
             today = today,
+            paidOccurrences = paidOccurrences,
         )
 
         val groupedPast = if (userSettings?.showPastTransactions == false) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/CurrentPeriodRecurrentSection.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/CurrentPeriodRecurrentSection.kt
@@ -15,27 +15,27 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.serranoie.app.minus.R
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.presentation.ui.history.RecurrentPaymentsViewMode
+import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import com.serranoie.app.minus.presentation.ui.theme.component.date.DayTotalItem
 import com.serranoie.app.minus.presentation.ui.theme.component.expense.RecurrentPaymentsDivider
 import com.serranoie.app.minus.presentation.ui.theme.component.expense.SwipeableUpcomingRecurrentItem
 import com.serranoie.app.minus.presentation.ui.theme.component.expense.UpcomingRecurrentItem
-import java.text.NumberFormat
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import com.serranoie.app.minus.domain.model.RecurrentFrequency
-import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import java.math.BigDecimal
+import java.text.NumberFormat
 import java.time.LocalDate
+import java.time.LocalTime
 
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -98,7 +98,17 @@ internal fun LazyListScope.currentPeriodRecurrentSection(
                             isExpanded = expandedTransactionId == item.transaction.id,
                             onDelete = { onDelete(item.transaction) },
                             onEdit = { onEdit(item.transaction) },
-                            onMarkAsPaid = { onMarkAsPaid(item.transaction) },
+                            onMarkAsPaid = {
+                                onMarkAsPaid(
+                                    item.transaction.copy(
+                                        date = item.nextChargeDate.atTime(
+                                            item.transaction.date?.toLocalTime() ?: LocalTime.MIDNIGHT
+                                        ),
+                                        sourceTransactionId = item.transaction.sourceTransactionId
+                                            ?: item.transaction.id,
+                                    )
+                                )
+                            },
                             onClick = { onClick(item.transaction) },
                             creditCardCutoffDay = creditCardCutoffDay,
                         )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/FutureRecurrentSection.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/sections/FutureRecurrentSection.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.ui.tooling.preview.Preview
 import com.serranoie.app.minus.presentation.ui.theme.MinusTheme
 import java.time.LocalDate
+import java.time.LocalTime
 import java.text.NumberFormat
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -113,7 +114,17 @@ internal fun LazyListScope.futureRecurrentSection(
                             isExpanded = expandedTransactionId == item.transaction.id,
                             onDelete = { onDelete(item.transaction) },
                             onEdit = { onEdit(item.transaction) },
-                            onMarkAsPaid = { onMarkAsPaid(item.transaction) },
+                            onMarkAsPaid = {
+                                onMarkAsPaid(
+                                    item.transaction.copy(
+                                        date = item.nextChargeDate.atTime(
+                                            item.transaction.date?.toLocalTime() ?: LocalTime.MIDNIGHT
+                                        ),
+                                        sourceTransactionId = item.transaction.sourceTransactionId
+                                            ?: item.transaction.id,
+                                    )
+                                )
+                            },
                             onClick = { onClick(item.transaction) },
                             creditCardCutoffDay = creditCardCutoffDay,
                         )

--- a/app/src/test/java/com/serranoie/app/minus/domain/calculator/RecurringExpenseCalculatorTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/domain/calculator/RecurringExpenseCalculatorTest.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.domain.calculator
 
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import org.junit.Assert.assertEquals
@@ -42,6 +43,54 @@ class RecurringExpenseCalculatorTest {
         val result = calculator.calculateRecurringDueToday(listOf(dueWeekly, dueMonthly, notDue), today)
 
         assertEquals(BigDecimal("12.50"), result)
+    }
+
+    @Test
+    fun calculateRecurringDueToday_excludesAnOccurrenceAlreadyMarkedPaidForToday() {
+        val today = LocalDate.of(2026, 3, 15)
+        val dueToday = recurrentTransaction(
+            LocalDate.of(2026, 3, 1), RecurrentFrequency.MONTHLY, subscriptionDay = 15, amount = BigDecimal("15.00")
+        ).let { it.copy(id = 7L) }
+
+        val result = calculator.calculateRecurringDueToday(
+            transactions = listOf(dueToday),
+            today = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(transactionId = 7L, occurrenceDate = today)),
+        )
+
+        assertEquals(BigDecimal.ZERO, result)
+    }
+
+    @Test
+    fun calculateRecurringDueToday_stillCountsAnUnpaidOccurrence() {
+        val today = LocalDate.of(2026, 3, 15)
+        val dueToday = recurrentTransaction(
+            LocalDate.of(2026, 3, 1), RecurrentFrequency.MONTHLY, subscriptionDay = 15, amount = BigDecimal("15.00")
+        ).let { it.copy(id = 7L) }
+
+        val result = calculator.calculateRecurringDueToday(
+            transactions = listOf(dueToday),
+            today = today,
+            paidOccurrences = emptySet(),
+        )
+
+        assertEquals(BigDecimal("15.00"), result)
+    }
+
+    @Test
+    fun calculateRecurringDueToday_apaidOccurrenceOnADifferentDateDoesNotSuppressTodaysDue() {
+        val today = LocalDate.of(2026, 3, 15)
+        val dueToday = recurrentTransaction(
+            LocalDate.of(2026, 3, 1), RecurrentFrequency.MONTHLY, subscriptionDay = 15, amount = BigDecimal("15.00")
+        ).let { it.copy(id = 7L) }
+
+        val result = calculator.calculateRecurringDueToday(
+            transactions = listOf(dueToday),
+            today = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(transactionId = 7L, occurrenceDate = LocalDate.of(2026, 2, 15))),
+        )
+
+        assertEquals(BigDecimal("15.00"), result)
     }
 
     private fun recurrentTransaction(

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculatorTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculatorTest.kt
@@ -230,6 +230,35 @@ class BudgetStateCalculatorTest {
         )
 
         assertThat(result.totalSpentToday).isEqualTo(BigDecimal("15.00"))
+        assertThat(result.totalSpentInPeriod).isEqualTo(BigDecimal("15.00"))
+    }
+
+    @Test
+    fun `a recurring templates own row never counts toward period totals, only its projection or a materialized transaction does`() {
+        val today = LocalDate.of(2026, 3, 15)
+        val recurringTemplate = Transaction(
+            id = 1L,
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = LocalDate.of(2026, 3, 1).atStartOfDay(),
+            periodId = 5L,
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 15,
+        )
+
+        val result = calculator.calculateBudgetState(
+            settings = settings(
+                totalBudget = BigDecimal("1000"),
+                start = LocalDate.of(2026, 3, 1),
+                end = LocalDate.of(2026, 3, 31),
+            ),
+            transactions = listOf(recurringTemplate),
+            currentDate = today,
+        )
+
+        assertThat(result.totalSpentInPeriod).isEqualTo(BigDecimal("15.00"))
+        assertThat(result.totalSpentToday).isEqualTo(BigDecimal("15.00"))
     }
 
     @Test

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculatorTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetStateCalculatorTest.kt
@@ -5,6 +5,8 @@ import com.serranoie.app.minus.domain.calculator.RecurringExpenseCalculator
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
 import com.serranoie.app.minus.domain.model.BudgetSplitMode
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
 import com.serranoie.app.minus.domain.model.Transaction
 import org.junit.Test
 import java.math.BigDecimal
@@ -51,9 +53,6 @@ class BudgetStateCalculatorTest {
 
     @Test
     fun `static split - daily budget ignores how much was spent and how many days are left`() {
-        // The static formula is fixed: it's always totalBudget / totalDays,
-        // regardless of remaining days or spending. So the same totalBudget
-        // and totalDays produce the same dailyBudget no matter what.
         val baseSettings = settings(
             totalBudget = BigDecimal("2000"),
             start = LocalDate.of(2026, 7, 1),
@@ -128,12 +127,6 @@ class BudgetStateCalculatorTest {
         )
         assertThat(day2.dailyBudget).isEqualTo(BigDecimal("693.77"))
 
-        // The key invariant: the daily amount INCREASES when the user
-        // doesn't spend and a day rolls over. This is the intended
-        // behavior of the DYNAMIC split mode (and the source of the
-        // user's confusion: "why is it more if I didn't spend
-        // yesterday?"). The fix is to make the top-bar pill use the
-        // same formula so it doesn't appear stuck.
         assertThat(day2.dailyBudget).isGreaterThan(day1.dailyBudget)
     }
 
@@ -154,7 +147,6 @@ class BudgetStateCalculatorTest {
 
     @Test
     fun `dynamic split - daily budget is zero when the remaining balance is non-positive`() {
-        // Over budget, don't show a negative daily.
         val result = calculator.calculateBudgetState(
             settings = settings(
                 totalBudget = BigDecimal("1000"),
@@ -203,4 +195,68 @@ class BudgetStateCalculatorTest {
         date = date.atTime(12, 0),
         periodId = 1L,
     )
+
+    @Test
+    fun `marking a recurring occurrence paid on its due date does not double-count todays spend`() {
+        val today = LocalDate.of(2026, 3, 15)
+        val recurringTemplate = Transaction(
+            id = 1L,
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = LocalDate.of(2026, 3, 1).atStartOfDay(),
+            periodId = 5L,
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 15,
+        )
+        val materializedFromMarkAsPaid = Transaction(
+            id = 2L,
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = today.atStartOfDay(),
+            periodId = 5L,
+            isRecurrent = false,
+        )
+
+        val result = calculator.calculateBudgetState(
+            settings = settings(
+                totalBudget = BigDecimal("1000"),
+                start = LocalDate.of(2026, 3, 1),
+                end = LocalDate.of(2026, 3, 31),
+            ),
+            transactions = listOf(recurringTemplate, materializedFromMarkAsPaid),
+            currentDate = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(transactionId = 1L, occurrenceDate = today)),
+        )
+
+        assertThat(result.totalSpentToday).isEqualTo(BigDecimal("15.00"))
+    }
+
+    @Test
+    fun `an unpaid recurring occurrence still counts as projected spend today`() {
+        val today = LocalDate.of(2026, 3, 15)
+        val recurringTemplate = Transaction(
+            id = 1L,
+            amount = BigDecimal("15.00"),
+            comment = "Netflix",
+            date = LocalDate.of(2026, 3, 1).atStartOfDay(),
+            periodId = 5L,
+            isRecurrent = true,
+            recurrentFrequency = RecurrentFrequency.MONTHLY,
+            subscriptionDay = 15,
+        )
+
+        val result = calculator.calculateBudgetState(
+            settings = settings(
+                totalBudget = BigDecimal("1000"),
+                start = LocalDate.of(2026, 3, 1),
+                end = LocalDate.of(2026, 3, 31),
+            ),
+            transactions = listOf(recurringTemplate),
+            currentDate = today,
+            paidOccurrences = emptySet(),
+        )
+
+        assertThat(result.totalSpentToday).isEqualTo(BigDecimal("15.00"))
+    }
 }

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandlerTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetTransactionHandlerTest.kt
@@ -1,0 +1,117 @@
+package com.serranoie.app.minus.presentation.ui.budget
+
+import com.google.common.truth.Truth.assertThat
+import com.serranoie.app.minus.data.repository.BudgetRepository
+import com.serranoie.app.minus.domain.model.Category
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
+import com.serranoie.app.minus.domain.model.Transaction
+import com.serranoie.app.minus.domain.usecase.AddTransactionUseCase
+import com.serranoie.app.minus.domain.usecase.DeleteTransactionUseCase
+import com.serranoie.app.minus.presentation.notification.NotificationScheduler
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BudgetTransactionHandlerTest {
+
+    private val budgetRepository: BudgetRepository = mockk(relaxed = true)
+    private val notificationScheduler: NotificationScheduler = mockk(relaxed = true)
+
+    private lateinit var handler: BudgetTransactionHandler
+
+    private val template = Transaction(
+        id = 42L,
+        amount = BigDecimal("15.00"),
+        comment = "Netflix",
+        date = LocalDateTime.of(2026, 1, 15, 0, 0),
+        isRecurrent = true,
+        recurrentFrequency = RecurrentFrequency.MONTHLY,
+        subscriptionDay = 15,
+    )
+
+    @Before
+    fun setUp() {
+        handler = BudgetTransactionHandler(
+            budgetRepository = budgetRepository,
+            addTransactionUseCase = AddTransactionUseCase(budgetRepository),
+            deleteTransactionUseCase = DeleteTransactionUseCase(budgetRepository),
+            budgetExpressionEvaluator = BudgetExpressionEvaluator(),
+            notificationScheduler = notificationScheduler,
+        )
+
+        coEvery { budgetRepository.getTransactionById(template.id) } returns template
+        coEvery { budgetRepository.findOrCreateCategory(any()) } returns Category(id = 1L, name = "Netflix")
+    }
+
+    @Test
+    fun `marking a future occurrence paid records the scheduled date as handled`() = runTest {
+        val futureOccurrence = template.copy(date = LocalDate.of(2026, 4, 15).atStartOfDay())
+
+        handler.markRecurrentOccurrencePaid(futureOccurrence, activePeriodId = 7L)
+
+        coVerify {
+            budgetRepository.markRecurrentOccurrencePaid(template.id, LocalDate.of(2026, 4, 15))
+        }
+    }
+
+    @Test
+    fun `marking an occurrence paid creates a real transaction dated today, not the scheduled date`() = runTest {
+        val futureOccurrence = template.copy(date = LocalDate.of(2026, 4, 15).atStartOfDay())
+        val captured = slot<Transaction>()
+
+        handler.markRecurrentOccurrencePaid(futureOccurrence, activePeriodId = 7L)
+
+        coVerify { budgetRepository.addTransaction(capture(captured)) }
+        val recorded = captured.captured
+        assertThat(recorded.date?.toLocalDate()).isEqualTo(LocalDate.now())
+        assertThat(recorded.date?.toLocalDate()).isNotEqualTo(LocalDate.of(2026, 4, 15))
+        assertThat(recorded.amount).isEqualTo(template.amount)
+        assertThat(recorded.comment).isEqualTo(template.comment)
+        assertThat(recorded.periodId).isEqualTo(7L)
+    }
+
+    @Test
+    fun `the materialized transaction is not itself recurring and has no link back to the template`() = runTest {
+        val futureOccurrence = template.copy(date = LocalDate.of(2026, 4, 15).atStartOfDay())
+        val captured = slot<Transaction>()
+
+        handler.markRecurrentOccurrencePaid(futureOccurrence, activePeriodId = 7L)
+
+        coVerify { budgetRepository.addTransaction(capture(captured)) }
+        assertThat(captured.captured.sourceTransactionId).isNull()
+        assertThat(captured.captured.isRecurrent).isFalse()
+    }
+
+    @Test
+    fun `marking paid reschedules the series notification past the paid date`() = runTest {
+        val futureOccurrence = template.copy(date = LocalDate.of(2026, 4, 15).atStartOfDay())
+
+        handler.markRecurrentOccurrencePaid(futureOccurrence, activePeriodId = 7L)
+
+        coVerify { notificationScheduler.scheduleRecurrentExpenseNotification(template) }
+    }
+
+    @Test
+    fun `marking a virtual occurrence paid resolves back to the real template via sourceTransactionId`() = runTest {
+        val virtualOccurrence = template.copy(
+            id = template.id * 1000000 + LocalDate.of(2026, 2, 15).toEpochDay(),
+            date = LocalDate.of(2026, 2, 15).atStartOfDay(),
+            sourceTransactionId = template.id,
+        )
+
+        handler.markRecurrentOccurrencePaid(virtualOccurrence, activePeriodId = 7L)
+
+        coVerify {
+            budgetRepository.markRecurrentOccurrencePaid(template.id, LocalDate.of(2026, 2, 15))
+        }
+    }
+}

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModelTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/budget/BudgetViewModelTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.serranoie.app.minus.data.repository.BudgetRepository
 import com.serranoie.app.minus.domain.model.BudgetPeriod
 import com.serranoie.app.minus.domain.model.BudgetSettings
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
 import com.serranoie.app.minus.domain.model.Transaction
 import com.serranoie.app.minus.domain.usecase.ClearEarlyFinishStateUseCase
 import com.serranoie.app.minus.domain.usecase.FinishBudgetEarlyUseCase
@@ -73,6 +74,7 @@ class BudgetViewModelTest {
     private val rolloverFlow = MutableStateFlow(BigDecimal.ZERO to false)
     private val categoriesFlow = MutableStateFlow<List<com.serranoie.app.minus.domain.model.Category>>(emptyList())
     private val queuedTransactionsFlow = MutableStateFlow<List<Transaction>>(emptyList())
+    private val paidOccurrencesFlow = MutableStateFlow<Set<PaidRecurrentOccurrence>>(emptySet())
 
     @Before
     fun setUp() {
@@ -81,6 +83,7 @@ class BudgetViewModelTest {
         every { budgetRepository.getTransactions() } returns transactionsFlow
         every { budgetRepository.getQueuedTransactions() } returns queuedTransactionsFlow
         every { budgetRepository.getActiveCategories() } returns categoriesFlow
+        every { budgetRepository.getPaidRecurrentOccurrences() } returns paidOccurrencesFlow
         every { observeCurrentPeriodBoundaryUseCase() } returns boundaryFlow
         every { observeCurrentPeriodRolloverUseCase() } returns rolloverFlow
     }

--- a/app/src/test/java/com/serranoie/app/minus/presentation/ui/history/HistoryCalculationsTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/presentation/ui/history/HistoryCalculationsTest.kt
@@ -1,0 +1,166 @@
+package com.serranoie.app.minus.presentation.ui.history
+
+import com.serranoie.app.minus.domain.model.PaidRecurrentOccurrence
+import com.serranoie.app.minus.domain.model.RecurrentFrequency
+import com.serranoie.app.minus.domain.model.Transaction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class HistoryCalculationsTest {
+
+    private fun recurrentTransaction(
+        id: Long,
+        startDate: LocalDate,
+        frequency: RecurrentFrequency = RecurrentFrequency.MONTHLY,
+        subscriptionDay: Int? = null,
+    ): Transaction = Transaction(
+        id = id,
+        amount = BigDecimal("15.00"),
+        comment = "Netflix",
+        date = startDate.atStartOfDay(),
+        isRecurrent = true,
+        recurrentFrequency = frequency,
+        subscriptionDay = subscriptionDay,
+    )
+
+    @Test
+    fun when_next_charge_date_is_paid_then_item_is_excluded_from_upcoming_in_period() {
+        val today = LocalDate.of(2026, 3, 1)
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 31)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 1, 15), subscriptionDay = 15)
+        val nextChargeDate = LocalDate.of(2026, 3, 15)
+
+        val (upcoming, _) = buildUpcomingRecurrentItems(
+            transactions = listOf(tx),
+            budgetStartDate = periodStart,
+            budgetEndDate = periodEnd,
+            today = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(tx.id, nextChargeDate)),
+        )
+
+        assertTrue(upcoming.isEmpty())
+    }
+
+    @Test
+    fun when_next_charge_date_is_not_paid_then_item_is_included() {
+        val today = LocalDate.of(2026, 3, 1)
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 31)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 1, 15), subscriptionDay = 15)
+
+        val (upcoming, _) = buildUpcomingRecurrentItems(
+            transactions = listOf(tx),
+            budgetStartDate = periodStart,
+            budgetEndDate = periodEnd,
+            today = today,
+            paidOccurrences = emptySet(),
+        )
+
+        assertEquals(1, upcoming.size)
+        assertEquals(LocalDate.of(2026, 3, 15), upcoming.first().nextChargeDate)
+    }
+
+    @Test
+    fun when_a_different_transactions_occurrence_is_paid_then_this_item_is_unaffected() {
+        val today = LocalDate.of(2026, 3, 1)
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 31)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 1, 15), subscriptionDay = 15)
+        val otherPaidOccurrence = PaidRecurrentOccurrence(
+            transactionId = 2L,
+            occurrenceDate = LocalDate.of(2026, 3, 15),
+        )
+
+        val (upcoming, _) = buildUpcomingRecurrentItems(
+            transactions = listOf(tx),
+            budgetStartDate = periodStart,
+            budgetEndDate = periodEnd,
+            today = today,
+            paidOccurrences = setOf(otherPaidOccurrence),
+        )
+
+        assertEquals(1, upcoming.size)
+    }
+
+    @Test
+    fun when_out_of_period_charge_date_is_paid_then_item_is_excluded_from_future_out_of_period() {
+        val today = LocalDate.of(2026, 3, 1)
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 10)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 1, 15), subscriptionDay = 15)
+        val nextChargeDate = LocalDate.of(2026, 3, 15)
+
+        val (upcoming, future) = buildUpcomingRecurrentItems(
+            transactions = listOf(tx),
+            budgetStartDate = periodStart,
+            budgetEndDate = periodEnd,
+            today = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(tx.id, nextChargeDate)),
+        )
+
+        assertTrue(upcoming.isEmpty())
+        assertTrue(future.isEmpty())
+    }
+
+    @Test
+    fun when_out_of_period_charge_date_is_not_paid_then_item_appears_in_future_out_of_period() {
+        val today = LocalDate.of(2026, 3, 1)
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 10)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 1, 15), subscriptionDay = 15)
+
+        val (upcoming, future) = buildUpcomingRecurrentItems(
+            transactions = listOf(tx),
+            budgetStartDate = periodStart,
+            budgetEndDate = periodEnd,
+            today = today,
+        )
+
+        assertTrue(upcoming.isEmpty())
+        assertEquals(1, future.size)
+        assertEquals(LocalDate.of(2026, 3, 15), future.first().nextChargeDate)
+    }
+
+    @Test
+    fun when_one_occurrence_is_paid_then_only_that_occurrence_is_excluded() {
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 31)
+        val today = LocalDate.of(2026, 3, 31)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 3, 2), frequency = RecurrentFrequency.WEEKLY)
+        val paidDate = LocalDate.of(2026, 3, 9)
+
+        val charges = getRecurringChargesInPeriod(
+            transaction = tx,
+            periodStart = periodStart,
+            periodEnd = periodEnd,
+            today = today,
+            paidOccurrences = setOf(PaidRecurrentOccurrence(tx.id, paidDate)),
+        )
+
+        val chargeDates = charges.map { it.date?.toLocalDate() }
+        assertTrue(chargeDates.contains(LocalDate.of(2026, 3, 2)))
+        assertTrue(!chargeDates.contains(paidDate))
+        assertTrue(chargeDates.contains(LocalDate.of(2026, 3, 16)))
+    }
+
+    @Test
+    fun when_no_occurrences_are_paid_then_all_occurrences_in_period_are_returned() {
+        val periodStart = LocalDate.of(2026, 3, 1)
+        val periodEnd = LocalDate.of(2026, 3, 31)
+        val today = LocalDate.of(2026, 3, 31)
+        val tx = recurrentTransaction(id = 1L, startDate = LocalDate.of(2026, 3, 2), frequency = RecurrentFrequency.WEEKLY)
+
+        val charges = getRecurringChargesInPeriod(
+            transaction = tx,
+            periodStart = periodStart,
+            periodEnd = periodEnd,
+            today = today,
+        )
+
+        assertEquals(5, charges.size)
+    }
+}


### PR DESCRIPTION
## Description
Be able to mark as paid recurring payments that are inside or outside the period and take that action into the current period

## Change strategy
Generated a new entity regarding all the recurring payments that are being marked as paid to persist and delete the incoming notification reminder.

## Implemented
- Add `paid_recurrent_occurrences` database table and DAO to persist the paid status of specific recurring transaction dates.
- Update `BudgetRepository` and its implementation to support marking, retrieving, and cleaning up paid occurrences.
- Refactor `BudgetStateCalculator` and `HistoryCalculations` to exclude paid occurrences from "due today" totals and "upcoming" lists to prevent double-counting.
- Enhance `BudgetTransactionHandler` to materialize a real one-time transaction and reschedule notifications when a recurring occurrence is marked as paid.
- Update `NotificationScheduler` and `RecurrentExpenseNotificationWorker` to suppress alerts for occurrences already recorded as paid.
- Integrate the paid occurrences flow into `BudgetViewModel` and `HistoryViewModel` for reactive UI updates.
- Add comprehensive unit and integration tests for recurring payment logic, including state transitions and notification scheduling.

## Working demo
https://github.com/user-attachments/assets/98cde6c4-1e23-456e-a655-fec95ff73c55

## Testing

- [x] Ran `./gradlew :app:compileDebugKotlin :wear:compileDebugKotlin :sync-contract:compileKotlin :app:testDebugUnitTest`
- [x] Added/updated tests when applicable
- [x] Added screenshots or screen recordings for UI changes

## Notes
#189 