### PR TITLE
fix: enable marquee effect on projection label

### DIFF
--- a/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImpl.kt
@@ -159,7 +159,7 @@ class SettingsRepositoryImpl @Inject constructor(
                     ?: ContrastMode.NORMAL,
                 colorScheme = preferences[COLOR_SCHEME]?.toAppColorScheme()
                     ?: com.serranoie.app.minus.domain.model.AppColorScheme.BRAND,
-                language = preferences[LANGUAGE] ?: "en",
+                language = preferences[LANGUAGE] ?: "system",
                 dynamicColorEnabled = preferences[DYNAMIC_COLOR] ?: false,
                 isRoundedFontEnabled = preferences[ROUNDED_FONT] ?: true,
                 isAmoledEnabled = preferences[AMOLED] ?: false,

--- a/app/src/main/java/com/serranoie/app/minus/domain/model/UserSettingsModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/domain/model/UserSettingsModel.kt
@@ -17,7 +17,7 @@ data class UserSettings(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val typographyMode: TypographyMode = TypographyMode.EXPRESSIVE,
     val contrastMode: ContrastMode = ContrastMode.NORMAL,
-    val language: String = "en",
+    val language: String = "system",
     val colorScheme: AppColorScheme = AppColorScheme.BRAND,
     val dynamicColorEnabled: Boolean = false,
     val isCreditQuickToggleEnabled: Boolean = false,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/SettingsViewModel.kt
@@ -229,7 +229,11 @@ class SettingsViewModel @Inject constructor(
     fun onLanguageChange(language: String) {
         viewModelScope.launch {
             settingsRepository.setLanguage(language)
-            val appLocale: LocaleListCompat = LocaleListCompat.forLanguageTags(language)
+            val appLocale: LocaleListCompat = if (language == "system") {
+                LocaleListCompat.getEmptyLocaleList()
+            } else {
+                LocaleListCompat.forLanguageTags(language)
+            }
             AppCompatDelegate.setApplicationLocales(appLocale)
         }
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/appearance/AppearanceOptionsScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/settings/appearance/AppearanceOptionsScreen.kt
@@ -613,6 +613,7 @@ private fun LanguageSection(
     onLanguageChange: (String) -> Unit
 ) {
     val languages = listOf(
+        "system" to stringResource(R.string.settings_theme_system),
         "en" to stringResource(R.string.settings_language_en),
         "de" to stringResource(R.string.settings_language_de),
         "el" to stringResource(R.string.settings_language_el),
@@ -630,7 +631,7 @@ private fun LanguageSection(
 
     var isExpanded by remember { mutableStateOf(false) }
     val currentLabel = languages.find { it.first == currentLanguage }?.second
-        ?: stringResource(R.string.settings_language_en)
+        ?: stringResource(R.string.settings_theme_system)
 
     PaddedExpandableList(
         isExpanded = isExpanded,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/ThemeManager.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/ThemeManager.kt
@@ -1,6 +1,8 @@
 package com.serranoie.app.minus.presentation.ui.theme
 
 import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import com.serranoie.app.minus.domain.model.UserSettings
 import com.serranoie.app.minus.presentation.appColorScheme
 import com.serranoie.app.minus.presentation.appTheme
@@ -21,5 +23,14 @@ class ThemeManager @Inject constructor() {
         context.isAmoledEnabled = settings.isAmoledEnabled
         context.appColorScheme = settings.colorScheme
         context.dynamicColorEnabled = settings.dynamicColorEnabled
+        val appLocale = if (settings.language == "system") {
+            LocaleListCompat.getEmptyLocaleList()
+        } else {
+            LocaleListCompat.forLanguageTags(settings.language)
+        }
+        if (AppCompatDelegate.getApplicationLocales() != appLocale) {
+            AppCompatDelegate.setApplicationLocales(appLocale)
+        }
     }
 }
+

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/pill/BudgetPill.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/pill/BudgetPill.kt
@@ -1,5 +1,6 @@
 package com.serranoie.app.minus.presentation.ui.theme.component.budget.pill
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -42,7 +43,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.Wallpapers
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.serranoie.app.minus.R
@@ -682,4 +685,55 @@ private fun PreviewBudgetPillSmallHeight() {
         }
     }
 }
+
+@Preview(showBackground = true, locale = "bg", device = "id:4in WVGA (Nexus S)")
+@Preview(showBackground = true, locale = "bg", device = "id:4in WVGA (Nexus S)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+    wallpaper = Wallpapers.GREEN_DOMINATED_EXAMPLE
+)
+@Composable
+private fun PreviewBudgetPillWeeklyExceededWithProjection() {
+    MinusTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(16.dp)
+        ) {
+            BudgetPill(
+                budgetState = BudgetState(
+                    remainingToday = BigDecimal("-500.00"),
+                    totalSpentToday = BigDecimal("600.00"),
+                    dailyBudget = BigDecimal("47.62"),
+                    daysRemaining = 14,
+                    progress = 0.6f,
+                    isOverBudget = false,
+                    totalBudget = BigDecimal("1000.00"),
+                    totalSpentInPeriod = BigDecimal("600.00"),
+                    totalSpentThisWeek = BigDecimal("600.00"),
+                    dailyAllocation = BigDecimal("40.00"),
+                    weeklyAllocation = BigDecimal("333.33"),
+                    biweeklyAllocation = BigDecimal("466.67"),
+                    isTodayOverDailyAllocation = true,
+                    nextWeeklyAllocation = BigDecimal("200.00"),
+                ),
+                budgetSettings = BudgetSettings(
+                    totalBudget = BigDecimal("1000.00"),
+                    period = BudgetPeriod.BIWEEKLY,
+                    startDate = LocalDate.now(),
+                    currencyCode = "MXN",
+                    splitMode = BudgetSplitMode.DYNAMIC,
+                ),
+                viewPeriod = BudgetPeriod.WEEKLY,
+                currencyCode = "MXN",
+                splitMode = BudgetSplitMode.DYNAMIC,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp),
+                onOpenBudgetSheet = { },
+            )
+        }
+    }
+}
+
 

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/pill/BudgetPillStatusLabel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/budget/pill/BudgetPillStatusLabel.kt
@@ -128,13 +128,16 @@ internal fun StatusLabel(
             ) + fadeIn(animationSpec = tween(300))
         ) {
             if (hasProjection) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.basicMarquee(),
+                ) {
                     Text(
                         text = "${projectionLabel.orEmpty()} ",
                         style = secondaryStyle,
                         color = textColor,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        overflow = TextOverflow.Clip,
                     )
                     SegmentedAmountText(
                         text = projectionAmount,

--- a/app/src/test/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/java/com/serranoie/app/minus/data/repository/SettingsRepositoryImplTest.kt
@@ -41,7 +41,7 @@ class SettingsRepositoryImplTest {
 
         assertThat(settings.onboardingCompleted).isFalse()
         assertThat(settings.themeMode).isEqualTo(ThemeMode.SYSTEM)
-        assertThat(settings.language).isEqualTo("en")
+        assertThat(settings.language).isEqualTo("system")
         assertThat(settings.notificationHour).isEqualTo(UserSettings.DEFAULT_NOTIFICATION_HOUR)
         assertThat(settings.recurrentNotificationHour)
             .isEqualTo(UserSettings.DEFAULT_RECURRENT_NOTIFICATION_HOUR)


### PR DESCRIPTION
## Description
<!-- Purpose of the PR -->
add missing marquee effect on label

#### Issue Linked (if any)
#232 

## Implemented
- System locale to run when opening the app in case that the user have a different locale.
- add marquee modifier into budget pill label when projection is enabled.

## Testing
- [x] Ran `:app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug --continue` for E2E test on a device and verify screenshots.
- [x] Added/updated tests when applicable.
- [x] Added screenshots or screen recordings for UI changes