### PR TITLE
fix: add API compatibility guards

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/edit/TransactionEditScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/history/edit/TransactionEditScreen.kt
@@ -270,10 +270,6 @@ fun TransactionEditScreen(
 
                 Spacer(modifier = Modifier.weight(1f))
             } else {
-                // A `weight` modifier passed as a parameter into TransactionEditToggleButton
-                // never reaches Row: TooltipBox interposes its own unweighted Box above the
-                // button, so the ParentData is attached too deep to be read. Hosting the button
-                // inside a directly-weighted Box here is what makes it actually stretch.
                 Box(modifier = Modifier.weight(1f)) {
                     TransactionEditToggleButton(
                         checked = isRecurrent,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/home/MainScreen.kt
@@ -1,7 +1,6 @@
 package com.serranoie.app.minus.presentation.ui.home
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,7 +22,6 @@ import logcat.logcat
 
 private const val TAG = "ISAAC:MainScreen"
 
-@RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun MainScreen(
     onNavigateToAnalytics: () -> Unit = {},
@@ -103,7 +101,11 @@ fun MainScreen(
                 context.packageName,
                 0,
             )
-            @Suppress("DEPRECATION") info.longVersionCode.toInt()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                info.longVersionCode.toInt()
+            } else {
+                @Suppress("DEPRECATION") info.versionCode
+            }
         },
     ) {
         TutorialBox(

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/Type.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/Type.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.presentation.ui.theme
 
+import android.os.Build
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -16,6 +17,11 @@ fun roundness(value: Float): FontVariation.Setting {
     return FontVariation.Setting("ROND", value)
 }
 
+// Version code guard since on API 27 fonts with custom width render incorrectly
+internal fun safeVariableWidth(width: Float): Float {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) width else 100f
+}
+
 @OptIn(ExperimentalTextApi::class)
 fun googleSansFlex(
     weight: Int = 400,
@@ -26,7 +32,7 @@ fun googleSansFlex(
         resId = R.font.google_sans_flex,
         variationSettings = FontVariation.Settings(
             FontVariation.weight(weight),
-            FontVariation.width(width),
+            FontVariation.width(safeVariableWidth(width)),
             roundness(if (isRounded) 100f else 0f)
         )
     )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/NumpadButton.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/numpad/NumpadButton.kt
@@ -53,6 +53,7 @@ import com.serranoie.app.minus.presentation.ui.theme.colorButton
 import com.serranoie.app.minus.presentation.ui.theme.colorOnButton
 import com.serranoie.app.minus.presentation.ui.theme.displaySmallCondensed
 import com.serranoie.app.minus.presentation.ui.theme.roundness
+import com.serranoie.app.minus.presentation.ui.theme.safeVariableWidth
 
 enum class NumpadButtonType { DEFAULT, PRIMARY, SECONDARY, TERTIARY, DELETE, OPERATOR }
 
@@ -175,7 +176,7 @@ private fun TextStyle.interpolateToEmphasized(
                 resId = R.font.google_sans_flex,
                 variationSettings = FontVariation.Settings(
                     FontVariation.weight(animatedWeight.toInt()),
-                    FontVariation.width(animatedWidth),
+                    FontVariation.width(safeVariableWidth(animatedWidth)),
                     roundness(if (isRounded) 100f else 0f)
                 )
             )


### PR DESCRIPTION
## Description
Add missing guard for the changelog generation using the version code.

#### Issue Linked (if any)
#221 

## Implemented
- Removed custom width font variation on API 27 since the app renders that custom typo with wrong spacing.

## Working demo
<!-- Attach any evidence of the change in action. -->
[Screen_recording_20260904_130433.webm](https://github.com/user-attachments/assets/f91b1a29-6eae-4631-812e-3c6118e71bd7)


## Testing
- [x] Ran `:app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug --continue` for E2E test on a device and verify screenshots.
- [x] Added/updated tests when applicable.
- [x] Added screenshots or screen recordings for UI changes.
