### PR TITLE
feat(wear): apply dynamic currency formatting in entry screens

### DIFF
--- a/wear/src/main/java/com/serranoie/app/wear/minus/presentation/CategoryDecEntryScreen.kt
+++ b/wear/src/main/java/com/serranoie/app/wear/minus/presentation/CategoryDecEntryScreen.kt
@@ -1,6 +1,7 @@
 package com.serranoie.app.wear.minus.presentation
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,142 +36,148 @@ import com.serranoie.app.wear.minus.presentation.theme.component.PaddedListItemP
 
 @Composable
 internal fun CategoryDecEntryScreen(
-	amount: String,
-	categories: List<String>,
-	selectedCategory: String,
-	onCategoryTap: (String) -> Unit,
-	onCategoryInputChanged: (String) -> Unit,
-	onSave: () -> Unit
+    amount: String,
+    currencySymbol: String,
+    symbolAtEnd: Boolean,
+    categories: List<String>,
+    selectedCategory: String,
+    onCategoryTap: (String) -> Unit,
+    onCategoryInputChanged: (String) -> Unit,
+    onSave: () -> Unit
 ) {
-	val listState = rememberTransformingLazyColumnState()
+    val listState = rememberTransformingLazyColumnState()
 
-	AppScaffold(timeText = {}) {
-		ScreenScaffold(
-			scrollState = listState, timeText = null, edgeButton = {
-				EdgeButton(onClick = onSave) {
-					Text(stringResource(R.string.category_save))
-				}
-			}) {
-			TransformingLazyColumn(
-				state = listState,
-				modifier = Modifier
+    AppScaffold(timeText = {}) {
+        ScreenScaffold(
+            scrollState = listState, timeText = null, edgeButton = {
+                EdgeButton(onClick = onSave) {
+                    Text(stringResource(R.string.category_save))
+                }
+            }) {
+            TransformingLazyColumn(
+                state = listState,
+                modifier = Modifier
 					.fillMaxSize()
 					.padding(horizontal = 8.dp),
-				contentPadding = PaddingValues(top = 8.dp, bottom = 56.dp),
-				verticalArrangement = Arrangement.spacedBy(6.dp)
-			) {
-				item {
-					Text(
-						text = "$$amount",
-						style = MaterialTheme.typography.displayMedium,
-						modifier = Modifier.padding(top = 8.dp)
-					)
-				}
+                contentPadding = PaddingValues(top = 8.dp, bottom = 56.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                item {
+                    Text(
+                        text = formatMoney(currencySymbol, symbolAtEnd, amount),
+                        style = MaterialTheme.typography.displayMedium,
+                        maxLines = 1,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = 8.dp).basicMarquee()
+                    )
+                }
 
-				item {
-					ManualCategoryInput(
-						value = selectedCategory,
-						onValueChange = onCategoryInputChanged,
-					)
-				}
+                item {
+                    ManualCategoryInput(
+                        value = selectedCategory,
+                        onValueChange = onCategoryInputChanged,
+                    )
+                }
 
-				item {
-					if (categories.isNotEmpty()) {
-						PaddedListGroup {
-							categories.forEachIndexed { index, category ->
-								CategoryListItem(
-									label = category,
-									selected = category == selectedCategory,
-									position = categoryPosition(index, categories.lastIndex),
-									onClick = { onCategoryTap(category) })
-							}
-						}
-					} else {
-						Text(text = stringResource(R.string.category_none_yet), fontSize = 10.sp)
-					}
-				}
-			}
-		}
-	}
+                item {
+                    if (categories.isNotEmpty()) {
+                        PaddedListGroup {
+                            categories.forEachIndexed { index, category ->
+                                CategoryListItem(
+                                    label = category,
+                                    selected = category == selectedCategory,
+                                    position = categoryPosition(index, categories.lastIndex),
+                                    onClick = { onCategoryTap(category) })
+                            }
+                        }
+                    } else {
+                        Text(text = stringResource(R.string.category_none_yet), fontSize = 10.sp)
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable
 private fun ManualCategoryInput(
-	value: String,
-	onValueChange: (String) -> Unit,
+    value: String,
+    onValueChange: (String) -> Unit,
 ) {
-	BasicTextField(
-		value = value,
-		onValueChange = { onValueChange(it.take(24)) },
-		singleLine = true,
-		keyboardOptions = KeyboardOptions(
-			capitalization = KeyboardCapitalization.Words, imeAction = ImeAction.Done
-		),
-		textStyle = MaterialTheme.typography.labelMedium.copy(color = MaterialTheme.colorScheme.onTertiaryContainer),
-		modifier = Modifier
+    BasicTextField(
+        value = value,
+        onValueChange = { onValueChange(it.take(24)) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Words, imeAction = ImeAction.Done
+        ),
+        textStyle = MaterialTheme.typography.labelMedium.copy(color = MaterialTheme.colorScheme.onTertiaryContainer),
+        modifier = Modifier
 			.fillMaxWidth()
 			.height(36.dp)
 			.background(MaterialTheme.colorScheme.surfaceContainer, RoundedCornerShape(5.dp))
 			.padding(horizontal = 16.dp, vertical = 8.dp),
-		decorationBox = { innerTextField ->
-			if (value.isBlank()) {
-				Text(
-					text = stringResource(R.string.category_input_hint),
-					style = MaterialTheme.typography.labelSmall,
-					color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-				)
-			}
-			innerTextField()
-		})
+        decorationBox = { innerTextField ->
+            if (value.isBlank()) {
+                Text(
+                    text = stringResource(R.string.category_input_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+            }
+            innerTextField()
+        })
 }
 
 @Composable
 private fun CategoryListItem(
-	label: String, selected: Boolean, position: PaddedListItemPosition, onClick: () -> Unit
+    label: String, selected: Boolean, position: PaddedListItemPosition, onClick: () -> Unit
 ) {
-	CustomPaddedListItem(
-		onClick = onClick, position = position, background = if (selected) {
-			MaterialTheme.colorScheme.secondary
-		} else {
-			MaterialTheme.colorScheme.surfaceContainer
-		}, contentColor = if (selected) {
-			MaterialTheme.colorScheme.onSecondary
-		} else {
-			MaterialTheme.colorScheme.onSurface
-		}
-	) {
-		Text(
-			text = label, maxLines = 1, style = MaterialTheme.typography.labelSmall.copy(
-				fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
-			), color = if (selected) {
-				MaterialTheme.colorScheme.onPrimary
-			} else {
-				MaterialTheme.colorScheme.onSurface
-			}, modifier = Modifier.fillMaxWidth()
-		)
-	}
+    CustomPaddedListItem(
+        onClick = onClick, position = position, background = if (selected) {
+            MaterialTheme.colorScheme.secondary
+        } else {
+            MaterialTheme.colorScheme.surfaceContainer
+        }, contentColor = if (selected) {
+            MaterialTheme.colorScheme.onSecondary
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+    ) {
+        Text(
+            text = label, maxLines = 1, style = MaterialTheme.typography.labelSmall.copy(
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
+            ), color = if (selected) {
+                MaterialTheme.colorScheme.onPrimary
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }, modifier = Modifier.fillMaxWidth()
+        )
+    }
 }
 
 private fun categoryPosition(index: Int, lastIndex: Int): PaddedListItemPosition {
-	return when {
-		lastIndex == 0 -> PaddedListItemPosition.Single
-		index == 0 -> PaddedListItemPosition.First
-		index == lastIndex -> PaddedListItemPosition.Last
-		else -> PaddedListItemPosition.Middle
-	}
+    return when {
+        lastIndex == 0 -> PaddedListItemPosition.Single
+        index == 0 -> PaddedListItemPosition.First
+        index == lastIndex -> PaddedListItemPosition.Last
+        else -> PaddedListItemPosition.Middle
+    }
 }
 
 @Preview(device = "id:wearos_small_round", showBackground = true, showSystemUi = true)
 @Composable
 private fun PreviewCategoryEntry() {
-	MinusTheme {
-		CategoryDecEntryScreen(
-			amount = "123",
-			categories = listOf("Groceries", "Coffee", "Food"),
-			selectedCategory = "Coffee",
-			onCategoryTap = {},
-			onCategoryInputChanged = {},
-			onSave = {},
-		)
-	}
+    MinusTheme {
+        CategoryDecEntryScreen(
+            amount = "123123.52",
+            categories = listOf("Groceries", "Coffee", "Food"),
+            selectedCategory = "Coffee",
+            onCategoryTap = {},
+            onCategoryInputChanged = {},
+            onSave = {},
+            currencySymbol = "AED",
+            symbolAtEnd = false,
+        )
+    }
 }

--- a/wear/src/main/java/com/serranoie/app/wear/minus/presentation/MainActivity.kt
+++ b/wear/src/main/java/com/serranoie/app/wear/minus/presentation/MainActivity.kt
@@ -175,6 +175,8 @@ private fun WearCalculatorContent(
 
             EntryStep.AMOUNT -> NumpadEntryScreen(
                 amount = amountState.value,
+                currencySymbol = overviewState.currencySymbol,
+                symbolAtEnd = overviewState.symbolAtEnd,
                 onDigit = { key -> appendDigit(amountState, key) },
                 onDot = { appendDot(amountState) },
                 onBackspace = { amountState.value = amountState.value.dropLast(1) },
@@ -190,6 +192,8 @@ private fun WearCalculatorContent(
 
             EntryStep.CATEGORY -> CategoryDecEntryScreen(
                 amount = amountState.value,
+                currencySymbol = overviewState.currencySymbol,
+                symbolAtEnd = overviewState.symbolAtEnd,
                 categories = categories,
                 selectedCategory = commentState.value,
                 onCategoryTap = { selected -> commentState.value = selected },

--- a/wear/src/main/java/com/serranoie/app/wear/minus/presentation/NumpadEntryScreen.kt
+++ b/wear/src/main/java/com/serranoie/app/wear/minus/presentation/NumpadEntryScreen.kt
@@ -32,173 +32,170 @@ import androidx.wear.compose.material3.TextButtonDefaults
 import com.serranoie.app.wear.minus.R
 import com.serranoie.app.wear.minus.presentation.theme.MinusTheme
 import java.math.BigDecimal
-import java.text.NumberFormat
-import java.util.Locale
 
 @Composable
 internal fun NumpadEntryScreen(
-	amount: String,
-	onDigit: (String) -> Unit,
-	onDot: () -> Unit,
-	onBackspace: () -> Unit,
-	onClear: () -> Unit,
-	onContinue: () -> Unit
+    amount: String,
+    currencySymbol: String,
+    symbolAtEnd: Boolean,
+    onDigit: (String) -> Unit,
+    onDot: () -> Unit,
+    onBackspace: () -> Unit,
+    onClear: () -> Unit,
+    onContinue: () -> Unit
 ) {
-	val listState = rememberTransformingLazyColumnState()
-	val canContinue = amountToBigDecimalOrZero(amount) > BigDecimal.ZERO
+    val listState = rememberTransformingLazyColumnState()
+    val canContinue = amountToBigDecimalOrZero(amount) > BigDecimal.ZERO
 
-	AppScaffold(timeText = {}) {
-		ScreenScaffold(
-			scrollState = listState, timeText = null, edgeButton = {
-				EdgeButton(onClick = onContinue, enabled = canContinue) {
-					Text(text = "+")
-				}
-			}) {
-			TransformingLazyColumn(
-				state = listState,
-				modifier = Modifier.fillMaxSize(),
-				contentPadding = PaddingValues(top = 14.dp, bottom = 65.dp),
-				verticalArrangement = Arrangement.spacedBy(4.dp),
-				horizontalAlignment = Alignment.CenterHorizontally
-			) {
-				item {
-					Text(
-						text = visualTransformationAsCurrency(amount),
-						style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Black),
-						color = MaterialTheme.colorScheme.primary
-					)
-				}
+    AppScaffold(timeText = {}) {
+        ScreenScaffold(
+            scrollState = listState, timeText = null, edgeButton = {
+                EdgeButton(onClick = onContinue, enabled = canContinue) {
+                    Text(text = "+")
+                }
+            }) {
+            TransformingLazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(top = 14.dp, bottom = 65.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                item {
+                    Text(
+                        text = formatMoney(currencySymbol, symbolAtEnd, amount),
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Black),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
 
-				items(listOf("1" to "2" to "3", "4" to "5" to "6", "7" to "8" to "9")) { row ->
-					val (leftPair, right) = row
-					val (left, middle) = leftPair
-					KeypadRow(modifier = Modifier.fillMaxWidth(), left = { slot ->
-						NumberKey(
-							text = left, modifier = slot
-						) { onDigit(left) }
-					}, middle = { slot ->
-						NumberKey(text = middle, modifier = slot) {
-							onDigit(
-								middle
-							)
-						}
-					}, right = { slot ->
-						NumberKey(
-							text = right, modifier = slot
-						) { onDigit(right) }
-					})
-				}
+                items(listOf("1" to "2" to "3", "4" to "5" to "6", "7" to "8" to "9")) { row ->
+                    val (leftPair, right) = row
+                    val (left, middle) = leftPair
+                    KeypadRow(modifier = Modifier.fillMaxWidth(), left = { slot ->
+                        NumberKey(
+                            text = left, modifier = slot
+                        ) { onDigit(left) }
+                    }, middle = { slot ->
+                        NumberKey(text = middle, modifier = slot) {
+                            onDigit(
+                                middle
+                            )
+                        }
+                    }, right = { slot ->
+                        NumberKey(
+                            text = right, modifier = slot
+                        ) { onDigit(right) }
+                    })
+                }
 
-				item {
-					KeypadRow(
-						modifier = Modifier.fillMaxWidth(),
-						left = { slot -> NumberKey(text = ".", modifier = slot) { onDot() } },
-						middle = { slot ->
-							NumberKey(
-								text = "0", modifier = slot
-							) { onDigit("0") }
-						},
-						right = { slot ->
-							DeleteKey(
-								modifier = slot,
-								onClick = onBackspace,
-								onLongClick = onClear
-							)
-						},
-					)
-				}
-			}
-		}
-	}
+                item {
+                    KeypadRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        left = { slot -> NumberKey(text = ".", modifier = slot) { onDot() } },
+                        middle = { slot ->
+                            NumberKey(
+                                text = "0", modifier = slot
+                            ) { onDigit("0") }
+                        },
+                        right = { slot ->
+                            DeleteKey(
+                                modifier = slot,
+                                onClick = onBackspace,
+                                onLongClick = onClear
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
 private fun KeypadRow(
-	left: @Composable (Modifier) -> Unit,
-	middle: @Composable (Modifier) -> Unit,
-	right: @Composable (Modifier) -> Unit,
-	modifier: Modifier
+    left: @Composable (Modifier) -> Unit,
+    middle: @Composable (Modifier) -> Unit,
+    right: @Composable (Modifier) -> Unit,
+    modifier: Modifier
 ) {
-	Row(
-		horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
-		modifier = modifier.padding(horizontal = 16.dp)
-	) {
-		val slotModifier = Modifier.weight(1f)
-		left(slotModifier)
-		middle(slotModifier)
-		right(slotModifier)
-	}
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
+        modifier = modifier.padding(horizontal = 16.dp)
+    ) {
+        val slotModifier = Modifier.weight(1f)
+        left(slotModifier)
+        middle(slotModifier)
+        right(slotModifier)
+    }
 }
 
 @Composable
 private fun NumberKey(text: String, modifier: Modifier = Modifier, onClick: () -> Unit) {
-	TextButton(
-		onClick = onClick,
-		modifier = modifier
+    TextButton(
+        onClick = onClick,
+        modifier = modifier
 			.height(32.dp)
 			.width(32.dp),
-		colors = TextButtonDefaults.textButtonColors(
-			containerColor = MaterialTheme.colorScheme.surfaceContainer,
-			contentColor = MaterialTheme.colorScheme.onSurface
-		),
-		shapes = TextButtonDefaults.animatedShapes(),
-	) {
-		Box(
-			modifier = Modifier.fillMaxSize(),
-			contentAlignment = Alignment.Center
-		) {
-			Text(
-				text = text,
-				textAlign = TextAlign.Center,
-				style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-			)
-		}
-	}
+        colors = TextButtonDefaults.textButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            contentColor = MaterialTheme.colorScheme.onSurface
+        ),
+        shapes = TextButtonDefaults.animatedShapes(),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+        }
+    }
 }
 
 @Composable
 private fun DeleteKey(
-	modifier: Modifier = Modifier,
-	onClick: () -> Unit,
-	onLongClick: () -> Unit
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
 ) {
-	FilledIconButton(
-		onClick = onClick,
-		onLongClick = onLongClick,
-		onLongClickLabel = stringResource(R.string.numpad_clear_amount),
-		colors = IconButtonDefaults.filledIconButtonColors(
-			containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-			contentColor = MaterialTheme.colorScheme.tertiary
-		),
-		shapes = IconButtonDefaults.animatedShapes(),
-		modifier = modifier
+    FilledIconButton(
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onLongClickLabel = stringResource(R.string.numpad_clear_amount),
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.tertiary
+        ),
+        shapes = IconButtonDefaults.animatedShapes(),
+        modifier = modifier
 			.height(32.dp)
 			.width(32.dp)
-	) {
-		Text(text = "⌫", style = MaterialTheme.typography.titleMedium)
-	}
-}
-
-private fun visualTransformationAsCurrency(rawAmount: String): String {
-	val amount = amountToBigDecimalOrZero(rawAmount)
-	return NumberFormat.getCurrencyInstance(Locale.US).format(amount)
+    ) {
+        Text(text = "⌫", style = MaterialTheme.typography.titleMedium)
+    }
 }
 
 private fun amountToBigDecimalOrZero(rawAmount: String): BigDecimal {
-	if (rawAmount.isBlank()) return BigDecimal.ZERO
-	return rawAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO
+    if (rawAmount.isBlank()) return BigDecimal.ZERO
+    return rawAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO
 }
 
 @Preview(device = "id:wearos_small_round", showSystemUi = false)
 @Composable
 private fun NumpadEntryScreenPreview() {
-	MinusTheme {
-		NumpadEntryScreen(
-			amount = "12,500.00",
-			onDigit = {},
-			onDot = {},
-			onBackspace = {},
-			onClear = {},
-			onContinue = {})
-	}
+    MinusTheme {
+        NumpadEntryScreen(
+            amount = "12500.00",
+            currencySymbol = "MAD",
+            symbolAtEnd = false,
+            onDigit = {},
+            onDot = {},
+            onBackspace = {},
+            onClear = {},
+            onContinue = {})
+    }
 }

--- a/wear/src/main/java/com/serranoie/app/wear/minus/presentation/PeriodOverviewScreen.kt
+++ b/wear/src/main/java/com/serranoie/app/wear/minus/presentation/PeriodOverviewScreen.kt
@@ -62,6 +62,8 @@ internal data class PeriodOverviewUiState(
 	val periodEndText: String = "",
 	val period: BudgetPeriodKind = BudgetPeriodKind.UNKNOWN,
 	val daysRemaining: Int = 0,
+	val currencySymbol: String = "$",
+	val symbolAtEnd: Boolean = false,
 )
 
 @Composable
@@ -275,6 +277,8 @@ internal fun BudgetStatePayload?.toOverviewUiState(): PeriodOverviewUiState {
 		periodEndText = formatDay(periodEndEpochDay),
 		period = budgetPeriodKind(period),
 		daysRemaining = daysRemaining,
+		currencySymbol = currencySymbol,
+		symbolAtEnd = symbolAtEnd,
 	)
 }
 
@@ -295,7 +299,7 @@ private fun formatDay(epochDay: Long): String {
 	return LocalDate.ofEpochDay(epochDay).format(dateFormatter)
 }
 
-private fun formatMoney(symbol: String, symbolAtEnd: Boolean, rawAmount: String): String {
+internal fun formatMoney(symbol: String, symbolAtEnd: Boolean, rawAmount: String): String {
 	val amount = rawAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO
 	val negative = amount.signum() < 0
 	val magnitude = amount.abs().setScale(2, RoundingMode.HALF_UP).stripTrailingZeros()


### PR DESCRIPTION
## Description
use correct currency code on the numpad entry screen

#### Issue Linked (if any)
#228 

## Change strategy
Pass, format and use correct currency code on the wear app.


## Testing
- [x] Ran `:app:connectedFossDebugAndroidTest :app:verifyPaparazziFossDebug --continue` for E2E test on a device and verify screenshots.
- [x] Added/updated tests when applicable.
- [x] Added screenshots or screen recordings for UI changes.
