### PR TITLE
fix: hide result text when isSimpleSignEntry is true

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/editor/Editor.kt
@@ -566,6 +566,11 @@ private fun EditingContent(
 
     val hasExpressionOperators = remember(input) { input.any { it in "+-×÷" } }
 
+    val isSimpleSignEntry = remember(input) {
+        (input.startsWith("+") || input.startsWith("-")) &&
+            input.substring(1).none { it in "+-×÷" }
+    }
+
     val calculationResult = remember(input, hasExpressionOperators) {
         if (!hasExpressionOperators || input.isEmpty()) return@remember null
 
@@ -696,10 +701,7 @@ private fun EditingContent(
             }
         }
 
-    val annotatedCalculationResult = remember(calculationResult, currencyCode, symbolStyle, input) {
-        val isSimpleSignEntry = (input.startsWith("+") || input.startsWith("-")) &&
-                input.substring(1).none { it in "+-×÷" }
-
+    val annotatedCalculationResult = remember(calculationResult, currencyCode, symbolStyle, isSimpleSignEntry) {
         if (calculationResult == null || isSimpleSignEntry) return@remember null
         val supportedCurrency = SupportedCurrency.findByCode(currencyCode)
         val currencySymbol = supportedCurrency?.symbol ?: "$"
@@ -773,7 +775,7 @@ private fun EditingContent(
                 contentAlignment = Alignment.CenterEnd
             ) {
                 AnimatedContent(
-                    targetState = if (hasExpressionOperators && calculationResult != null) "result" else "input",
+                    targetState = if (hasExpressionOperators && calculationResult != null && !isSimpleSignEntry) "result" else "input",
                     transitionSpec = {
                         (
                                 fadeIn(animationSpec = tween(200)) + slideInHorizontally(
@@ -788,7 +790,7 @@ private fun EditingContent(
                     label = "EditorNumberTransition",
                     modifier = Modifier.fillMaxWidth()
                 ) { state ->
-                    if (state == "result" && hasExpressionOperators && calculationResult != null) {
+                    if (state == "result" && hasExpressionOperators && calculationResult != null && !isSimpleSignEntry) {
                         Column(
                             horizontalAlignment = Alignment.End,
                             modifier = Modifier.fillMaxWidth()


### PR DESCRIPTION
## Description
<!-- Purpose of the PR -->
Hide result text when adding or decreasing manually the budget period.

#### Issue Linked (if any)
#214 

## Change strategy
<!-- Briefly explain the approach. -->
Dont show and check for the isSimpleSignEntry value to see if the current input of the numpad has any + or - as a leading value to hide the result label when typing any arithmetic value.

## Working demo
<!-- Attach any evidence of the change in action. -->
<img width="376" height="757" alt="Screenshot 2026-08-31 at 2 55 49 a m" src="https://github.com/user-attachments/assets/7eb6edb7-3c27-4fd9-95cc-8651a9763849" />

## Testing
- [x] Ran `:app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug --continue` for E2E test on a device and verify screenshots.
- [x] Added/updated tests when applicable.
- [x] Added screenshots or screen recordings for UI changes.
