### PR TITLE
feat: use biometric to enable past period transactios

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -225,6 +225,7 @@ dependencies {
     }
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.biometric)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -1,6 +1,5 @@
 package com.serranoie.app.minus.presentation.ui.analytics
 
-import android.widget.Toast
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.fragment.app.FragmentActivity
 import com.serranoie.app.minus.presentation.util.BiometricPromptHelper
@@ -114,6 +113,7 @@ import com.serranoie.app.minus.presentation.ui.tutorial.markForTutorial
 import com.serranoie.app.minus.presentation.ui.tutorial.rememberTutorialBoxState
 import com.serranoie.app.minus.presentation.util.Utils.confirmFeedback
 import com.serranoie.app.minus.presentation.util.Utils.strongHapticFeedback
+import com.serranoie.app.minus.presentation.util.Utils.toToast
 import com.serranoie.app.minus.presentation.util.Utils.weakHapticFeedback
 import com.serranoie.app.minus.presentation.util.combineColors
 import kotlinx.coroutines.delay
@@ -634,7 +634,7 @@ fun Analytics(
                                 negativeButtonText = negativeButtonText,
                                 onSuccess = {
                                     isPastPeriodUnlocked = true
-                                    Toast.makeText(context, unlockedMessage, Toast.LENGTH_SHORT).show()
+                                    unlockedMessage.toToast(context)
                                     pendingTransactionIntent?.let { intent ->
                                         when (intent) {
                                             is HistoryUiIntent.SetEditingTransaction -> {
@@ -652,8 +652,8 @@ fun Analytics(
                                         pendingTransactionIntent = null
                                     }
                                 },
-                                onError = { err ->
-                                    Toast.makeText(context, err, Toast.LENGTH_SHORT).show()
+                                onError = { err: String ->
+                                    err.toToast(context)
                                     pendingTransactionIntent = null
                                 }
                             )

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/Analytics.kt
@@ -1,6 +1,10 @@
 package com.serranoie.app.minus.presentation.ui.analytics
 
+import android.widget.Toast
 import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.fragment.app.FragmentActivity
+import com.serranoie.app.minus.presentation.util.BiometricPromptHelper
+import com.serranoie.app.minus.presentation.ui.theme.bodyMediumCondensed
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -34,6 +38,7 @@ import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,6 +49,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
@@ -164,6 +170,8 @@ data class AnalyticsActions(
     val onHistoricalPeriodSelected: (Long) -> Unit = {},
     val onTutorialCompleted: (Boolean) -> Unit = {},
     val onGranularityChanged: (GraphGranularity) -> Unit = {},
+    val onUpdateTransaction: (Transaction) -> Unit = {},
+    val onDeleteTransaction: (Transaction) -> Unit = {},
 )
 
 data class Size(val width: Dp, val height: Dp)
@@ -185,6 +193,23 @@ fun Analytics(
     var historyExpandedDates by remember { mutableStateOf(setOf<LocalDate>()) }
     var showCreditSheet by remember { mutableStateOf(false) }
     var showPastPeriodsSheet by remember { mutableStateOf(false) }
+    var isPastPeriodUnlocked by remember { mutableStateOf(false) }
+    var localEditingTransaction by remember { mutableStateOf<Transaction?>(null) }
+    var showPastPeriodConfirmDialog by remember { mutableStateOf(false) }
+    var pendingTransactionIntent by remember { mutableStateOf<HistoryUiIntent?>(null) }
+
+    LaunchedEffect(state.isHistoricalView) {
+        if (!state.isHistoricalView) {
+            isPastPeriodUnlocked = false
+            localEditingTransaction = null
+        }
+    }
+
+    val biometricPromptTitle = stringResource(R.string.biometric_prompt_title)
+    val biometricPromptSubtitle = stringResource(R.string.biometric_prompt_subtitle)
+    val unlockedMessage = stringResource(R.string.past_period_unlocked_message)
+    val negativeButtonText = stringResource(android.R.string.cancel)
+
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val hasSpends = state.spends.isNotEmpty()
@@ -517,6 +542,48 @@ fun Analytics(
                 }
             }
 
+            var expandedTransactionId by remember { mutableStateOf<Long?>(null) }
+            val processHistoryIntent: (HistoryUiIntent) -> Unit = { intent ->
+                when (intent) {
+                    is HistoryUiIntent.ToggleExpandedDate -> {
+                        historyExpandedDates = if (historyExpandedDates.contains(intent.date)) {
+                            historyExpandedDates - intent.date
+                        } else {
+                            historyExpandedDates + intent.date
+                        }
+                    }
+                    is HistoryUiIntent.ToggleExpandedTransaction -> {
+                        expandedTransactionId = if (expandedTransactionId == intent.transactionId) null else intent.transactionId
+                    }
+                    is HistoryUiIntent.SetEditingTransaction -> {
+                        if (state.isHistoricalView && !isPastPeriodUnlocked && intent.transaction != null) {
+                            pendingTransactionIntent = intent
+                            showPastPeriodConfirmDialog = true
+                        } else {
+                            localEditingTransaction = intent.transaction
+                        }
+                    }
+                    is HistoryUiIntent.DeleteTransaction -> {
+                        if (state.isHistoricalView && !isPastPeriodUnlocked) {
+                            pendingTransactionIntent = intent
+                            showPastPeriodConfirmDialog = true
+                        } else {
+                            actions.onDeleteTransaction(intent.transaction)
+                        }
+                    }
+                    is HistoryUiIntent.SaveEditedTransaction -> {
+                        if (state.isHistoricalView && !isPastPeriodUnlocked) {
+                            pendingTransactionIntent = intent
+                            showPastPeriodConfirmDialog = true
+                        } else {
+                            actions.onUpdateTransaction(intent.transaction)
+                            localEditingTransaction = null
+                        }
+                    }
+                    else -> {}
+                }
+            }
+
             History(
                 uiState = HistoryUiState(
                     transactions = state.transactions,
@@ -527,16 +594,104 @@ fun Analytics(
                     creditOwed = state.creditOwed,
                     debtAdjustedBalance = state.debtAdjustedBalance,
                     expandedDates = historyExpandedDates,
-                ), readOnly = true, onProcessIntent = { intent ->
-                    if (intent is HistoryUiIntent.ToggleExpandedDate) {
-                        historyExpandedDates = if (historyExpandedDates.contains(intent.date)) {
-                            historyExpandedDates - intent.date
+                    expandedTransactionId = expandedTransactionId,
+                    editingTransaction = localEditingTransaction,
+                ),
+                readOnly = false,
+                onProcessIntent = processHistoryIntent,
+            )
+        }
+    }
+
+    if (showPastPeriodConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showPastPeriodConfirmDialog = false
+                pendingTransactionIntent = null
+            },
+            title = {
+                Text(
+                    stringResource(R.string.past_period_edit_confirm_title),
+                    style = MaterialTheme.typography.titleLargeEmphasized,
+                )
+            },
+            text = {
+                Text(
+                    stringResource(R.string.past_period_edit_confirm_message),
+                    style = MaterialTheme.typography.bodyMediumCondensed,
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showPastPeriodConfirmDialog = false
+                        val act = context as? FragmentActivity
+                        if (act != null) {
+                            BiometricPromptHelper.authenticate(
+                                activity = act,
+                                title = biometricPromptTitle,
+                                subtitle = biometricPromptSubtitle,
+                                negativeButtonText = negativeButtonText,
+                                onSuccess = {
+                                    isPastPeriodUnlocked = true
+                                    Toast.makeText(context, unlockedMessage, Toast.LENGTH_SHORT).show()
+                                    pendingTransactionIntent?.let { intent ->
+                                        when (intent) {
+                                            is HistoryUiIntent.SetEditingTransaction -> {
+                                                localEditingTransaction = intent.transaction
+                                            }
+                                            is HistoryUiIntent.DeleteTransaction -> {
+                                                actions.onDeleteTransaction(intent.transaction)
+                                            }
+                                            is HistoryUiIntent.SaveEditedTransaction -> {
+                                                actions.onUpdateTransaction(intent.transaction)
+                                                localEditingTransaction = null
+                                            }
+                                            else -> {}
+                                        }
+                                        pendingTransactionIntent = null
+                                    }
+                                },
+                                onError = { err ->
+                                    Toast.makeText(context, err, Toast.LENGTH_SHORT).show()
+                                    pendingTransactionIntent = null
+                                }
+                            )
                         } else {
-                            historyExpandedDates + intent.date
+                            isPastPeriodUnlocked = true
+                            pendingTransactionIntent?.let { intent ->
+                                when (intent) {
+                                    is HistoryUiIntent.SetEditingTransaction -> {
+                                        localEditingTransaction = intent.transaction
+                                    }
+                                    is HistoryUiIntent.DeleteTransaction -> {
+                                        actions.onDeleteTransaction(intent.transaction)
+                                    }
+                                    is HistoryUiIntent.SaveEditedTransaction -> {
+                                        actions.onUpdateTransaction(intent.transaction)
+                                        localEditingTransaction = null
+                                    }
+                                    else -> {}
+                                }
+                                pendingTransactionIntent = null
+                            }
                         }
                     }
-                })
-        }
+                ) {
+                    Text(stringResource(R.string.dialog_yes))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showPastPeriodConfirmDialog = false
+                        pendingTransactionIntent = null
+                    }
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 
     if (showPastPeriodsSheet) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsScreen.kt
@@ -65,6 +65,12 @@ fun AnalyticsScreen(
             },
             onGranularityChanged = { granularity ->
                 viewModel.onGranularityChanged(granularity)
+            },
+            onUpdateTransaction = { tx ->
+                viewModel.updateTransaction(tx)
+            },
+            onDeleteTransaction = { tx ->
+                viewModel.deleteTransaction(tx)
             }
         ),
         activityResultRegistryOwner = activityResultRegistryOwner,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/analytics/AnalyticsViewModel.kt
@@ -575,6 +575,18 @@ class AnalyticsViewModel @Inject constructor(
         _granularity.value = granularity
     }
 
+    fun updateTransaction(transaction: Transaction) {
+        viewModelScope.launch {
+            budgetRepository.updateTransaction(transaction)
+        }
+    }
+
+    fun deleteTransaction(transaction: Transaction) {
+        viewModelScope.launch {
+            budgetRepository.deleteTransaction(transaction)
+        }
+    }
+
     fun consumeEffect() {
         _effects.value = null
     }

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
@@ -68,7 +68,6 @@ fun ExpenseItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .then(if (!disableAnimations) Modifier.animateContentSize(animationSpec = tween(durationMillis = 150)) else Modifier)
     ) {
         val containerModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
             with(sharedTransitionScope) {

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/ExpenseItem.kt
@@ -68,7 +68,7 @@ fun ExpenseItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .then(if (!disableAnimations) Modifier.animateContentSize(animationSpec = tween(durationMillis = 200)) else Modifier)
+            .then(if (!disableAnimations) Modifier.animateContentSize(animationSpec = tween(durationMillis = 150)) else Modifier)
     ) {
         val containerModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
             with(sharedTransitionScope) {
@@ -91,7 +91,7 @@ fun ExpenseItem(
             AnimatedContent(
                 targetState = isExpanded,
                 transitionSpec = {
-                    fadeIn(tween(200, delayMillis = 100)) togetherWith fadeOut(tween(100))
+                    fadeIn(tween(150)) togetherWith fadeOut(tween(75))
                 },
                 label = "expense_item_header",
                 modifier = Modifier.weight(1f)

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/UpcomingRecurrentItemRow.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/UpcomingRecurrentItemRow.kt
@@ -99,7 +99,7 @@ fun UpcomingRecurrentItemRow(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .animateContentSize(animationSpec = tween(durationMillis = 200))
+            .animateContentSize(animationSpec = tween(durationMillis = 150))
     ) {
         CustomPaddedListItem(
             onClick = onClick,
@@ -111,7 +111,7 @@ fun UpcomingRecurrentItemRow(
             AnimatedContent(
                 targetState = isExpanded,
                 transitionSpec = {
-                    (fadeIn(animationSpec = tween(150, delayMillis = 50)) togetherWith
+                    (fadeIn(animationSpec = tween(150)) togetherWith
                             fadeOut(animationSpec = tween(50)))
                 },
                 label = "header_content",

--- a/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/UpcomingRecurrentItemRow.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/ui/theme/component/expense/UpcomingRecurrentItemRow.kt
@@ -99,7 +99,6 @@ fun UpcomingRecurrentItemRow(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .animateContentSize(animationSpec = tween(durationMillis = 150))
     ) {
         CustomPaddedListItem(
             onClick = onClick,

--- a/app/src/main/java/com/serranoie/app/minus/presentation/util/BiometricPromptHelper.kt
+++ b/app/src/main/java/com/serranoie/app/minus/presentation/util/BiometricPromptHelper.kt
@@ -1,0 +1,42 @@
+package com.serranoie.app.minus.presentation.util
+
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+object BiometricPromptHelper {
+    fun authenticate(
+        activity: FragmentActivity,
+        title: String,
+        subtitle: String,
+        negativeButtonText: String,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+        val biometricPrompt = BiometricPrompt(activity, executor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    super.onAuthenticationError(errorCode, errString)
+                    onError(errString.toString())
+                }
+
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    super.onAuthenticationSucceeded(result)
+                    onSuccess()
+                }
+
+                override fun onAuthenticationFailed() {
+                    super.onAuthenticationFailed()
+                }
+            })
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setNegativeButtonText(negativeButtonText)
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+    }
+}

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_month_heatmap_title">Месечна топлинна карта</string>
     <string name="widget_complete_budget_description">Проследявайте разходите, общия бюджет и оставащите дни — с бързо добавяне за нов разход</string>
     <string name="budget_graph_view_mode_cumulative">Тенденция</string>
+    <string name="unlock_past_period">Отключване за редактиране</string>
+    <string name="biometric_prompt_title">Отключване на минал период</string>
+    <string name="biometric_prompt_subtitle">Удостоверете се с пръстов отпечатък, за да промените предишни разходи</string>
+    <string name="past_period_unlocked_message">Редактирането на миналия период е успешно отключено</string>
+    <string name="past_period_edit_confirm_title">Промяна на разход от минал период?</string>
+    <string name="past_period_edit_confirm_message">Сигурни ли сте, че искате да редактирате или изтриете този разход от минал период? Ще е необходима биометрична автентификация.</string>
+    <string name="dialog_yes">Да</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_month_heatmap_title">Monats-Heatmap</string>
     <string name="widget_complete_budget_description">Behalten Sie Ausgaben, Gesamtbudget und verbleibende Tage im Blick – mit Schnellfunktion zum Hinzufügen neuer Ausgaben.</string>
     <string name="budget_graph_view_mode_cumulative">Tendenz</string>
+    <string name="unlock_past_period">Zum Bearbeiten entsperren</string>
+    <string name="biometric_prompt_title">Vergangenen Zeitraum entsperren</string>
+    <string name="biometric_prompt_subtitle">Authentifizieren Sie sich mit Ihrem Fingerabdruck, um vorherige Ausgaben zu ändern</string>
+    <string name="past_period_unlocked_message">Bearbeitung des vergangenen Zeitraums erfolgreich entsperrt</string>
+    <string name="past_period_edit_confirm_title">Ausgabe aus vergangenem Zeitraum ändern?</string>
+    <string name="past_period_edit_confirm_message">Sind Sie sicher, dass Sie diese Ausgabe aus einem vergangenen Zeitraum bearbeiten oder löschen möchten? Biometrische Authentifizierung ist erforderlich.</string>
+    <string name="dialog_yes">Ja</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_min_max_spent_title">Ελάχιστα/Μέγιστα δαπανηθέντα</string>
     <string name="widget_month_heatmap_title">Μηνιαίος χάρτης θερμότητας</string>
     <string name="widget_complete_budget_description">Παρακολουθήστε τις δαπάνες, το συνολικό προϋπολογισμό και τις ημέρες που απομένουν — με γρήγορη προσθήκη για νέα έξοδα</string>
+    <string name="unlock_past_period">Ξεκλείδωμα για επεξεργασία</string>
+    <string name="biometric_prompt_title">Ξεκλείδωμα προηγούμενης περιόδου</string>
+    <string name="biometric_prompt_subtitle">Επαληθεύστε με το δακτυλικό σας αποτύπωμα για να τροποποιήσετε προηγούμενα έξοδα</string>
+    <string name="past_period_unlocked_message">Η επεξεργασία της προηγούμενης περιόδου ξεκλειδώθηκε επιτυχώς</string>
+    <string name="past_period_edit_confirm_title">Τροποποίηση εξόδου προηγούμενης περιόδου;</string>
+    <string name="past_period_edit_confirm_message">Είστε σίγουροι ότι θέλετε να επεξεργαστείτε ή να διαγράψετε αυτό το έξοδο από προηγούμενη περίοδο; Θα απαιτηθεί βιομετρικός έλεγχος ταυτότητας.</string>
+    <string name="dialog_yes">Ναι</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_min_max_spent_title">Gasto mín/máx</string>
     <string name="widget_month_heatmap_title">Mapa de calor mensual</string>
     <string name="widget_complete_budget_description">Rastrea gastos, presupuesto total y días restantes — con adición rápida para un nuevo gasto</string>
+    <string name="unlock_past_period">Desbloquear para editar</string>
+    <string name="biometric_prompt_title">Desbloquear período anterior</string>
+    <string name="biometric_prompt_subtitle">Autentícate con tu huella digital para modificar gastos anteriores</string>
+    <string name="past_period_unlocked_message">Edición del período anterior desbloqueada exitosamente</string>
+    <string name="past_period_edit_confirm_title">¿Modificar gasto de período anterior?</string>
+    <string name="past_period_edit_confirm_message">¿Estás seguro de que deseas editar o eliminar este gasto de un período anterior? Se requerirá autenticación biométrica.</string>
+    <string name="dialog_yes">Sí</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -617,4 +617,11 @@
     <string name="widget_min_max_spent_title">Gasto mín/máx</string>
     <string name="widget_month_heatmap_title">Mapa de calor mensual</string>
     <string name="widget_complete_budget_description">Rastrea gastos, presupuesto total y días restantes — con adición rápida para un nuevo gasto</string>
+    <string name="unlock_past_period">Desbloquear para editar</string>
+    <string name="biometric_prompt_title">Desbloquear período anterior</string>
+    <string name="biometric_prompt_subtitle">Autentícate con tu huella digital para modificar gastos anteriores</string>
+    <string name="past_period_unlocked_message">Edición del período anterior desbloqueada exitosamente</string>
+    <string name="past_period_edit_confirm_title">¿Modificar gasto de período anterior?</string>
+    <string name="past_period_edit_confirm_message">¿Estás seguro de que deseas editar o eliminar este gasto de un período anterior? Se requerirá autenticación biométrica.</string>
+    <string name="dialog_yes">Sí</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_month_heatmap_title">Carte thermique mensuelle</string>
     <string name="widget_complete_budget_description">Suivez vos dépenses, le budget total et les jours restants — avec une fonction d\'ajout rapide pour une nouvelle dépense.</string>
     <string name="budget_graph_view_mode_cumulative">Tendance</string>
+    <string name="unlock_past_period">Déverrouiller pour modifier</string>
+    <string name="biometric_prompt_title">Déverrouiller la période précédente</string>
+    <string name="biometric_prompt_subtitle">Authentifiez-vous avec votre empreinte digitale pour modifier les dépenses précédentes</string>
+    <string name="past_period_unlocked_message">Modification de la période précédente déverrouillée avec succès</string>
+    <string name="past_period_edit_confirm_title">Modifier la dépense d\'une période précédente?</string>
+    <string name="past_period_edit_confirm_message">Êtes-vous sûr de vouloir modifier ou supprimer cette dépense d\'une période précédente? Une authentification biométrique sera requise.</string>
+    <string name="dialog_yes">Oui</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_min_max_spent_title">न्यूनतम/अधिकतम खर्च</string>
     <string name="widget_month_heatmap_title">महीने का हीटमैप</string>
     <string name="widget_complete_budget_description">खर्च, कुल बजट और बचे हुए दिनों को ट्रैक करें — नए खर्च के लिए क्विक-एड के साथ</string>
+    <string name="unlock_past_period">संपादित करने के लिए अनलॉक करें</string>
+    <string name="biometric_prompt_title">पिछली अवधि अनलॉक करें</string>
+    <string name="biometric_prompt_subtitle">पिछले खर्चों को संशोधित करने के लिए अपने फिंगरप्रिंट से प्रमाणित करें</string>
+    <string name="past_period_unlocked_message">पिछली अवधि का संपादन सफलतापूर्वक अनलॉक किया गया</string>
+    <string name="past_period_edit_confirm_title">क्या पिछली अवधि का खर्च संशोधित करें?</string>
+    <string name="past_period_edit_confirm_message">क्या आप वाकई पिछली अवधि के इस खर्च को संपादित या हटाना चाहते हैं? बायोमेट्रिक प्रमाणीकरण आवश्यक होगा।</string>
+    <string name="dialog_yes">हाँ</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_min_max_spent_title">Spesa Min/Max</string>
     <string name="widget_month_heatmap_title">Mappa termica mensile</string>
     <string name="widget_complete_budget_description">Monitora le spese, il budget totale e i giorni rimasti — con aggiunta rapida per una nuova spesa</string>
+    <string name="unlock_past_period">Sblocca per modificare</string>
+    <string name="biometric_prompt_title">Sblocca periodo precedente</string>
+    <string name="biometric_prompt_subtitle">Autenticati con la tua impronta digitale per modificare le spese precedenti</string>
+    <string name="past_period_unlocked_message">Modifica del periodo precedente sbloccata con successo</string>
+    <string name="past_period_edit_confirm_title">Modificare la spesa del periodo precedente?</string>
+    <string name="past_period_edit_confirm_message">Sei sicuro di voler modificare o eliminare questa spesa da un periodo precedente? Sarà richiesta l\'autenticazione biometrica.</string>
+    <string name="dialog_yes">Sì</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_month_heatmap_title">月間ヒートマップ</string>
     <string name="widget_complete_budget_description">支出、総予算、残り日数を追跡 — 新しい支出をすぐに追加可能</string>
     <string name="expand_numpad">テンキーを展開</string>
+    <string name="unlock_past_period">編集のロックを解除</string>
+    <string name="biometric_prompt_title">過去の期間のロック解除</string>
+    <string name="biometric_prompt_subtitle">指紋認証で過去の支出を修正します</string>
+    <string name="past_period_unlocked_message">過去の期間の編集が正常にロック解除されました</string>
+    <string name="past_period_edit_confirm_title">過去の期間の支出を修正しますか？</string>
+    <string name="past_period_edit_confirm_message">過去の期間の支出を編集または削除してもよろしいですか？ 生体認証が必要です。</string>
+    <string name="dialog_yes">はい</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -616,4 +616,11 @@
     <string name="widget_min_max_spent_title">최소/최대 지출</string>
     <string name="widget_month_heatmap_title">월간 히트맵</string>
     <string name="widget_complete_budget_description">지출, 총 예산 및 남은 일수 추적 — 새 지출 빠른 추가 기능 포함</string>
+    <string name="unlock_past_period">편집 잠금 해제</string>
+    <string name="biometric_prompt_title">이전 기간 잠금 해제</string>
+    <string name="biometric_prompt_subtitle">지문 인증으로 이전 지출을 수정하세요</string>
+    <string name="past_period_unlocked_message">이전 기간 편집 잠금이 성공적으로 해제되었습니다</string>
+    <string name="past_period_edit_confirm_title">이전 기간 지출을 수정하시겠습니까?</string>
+    <string name="past_period_edit_confirm_message">이전 기간의 지출을 수정하거나 삭제하시겠습니까? 생체 인식 인증이 필요합니다.</string>
+    <string name="dialog_yes">예</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -615,4 +615,11 @@
     <string name="widget_min_max_spent_title">Gasto Mín/Máx</string>
     <string name="widget_month_heatmap_title">Mapa de calor mensal</string>
     <string name="widget_complete_budget_description">Acompanhe gastos, orçamento total e dias restantes — com adição rápida para uma nova despesa</string>
+    <string name="unlock_past_period">Desbloquear para editar</string>
+    <string name="biometric_prompt_title">Desbloquear período anterior</string>
+    <string name="biometric_prompt_subtitle">Autentique-se com sua impressão digital para modificar despesas anteriores</string>
+    <string name="past_period_unlocked_message">Edição do período anterior desbloqueada com sucesso</string>
+    <string name="past_period_edit_confirm_title">Modificar despesa de período anterior?</string>
+    <string name="past_period_edit_confirm_message">Tem certeza de que deseja editar ou excluir esta despesa de um período anterior? A autenticação biométrica será necessária.</string>
+    <string name="dialog_yes">Sim</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -621,4 +621,11 @@
     <string name="widget_min_max_spent_title">Мин/Макс расходы</string>
     <string name="widget_month_heatmap_title">Месячная тепловая карта</string>
     <string name="widget_complete_budget_description">Отслеживайте расходы, общий бюджет и оставшиеся дни — с быстрым добавлением нового расхода</string>
+    <string name="unlock_past_period">Разблокировать для правки</string>
+    <string name="biometric_prompt_title">Разблокировать прошлый период</string>
+    <string name="biometric_prompt_subtitle">Подтвердите личность по отпечатку пальца для изменения прошлых расходов</string>
+    <string name="past_period_unlocked_message">Редактирование прошлого периода успешно разблокировано</string>
+    <string name="past_period_edit_confirm_title">Изменить расход за прошлый период?</string>
+    <string name="past_period_edit_confirm_message">Вы уверены, что хотите изменить или удалить этот расход из прошлого периода? Потребуется биометрическая аутентификация.</string>
+    <string name="dialog_yes">Да</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -614,4 +614,11 @@
     <string name="widget_complete_budget_description">追踪支出、总预算及剩余天数——支持快速添加新支出</string>
     <string name="budget_pill_calc_added">将添加 %1$s</string>
     <string name="budget_graph_view_mode_cumulative">趋势</string>
+    <string name="unlock_past_period">解锁以编辑</string>
+    <string name="biometric_prompt_title">解锁上一周期</string>
+    <string name="biometric_prompt_subtitle">使用指纹验证来修改先前的支出</string>
+    <string name="past_period_unlocked_message">已成功解锁上一周期的编辑权限</string>
+    <string name="past_period_edit_confirm_title">修改上一周期的支出？</string>
+    <string name="past_period_edit_confirm_message">您确定要编辑或删除上一周期的这笔支出吗？这需要生物识别验证。</string>
+    <string name="dialog_yes">是</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -691,6 +691,13 @@
     <string name="past_periods_estimated_divider">Estimated periods below</string>
     <string name="past_periods_status_saved">Saved %1$s</string>
     <string name="past_periods_saved_label">Money Saved</string>
+    <string name="unlock_past_period" translatable="false">Unlock to Edit</string>
+    <string name="biometric_prompt_title" translatable="false">Unlock Past Period</string>
+    <string name="biometric_prompt_subtitle" translatable="false">Authenticate with your fingerprint to modify previous expenses</string>
+    <string name="past_period_unlocked_message" translatable="false">Past period editing unlocked successfully</string>
+    <string name="past_period_edit_confirm_title" translatable="false">Modify Past Period Expense?</string>
+    <string name="past_period_edit_confirm_message" translatable="false">Are you sure you want to edit or delete this expense from a past period? Biometric authentication will be required.</string>
+    <string name="dialog_yes" translatable="false">Yes</string>
 
     <!-- Analytics Tutorial -->
     <string name="analytics_tutorial_minmax_title">Spending Trends</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -691,13 +691,13 @@
     <string name="past_periods_estimated_divider">Estimated periods below</string>
     <string name="past_periods_status_saved">Saved %1$s</string>
     <string name="past_periods_saved_label">Money Saved</string>
-    <string name="unlock_past_period" translatable="false">Unlock to Edit</string>
-    <string name="biometric_prompt_title" translatable="false">Unlock Past Period</string>
-    <string name="biometric_prompt_subtitle" translatable="false">Authenticate with your fingerprint to modify previous expenses</string>
-    <string name="past_period_unlocked_message" translatable="false">Past period editing unlocked successfully</string>
-    <string name="past_period_edit_confirm_title" translatable="false">Modify Past Period Expense?</string>
-    <string name="past_period_edit_confirm_message" translatable="false">Are you sure you want to edit or delete this expense from a past period? Biometric authentication will be required.</string>
-    <string name="dialog_yes" translatable="false">Yes</string>
+    <string name="unlock_past_period">Unlock to Edit</string>
+    <string name="biometric_prompt_title">Unlock Past Period</string>
+    <string name="biometric_prompt_subtitle">Authenticate with your fingerprint to modify previous expenses</string>
+    <string name="past_period_unlocked_message">Past period editing unlocked successfully</string>
+    <string name="past_period_edit_confirm_title">Modify Past Period Expense?</string>
+    <string name="past_period_edit_confirm_message">Are you sure you want to edit or delete this expense from a past period? Biometric authentication will be required.</string>
+    <string name="dialog_yes">Yes</string>
 
     <!-- Analytics Tutorial -->
     <string name="analytics_tutorial_minmax_title">Spending Trends</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,9 +51,11 @@ kotlinxCoroutinesTest = "1.10.2"
 turbine = "1.2.0"
 mockk = "1.14.11"
 byteBuddyAgent = "1.14.17"
+biometric = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Description
<!-- Purpose of the PR -->
Per user request, enable past period editing showing an alert dialog and biometric lock (99% of phones already have a finger sensor)

#### Issue Linked (if any)
#231 

## Change strategy
<!-- Briefly explain the approach. -->
Implement library to look into the biometric hardware and from total expenses list, enable swipe and expandable content when tapping each item.

## Working demo
<!-- Attach any evidence of the change in action. -->
https://github.com/user-attachments/assets/81edf6ac-74e0-4531-b2b8-77f400d61f35

## Testing
- [x] Ran `:app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug --continue` for E2E test on a device and verify screenshots.
- [x] Added/updated tests when applicable.
- [x] Added screenshots or screen recordings for UI changes.

## Notes
<!-- Risks, follow-ups, or anything reviewers should know. -->
